### PR TITLE
Improve portability

### DIFF
--- a/buildTests.sh
+++ b/buildTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #/**
 #* Copyright IBM Corporation 2016

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #/**
 #* Copyright IBM Corporation 2016


### PR DESCRIPTION
'bash' is installed at /usr/local/bin on some platform.