### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Kitura is a web framework and web server that is created for web services writte
 
 3. Install the necessary dependencies:
 
- `brew install http-parser pcre2 curl hiredis`
+ `brew install http-parser pcre2 curl hiredis wget`
 
 4. Download and install the latest Swift compiler.
 

--- a/README.md
+++ b/README.md
@@ -80,15 +80,11 @@ Kitura is a web framework and web server that is created for web services writte
 
  `brew install http-parser pcre2 curl hiredis wget`
 
-4. Download and install the latest Swift compiler.
+4. Build Kitura script
 
- Make sure the latest Swift compiler is installed https://swift.org/download/. After installing it, make sure you update your PATH environment variable as described in the installation instructions (e.g. export PATH=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin:$PATH)
+ Run `build_osx.sh` from the project root folder.
 
-5. Build Kitura and Kitura Sample
-
- Run `make` to build the helper libraries, Kitura framework, and the sample program (invokes swift build).
-
-6. Run KituraSample:
+5. Run KituraSample:
 
  You can run the sample program which located in: `<path-to-repo>/.build/debug`. From the project root, execute the `./.build/debug/KituraSample` command from a terminal window. You should see a message that says "Listening on port 8090".
 


### PR DESCRIPTION
• It's necessary to install [wget](https://www.gnu.org/software/wget/) with [brew](http://brew.sh/) on MacOS.

• Only run a script to install Kitura on MacOS.