### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@
 make:
 # run swift build with - to ignore its failure since swift build is expected to fail
 	-swift build
-	make -f Packages/Kitura-net*/Makefile
+	make -f Packages/KituraNet*/Makefile


### PR DESCRIPTION
I tried to run Kitura using the latest Swift compiler on **Ubuntu 15.10**, but build failed with error log as below.
```
make[1]: Packages/Kitura-net*/Makefile: No such file or directory
make[1]: *** No rule to make target 'Packages/Kitura-net*/Makefile'.  Stop.
```

compiler version(DEVELOPMENT-SNAPSHOT-2016-02-25-a) is as follow

```
$ swift --version
Swift version 3.0-dev (LLVM b361b0fc05, Clang 11493b0f62, Swift fc261045a5)
Target: x86_64-unknown-linux-gnu
```

I think **Swift Package Manager** is this cause. The behavior of Swift Package Manager has changed and directory names in `Packages` is different from previous version(DEVELOPMENT-SNAPSHOT-2016-02-08-a). For example,  previous version on **OSX** is here: 

```
$ ls Packages/
BlueSocket-0.0.4              Kitura-HttpParserHelper-0.2.0 Kitura-router-0.2.0
GRMustache.swift-1.0.1        Kitura-Pcre2-0.2.0            Kitura-sys-0.2.1
HeliumLogger-0.2.0            Kitura-TestFramework-0.2.0    LoggerAPI-0.2.0
Kitura-CurlHelpers-0.2.0      Kitura-net-0.2.0              SwiftyJSON-2.3.3
```

Latest version on **OSX** : 

```
$ ls Packages
BlueSocket-0.0.4              Kitura-Pcre2-0.2.0            LoggerAPI-0.2.0
HeliumLogger-0.2.0            Kitura-Sys-0.2.1              Mustache-1.0.1
Kitura-CurlHelpers-0.2.0      KituraNet-0.2.0               PhoenixTestFramework-0.2.0
Kitura-HttpParserHelper-0.2.0 KituraRouter-0.2.0            SwiftyJSON-2.3.3
```
