### PR TITLE
Fix vagrant provisioning by running as unprivileged user

### DIFF
--- a/vagrantfile
+++ b/vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
     s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
   end
 
-  config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
 
 ### Install packages
 # 1. Install compiler, autotools


### PR DESCRIPTION
After the https://github.com/IBM-Swift/Kitura/commit/c30c088d5980d7932fb97c1c57f03506ab926486 commit, which solves [#19 Move from the forked version of libdispatch (maintained by Chris) and use the official one from apple](https://github.com/IBM-Swift/Kitura/issues/19), the vagrant provisioning script stopped working. 

The main reason being that it was still pointing towards the fork of libdispatch, and the modulemap file it was pointing at no longer existing.

I went in and updated the script to work with the new version of it, and I have been able to run the sample app ("You're running Kitura") from just

~~~
> vagrant up
> vagrant ssh
> Kitura/.build/debug/KituraSample
~~~