### PR TITLE
README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ let package = Package(
 )
 ```
 
-4. Import the modules in your code:
+4. Import the modules in your code (Sources/main.swift):
 
 ```swift
 import KituraRouter


### PR DESCRIPTION
I was following the README and it wasn’t clear that I needed to import
the modules into main.swift, this should make it clearer to the next
developer.