### PR TITLE
Router methods grouping for same route

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -23,10 +23,10 @@ import Foundation
 
 import KituraTemplateEngine
 
-// MARK Router 
+// MARK Router
 
 public class Router {
-    
+
     ///
     /// Contains the list of routing elements
     ///
@@ -56,6 +56,12 @@ public class Router {
 
         Log.verbose("Router initialized")
 
+    }
+
+    // MARK: RouterGroup
+    public func group(path: String?=nil) -> RouterGroup {
+        let group = RouterGroup(router: self, path: path)
+        return group
     }
 
     // MARK: All

--- a/Sources/Kitura/RouterGroup.swift
+++ b/Sources/Kitura/RouterGroup.swift
@@ -19,7 +19,7 @@ import KituraSys
 
 public class RouterGroup {
 
-    private var router: Router
+    private (set) var router: Router
     private var path: String?
 
     ///
@@ -33,6 +33,12 @@ public class RouterGroup {
     public init(router: Router, path: String?) {
         self.router = router
         self.path = path
+    }
+
+    // MARK: RouterGroup
+    public func group(path: String?=nil) -> RouterGroup {
+        let group = RouterGroup(router: self.router, path: path)
+        return group
     }
 
     // MARK: All

--- a/Sources/Kitura/RouterGroup.swift
+++ b/Sources/Kitura/RouterGroup.swift
@@ -1,0 +1,604 @@
+/**
+ * Copyright IBM Corporation 2015
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import KituraNet
+import KituraSys
+
+public class RouterGroup {
+
+    private var router: Router
+    private var path: String?
+
+    ///
+    /// Initializes a Router Group
+    ///
+    /// - Parameter router: a Router object of current Group
+    /// - Parameter path: a Path for Group routes
+    ///
+    /// - Returns: a Router Group instance
+    ///
+    public init(router: Router, path: String?) {
+        self.router = router
+        self.path = path
+    }
+
+    // MARK: All
+    public func all(handler: RouterHandler...) -> RouterGroup {
+        router.all(path, handler: handler)
+        return self
+    }
+
+    public func all(handler: [RouterHandler]) -> RouterGroup {
+        router.all(path, handler: handler)
+        return self
+    }
+
+    public func all(middleware: RouterMiddleware...) -> RouterGroup {
+        router.all(path, middleware: middleware)
+        return self
+    }
+
+    public func all(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.all(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Get
+    public func get(handler: RouterHandler...) -> RouterGroup {
+        router.get(path, handler: handler)
+        return self
+    }
+
+    public func get(handler: [RouterHandler]) -> RouterGroup {
+        router.get(path, handler: handler)
+        return self
+    }
+
+    public func get(middleware: RouterMiddleware...) -> RouterGroup {
+        router.get(path, middleware: middleware)
+        return self
+    }
+
+    public func get(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.get(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Head
+    public func head(handler: RouterHandler...) -> RouterGroup {
+        router.head(path, handler: handler)
+        return self
+    }
+
+    public func head(handler: [RouterHandler]) -> RouterGroup {
+        router.head(path, handler: handler)
+        return self
+    }
+
+    public func head(middleware: RouterMiddleware...) -> RouterGroup {
+        router.head(path, middleware: middleware)
+        return self
+    }
+
+    public func head(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.head(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Post
+    public func post(handler: RouterHandler...) -> RouterGroup {
+        router.post(path, handler: handler)
+        return self
+    }
+
+    public func post(handler: [RouterHandler]) -> RouterGroup {
+        router.post(path, handler: handler)
+        return self
+    }
+
+    public func post(middleware: RouterMiddleware...) -> RouterGroup {
+        router.post(path, middleware: middleware)
+        return self
+    }
+
+    public func post(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.post(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Put
+    public func put(handler: RouterHandler...) -> RouterGroup {
+        router.put(path, handler: handler)
+        return self
+    }
+
+    public func put(handler: [RouterHandler]) -> RouterGroup {
+        router.put(path, handler: handler)
+        return self
+    }
+
+    public func put(middleware: RouterMiddleware...) -> RouterGroup {
+        router.put(path, middleware: middleware)
+        return self
+    }
+
+    public func put(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.put(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Delete
+    public func delete(handler: RouterHandler...) -> RouterGroup {
+        router.delete(path, handler: handler)
+        return self
+    }
+
+    public func delete(handler: [RouterHandler]) -> RouterGroup {
+        router.delete(path, handler: handler)
+        return self
+    }
+
+    public func delete(middleware: RouterMiddleware...) -> RouterGroup {
+        router.delete(path, middleware: middleware)
+        return self
+    }
+
+    public func delete(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.delete(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Options
+    public func options(handler: RouterHandler...) -> RouterGroup {
+        router.options(path, handler: handler)
+        return self
+    }
+
+    public func options(handler: [RouterHandler]) -> RouterGroup {
+        router.options(path, handler: handler)
+        return self
+    }
+
+    public func options(middleware: RouterMiddleware...) -> RouterGroup {
+        router.options(path, middleware: middleware)
+        return self
+    }
+
+    public func options(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.options(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Trace
+    public func trace(handler: RouterHandler...) -> RouterGroup {
+        router.trace(path, handler: handler)
+        return self
+    }
+
+    public func trace(handler: [RouterHandler]) -> RouterGroup {
+        router.trace(path, handler: handler)
+        return self
+    }
+
+    public func trace(middleware: RouterMiddleware...) -> RouterGroup {
+        router.trace(path, middleware: middleware)
+        return self
+    }
+
+    public func trace(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.trace(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Copy
+    public func copy(handler: RouterHandler...) -> RouterGroup {
+        router.copy(path, handler: handler)
+        return self
+    }
+
+    public func copy(handler: [RouterHandler]) -> RouterGroup {
+        router.copy(path, handler: handler)
+        return self
+    }
+
+    public func copy(middleware: RouterMiddleware...) -> RouterGroup {
+        router.copy(path, middleware: middleware)
+        return self
+    }
+
+    public func copy(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.copy(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Lock
+    public func lock(handler: RouterHandler...) -> RouterGroup {
+        router.lock(path, handler: handler)
+        return self
+    }
+
+    public func lock(handler: [RouterHandler]) -> RouterGroup {
+        router.lock(path, handler: handler)
+        return self
+    }
+
+    public func lock(middleware: RouterMiddleware...) -> RouterGroup {
+        router.lock(path, middleware: middleware)
+        return self
+    }
+
+    public func lock(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.lock(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: MkCol
+    public func mkCol(handler: RouterHandler...) -> RouterGroup {
+        router.mkCol(path, handler: handler)
+        return self
+    }
+
+    public func mkCol(handler: [RouterHandler]) -> RouterGroup {
+        router.mkCol(path, handler: handler)
+        return self
+    }
+
+    public func mkCol(middleware: RouterMiddleware...) -> RouterGroup {
+        router.mkCol(path, middleware: middleware)
+        return self
+    }
+
+    public func mkCol(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.mkCol(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Move
+    public func move(handler: RouterHandler...) -> RouterGroup {
+        router.move(path, handler: handler)
+        return self
+    }
+
+    public func move(handler: [RouterHandler]) -> RouterGroup {
+        router.move(path, handler: handler)
+        return self
+    }
+
+    public func move(middleware: RouterMiddleware...) -> RouterGroup {
+        router.move(path, middleware: middleware)
+        return self
+    }
+
+    public func move(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.move(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Purge
+    public func purge(handler: RouterHandler...) -> RouterGroup {
+        router.purge(path, handler: handler)
+        return self
+    }
+
+    public func purge(handler: [RouterHandler]) -> RouterGroup {
+        router.purge(path, handler: handler)
+        return self
+    }
+
+    public func purge(middleware: RouterMiddleware...) -> RouterGroup {
+        router.purge(path, middleware: middleware)
+        return self
+    }
+
+    public func purge(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.purge(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: PropFind
+    public func propFind(handler: RouterHandler...) -> RouterGroup {
+        router.propFind(path, handler: handler)
+        return self
+    }
+
+    public func propFind(handler: [RouterHandler]) -> RouterGroup {
+        router.propFind(path, handler: handler)
+        return self
+    }
+
+    public func propFind(middleware: RouterMiddleware...) -> RouterGroup {
+        router.propFind(path, middleware: middleware)
+        return self
+    }
+
+    public func propFind(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.propFind(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: PropPatch
+    public func propPatch(handler: RouterHandler...) -> RouterGroup {
+        router.propPatch(path, handler: handler)
+        return self
+    }
+
+    public func propPatch(handler: [RouterHandler]) -> RouterGroup {
+        router.propPatch(path, handler: handler)
+        return self
+    }
+
+    public func propPatch(middleware: RouterMiddleware...) -> RouterGroup {
+        router.propPatch(path, middleware: middleware)
+        return self
+    }
+
+    public func propPatch(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.propPatch(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Unlock
+    public func unlock(handler: RouterHandler...) -> RouterGroup {
+        router.unlock(path, handler: handler)
+        return self
+    }
+
+    public func unlock(handler: [RouterHandler]) -> RouterGroup {
+        router.unlock(path, handler: handler)
+        return self
+    }
+
+    public func unlock(middleware: RouterMiddleware...) -> RouterGroup {
+        router.unlock(path, middleware: middleware)
+        return self
+    }
+
+    public func unlock(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.unlock(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Report
+    public func report(handler: RouterHandler...) -> RouterGroup {
+        router.report(path, handler: handler)
+        return self
+    }
+
+    public func report(handler: [RouterHandler]) -> RouterGroup {
+        router.report(path, handler: handler)
+        return self
+    }
+
+    public func report(middleware: RouterMiddleware...) -> RouterGroup {
+        router.report(path, middleware: middleware)
+        return self
+    }
+
+    public func report(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.report(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: MkActivity
+    public func mkActivity(handler: RouterHandler...) -> RouterGroup {
+        router.mkActivity(path, handler: handler)
+        return self
+    }
+
+    public func mkActivity(handler: [RouterHandler]) -> RouterGroup {
+        router.mkActivity(path, handler: handler)
+        return self
+    }
+
+    public func mkActivity(middleware: RouterMiddleware...) -> RouterGroup {
+        router.mkActivity(path, middleware: middleware)
+        return self
+    }
+
+    public func mkActivity(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.mkActivity(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Checkout
+    public func checkout(handler: RouterHandler...) -> RouterGroup {
+        router.checkout(path, handler: handler)
+        return self
+    }
+
+    public func checkout(handler: [RouterHandler]) -> RouterGroup {
+        router.checkout(path, handler: handler)
+        return self
+    }
+
+    public func checkout(middleware: RouterMiddleware...) -> RouterGroup {
+        router.checkout(path, middleware: middleware)
+        return self
+    }
+
+    public func checkout(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.checkout(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Merge
+    public func merge(handler: RouterHandler...) -> RouterGroup {
+        router.merge(path, handler: handler)
+        return self
+    }
+
+    public func merge(handler: [RouterHandler]) -> RouterGroup {
+        router.merge(path, handler: handler)
+        return self
+    }
+
+    public func merge(middleware: RouterMiddleware...) -> RouterGroup {
+        router.merge(path, middleware: middleware)
+        return self
+    }
+
+    public func merge(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.merge(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: MSearch
+    public func mSearch(handler: RouterHandler...) -> RouterGroup {
+        router.mSearch(path, handler: handler)
+        return self
+    }
+
+    public func mSearch(handler: [RouterHandler]) -> RouterGroup {
+        router.mSearch(path, handler: handler)
+        return self
+    }
+
+    public func mSearch(middleware: RouterMiddleware...) -> RouterGroup {
+        router.mSearch(path, middleware: middleware)
+        return self
+    }
+
+    public func mSearch(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.mSearch(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Notify
+    public func notify(handler: RouterHandler...) -> RouterGroup {
+        router.notify(path, handler: handler)
+        return self
+    }
+
+    public func notify(handler: [RouterHandler]) -> RouterGroup {
+        router.notify(path, handler: handler)
+        return self
+    }
+
+    public func notify(middleware: RouterMiddleware...) -> RouterGroup {
+        router.notify(path, middleware: middleware)
+        return self
+    }
+
+    public func notify(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.notify(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Subscribe
+    public func subscribe(handler: RouterHandler...) -> RouterGroup {
+        router.subscribe(path, handler: handler)
+        return self
+    }
+
+    public func subscribe(handler: [RouterHandler]) -> RouterGroup {
+        router.subscribe(path, handler: handler)
+        return self
+    }
+
+    public func subscribe(middleware: RouterMiddleware...) -> RouterGroup {
+        router.subscribe(path, middleware: middleware)
+        return self
+    }
+
+    public func subscribe(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.subscribe(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Unsubscribe
+    public func unsubscribe(handler: RouterHandler...) -> RouterGroup {
+        router.unsubscribe(path, handler: handler)
+        return self
+    }
+
+    public func unsubscribe(handler: [RouterHandler]) -> RouterGroup {
+        router.unsubscribe(path, handler: handler)
+        return self
+    }
+
+    public func unsubscribe(middleware: RouterMiddleware...) -> RouterGroup {
+        router.unsubscribe(path, middleware: middleware)
+        return self
+    }
+
+    public func unsubscribe(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.unsubscribe(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Patch
+    public func patch(handler: RouterHandler...) -> RouterGroup {
+        router.patch(path, handler: handler)
+        return self
+    }
+
+    public func patch(handler: [RouterHandler]) -> RouterGroup {
+        router.patch(path, handler: handler)
+        return self
+    }
+
+    public func patch(middleware: RouterMiddleware...) -> RouterGroup {
+        router.patch(path, middleware: middleware)
+        return self
+    }
+
+    public func patch(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.patch(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Search
+    public func search(handler: RouterHandler...) -> RouterGroup {
+        router.search(path, handler: handler)
+        return self
+    }
+
+    public func search(handler: [RouterHandler]) -> RouterGroup {
+        router.search(path, handler: handler)
+        return self
+    }
+
+    public func search(middleware: RouterMiddleware...) -> RouterGroup {
+        router.search(path, middleware: middleware)
+        return self
+    }
+
+    public func search(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.search(path, middleware: middleware)
+        return self
+    }
+
+    // MARK: Connect
+    public func connect(handler: RouterHandler...) -> RouterGroup {
+        router.connect(path, handler: handler)
+        return self
+    }
+
+    public func connect(handler: [RouterHandler]) -> RouterGroup {
+        router.connect(path, handler: handler)
+        return self
+    }
+
+    public func connect(middleware: RouterMiddleware...) -> RouterGroup {
+        router.connect(path, middleware: middleware)
+        return self
+    }
+
+    public func connect(middleware: [RouterMiddleware]) -> RouterGroup {
+        router.connect(path, middleware: middleware)
+        return self
+    }
+}

--- a/Tests/Kitura/TestRouterGroup.swift
+++ b/Tests/Kitura/TestRouterGroup.swift
@@ -1,0 +1,106 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import XCTest
+
+@testable import Kitura
+@testable import KituraNet
+
+#if os(Linux)
+    import Glibc
+#else
+    import Darwin
+#endif
+
+class TestRouterGroup : KituraTest {
+    #if os(Linux)
+        override var allTests : [(String, () throws -> Void)] {
+            return [
+                ("testRouterGroupGet", testRouterGroupGet),
+                ("testRouterGroupPost", testRouterGroupPost)
+            ]
+        }
+    #endif
+
+    let router = TestRouterGroup.setupRouter()
+
+    func testRouterGroupGet() {
+    	performServerTest(router) {
+            self.performRequest("get", path:"/group", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                // XCTAssertEqual(response!.method, "GET", "The request wasn't recognized as a get")
+                do {
+                    let body = try response!.readString()
+                    XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Received GET</b><p>u1=Ploni Almoni</p></body></html>\n\n")
+                }
+                catch{
+                    XCTFail("No respose body")
+                }
+            })
+        }
+    }
+
+    func testRouterGroupPost() {
+      performServerTest(router) {
+            self.performRequest("post", path:"/group", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                // XCTAssertEqual(response!.method, "POST", "The request wasn't recognized as a post")
+                do {
+                    let body = try response!.readString()
+                    XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Received POST</b><p>u1=Ploni Almoni</p></body></html>\n\n")
+                }
+                catch{
+                    XCTFail("No respose body")
+                }
+            })
+        }
+    }
+
+    static func setupRouter() -> Router {
+        let router = Router()
+
+        router.group("/group")
+        .all { request, _, next in
+            request.userInfo["u1"] = "Ploni Almoni".bridge()
+            next()
+        }
+        .get { request, response, next in
+            response.setHeader("Content-Type", value: "text/html; charset=utf-8")
+            let u1 = request.userInfo["u1"] as? NSString ?? "(nil)"
+            do {
+                try response.status(HttpStatusCode.OK).send("<!DOCTYPE html><html><body><b>Received GET</b><p>u1=\(u1)</p></body></html>\n\n").end()
+            }
+            catch {}
+            next()
+        }
+        .post { request, response, next in
+            response.setHeader("Content-Type", value: "text/html; charset=utf-8")
+            let u1 = request.userInfo["u1"] as? NSString ?? "(nil)"
+            do {
+                try response.status(HttpStatusCode.OK).send("<!DOCTYPE html><html><body><b>Received POST</b><p>u1=\(u1)</p></body></html>\n\n").end()
+            }
+            catch {}
+            next()
+        }
+
+	      return router
+    }
+}


### PR DESCRIPTION
## Description

Added Router Group class that allows setting different methods for same route.

## Motivation and Context

IBM-Swift/Kitura#293

## How Has This Been Tested?

Added tests that cover route grouping for All, Get and Post Requests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.