### PR TITLE
Bug fix: BodyParser.parse contentType argument is nil.

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -45,7 +45,7 @@ public class BodyParser : RouterMiddleware {
     ///
     public func handle(request: RouterRequest, response: RouterResponse, next: () -> Void) {
         
-        request.body = BodyParser.parse(request, contentType: request.serverRequest.headers["Content-Type"])
+        request.body = BodyParser.parse(request, contentType: request.serverRequest.headers["content-type"])
         next()
         
     }


### PR DESCRIPTION
## Description
The capitalized "Content-Type" does not match the lowercase format for storing headers. When using the BodyParser to parse a request, the contentType argument is nil because the "Content-Type" subscript returns nil.

## Motivation and Context
The BodyParser() middleware fails to produce a request body for incoming JSON request with correct "Content-Type" header. The `request.body` property is `nil`.

## How Has This Been Tested?
I made the changes locally with the modification and found that it solved the issue. The `request.body` property was populated with the JSON data I was expecting.

## Checklist:
- [ x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.