### PR TITLE
Added expectations to server request test cases

### DIFF
--- a/Tests/Kitura/KituraTest.swift
+++ b/Tests/Kitura/KituraTest.swift
@@ -32,8 +32,6 @@ extension KituraTest {
   //       sleep(10)
     }
 
-
-
     func performServerTest(router: HttpServerDelegate, asyncTasks: (expectation: XCTestExpectation) -> Void...) {
         let server = setupServer(8090, delegate: router)
         let requestQueue = Queue(type: QueueType.SERIAL)
@@ -70,5 +68,24 @@ extension KituraTest {
     private func setupServer(port: Int, delegate: HttpServerDelegate) -> HttpServer {
         return HttpServer.listen(port, delegate: delegate,
                            notOnMainQueue:true)
+    }
+}
+
+extension XCTestCase: KituraTest {
+    func expectation(index index: Int) -> XCTestExpectation {
+        let expectationDescription = "\(self.dynamicType)-\(index)"
+        #if os(Linux)
+        return self.expectationWithDescription(expectationDescription)
+        #else
+        return self.expectation(withDescription: expectationDescription)
+        #endif
+    }
+
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        #if os(Linux)
+        self.waitForExpectationsWithTimeout(t, handler: handler)
+        #else
+        self.waitForExpectations(withTimeout: t, handler: handler)
+        #endif
     }
 }

--- a/Tests/Kitura/TestContentType.swift
+++ b/Tests/Kitura/TestContentType.swift
@@ -26,25 +26,25 @@ class TestContentType : XCTestCase {
             ("test_initialize", test_initialize),
         ]
     }
-    
+
     func test_initialize() {
 
         ContentType.initialize()
-        
+
         print("Type for png is: \(ContentType.contentTypeForExtension("png"))")
-        
+
         let pngType = ContentType.contentTypeForExtension("png")
-        
+
         XCTAssertEqual(pngType, "image/png")
         XCTAssertNotEqual(pngType, "application/javascript")
-        
+
         let htmlType = ContentType.contentTypeForExtension("html")
-        
+
         XCTAssertEqual(htmlType, "text/html")
         XCTAssertNotEqual(pngType, "application/javascript")
-        
+
         let jsType = ContentType.contentTypeForExtension("js")
-        
+
         XCTAssertEqual(jsType, "application/javascript")
 
 

--- a/Tests/Kitura/TestCookies.swift
+++ b/Tests/Kitura/TestCookies.swift
@@ -44,15 +44,11 @@ class TestCookies : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
-        let expectation: XCTestExpectation
-
         #if os(Linux)
         return self.expectationWithDescription("TestCookie-\(index)")
         #else
         return self.expectation(withDescription: "TestCookie-\(index)")
         #endif
-
-        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {

--- a/Tests/Kitura/TestCookies.swift
+++ b/Tests/Kitura/TestCookies.swift
@@ -30,7 +30,7 @@ let cookie3Value = "A-testing-we-go"
 
 let cookieHost = "localhost"
 
-class TestCookies : XCTestCase, KituraTest {
+class TestCookies : XCTestCase {
 
     static var allTests : [(String, TestCookies -> () throws -> Void)] {
         return [
@@ -41,23 +41,6 @@ class TestCookies : XCTestCase, KituraTest {
 
     override func tearDown() {
         doTearDown()
-    }
-
-    func expectation(index index: Int) -> XCTestExpectation {
-        let expectationDescription = "TestCookie-\(index)"
-        #if os(Linux)
-        return self.expectationWithDescription(expectationDescription)
-        #else
-        return self.expectation(withDescription: expectationDescription)
-        #endif
-    }
-
-    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
-        #if os(Linux)
-        self.waitForExpectationsWithTimeout(t, handler: handler)
-        #else
-        self.waitForExpectations(withTimeout: t, handler: handler)
-        #endif
     }
 
     let router = TestCookies.setupRouter()

--- a/Tests/Kitura/TestCookies.swift
+++ b/Tests/Kitura/TestCookies.swift
@@ -44,11 +44,23 @@ class TestCookies : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectation: XCTestExpectation
+
+        #if os(Linux)
+        return self.expectationWithDescription("TestCookie-\(index)")
+        #else
         return self.expectation(withDescription: "TestCookie-\(index)")
+        #endif
+
+        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        #if os(Linux)
+        self.waitForExpectationsWithTimeout(t, handler: handler)
+        #else
         self.waitForExpectations(withTimeout: t, handler: handler)
+        #endif
     }
 
     let router = TestCookies.setupRouter()

--- a/Tests/Kitura/TestCookies.swift
+++ b/Tests/Kitura/TestCookies.swift
@@ -44,10 +44,11 @@ class TestCookies : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectationDescription = "TestCookie-\(index)"
         #if os(Linux)
-        return self.expectationWithDescription("TestCookie-\(index)")
+        return self.expectationWithDescription(expectationDescription)
         #else
-        return self.expectation(withDescription: "TestCookie-\(index)")
+        return self.expectation(withDescription: expectationDescription)
         #endif
     }
 

--- a/Tests/Kitura/TestCookies.swift
+++ b/Tests/Kitura/TestCookies.swift
@@ -43,10 +43,18 @@ class TestCookies : XCTestCase, KituraTest {
         doTearDown()
     }
 
+    func expectation(index index: Int) -> XCTestExpectation {
+        return self.expectation(withDescription: "TestCookie-\(index)")
+    }
+
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        self.waitForExpectations(withTimeout: t, handler: handler)
+    }
+
     let router = TestCookies.setupRouter()
 
     func testCookieToServer() {
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/1/cookiedump", callback: {response in
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "cookiedump route did not match single path request")
                 do {
@@ -63,12 +71,13 @@ class TestCookies : XCTestCase, KituraTest {
                 catch {
                     XCTFail("Failed reading the body of the response")
                 }
+                expectation.fulfill()
             }, headers: ["Cookie": "Plover=qwer; Zxcv=tyuiop"])
         })
     }
 
     func testCookieFromServer() {
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/1/sendcookie", callback: {response in
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "/1/sendcookie route did not match single path request")
 
@@ -81,7 +90,7 @@ class TestCookies : XCTestCase, KituraTest {
                 XCTAssertFalse(cookie1!.secure, "\(cookie1Name) was marked as secure. Should have not been marked so.")
 #else
                 XCTAssertFalse(cookie1!.isSecure, "\(cookie1Name) was marked as secure. Should have not been marked so.")
-#endif 
+#endif
                 XCTAssertNil(cookie1Expire, "\(cookie1Name) had an expiration date. It shouldn't have had one")
 
                 let (cookie2, cookie2Expire) = self.cookieFromResponse(response!, named: cookie2Name)
@@ -93,13 +102,14 @@ class TestCookies : XCTestCase, KituraTest {
                 XCTAssertFalse(cookie2!.secure, "\(cookie2Name) was marked as secure. Should have not been marked so.")
 #else
                 XCTAssertFalse(cookie2!.isSecure, "\(cookie2Name) was marked as secure. Should have not been marked so.")
-#endif 
+#endif
                 XCTAssertNotNil(cookie2Expire, "\(cookie2Name) had no expiration date. It should have had one")
                 XCTAssertEqual(cookie2Expire!, SpiUtils.httpDate(cookie2ExpireExpected))
+                expectation.fulfill()
             })
         },
-        {
-            self.performRequest("get", path: "/2/sendcookie", callback: {response in
+        { expectation in
+            self.performRequest("get", path: "/2/sendcookie", callback: { response in
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "/2/sendcookie route did not match single path request")
 
                 let (cookie, cookieExpire) = self.cookieFromResponse(response!, named: cookie3Name)
@@ -111,8 +121,9 @@ class TestCookies : XCTestCase, KituraTest {
                 XCTAssertTrue(cookie!.secure, "\(cookie3Name) wasn't marked as secure. It should have been marked so.")
 #else
                 XCTAssertTrue(cookie!.isSecure, "\(cookie3Name) wasn't marked as secure. It should have been marked so.")
-#endif 
+#endif
                 XCTAssertNil(cookieExpire, "\(cookie3Name) had an expiration date. It shouldn't have had one")
+                expectation.fulfill()
             })
         })
     }
@@ -125,7 +136,7 @@ class TestCookies : XCTestCase, KituraTest {
             let lowercaseHeaderKey = headerKey.bridge().lowercaseString
 #else
             let lowercaseHeaderKey = headerKey.lowercased()
-#endif 
+#endif
             if  lowercaseHeaderKey  ==  "set-cookie"  {
                 for headerValue in headerValues {
 #if os(Linux)
@@ -154,7 +165,7 @@ class TestCookies : XCTestCase, KituraTest {
 #else
                             var pieces = part.componentsSeparated(by: "=")
                             let piece = pieces[0].bridge().lowercased()
-#endif 
+#endif
                             switch(piece) {
                                 case "secure", "httponly":
                                     properties[NSHTTPCookieSecure] = "Yes"

--- a/Tests/Kitura/TestErrors.swift
+++ b/Tests/Kitura/TestErrors.swift
@@ -43,32 +43,43 @@ class TestErrors : XCTestCase, KituraTest {
         doTearDown()
     }
 
+    func expectation(index index: Int) -> XCTestExpectation {
+        return self.expectation(withDescription: "TestErrors-\(index)")
+    }
+
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        self.waitForExpectations(withTimeout: t, handler: handler)
+    }
+
     let router = Router()
-    
+
     func testInvalidMethod() {
-        performServerTest(router) {
+        performServerTest(router) { expectation in
             self.performRequest("invalid", path: "/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.BAD_REQUEST, "HTTP Status code was \(response!.statusCode)")
+                expectation.fulfill()
             })
         }
     }
 
     func testInvalidEndpoint() {
-        performServerTest(router) {
+        performServerTest(router) { expectation in
             self.performRequest("get", path: "/notreal", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.NOT_FOUND, "HTTP Status code was \(response!.statusCode)")
+                expectation.fulfill()
             })
         }
     }
 
     func testInvalidHeader() {
-        performServerTest(router) {
+        performServerTest(router) { expectation in
             self.performRequest("get", path: "/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 // should this be ok?
-            }) {req in 
+                expectation.fulfill()
+            }) {req in
                 req.headers = ["garbage" : "dfsfdsf"]
             }
         }

--- a/Tests/Kitura/TestErrors.swift
+++ b/Tests/Kitura/TestErrors.swift
@@ -44,11 +44,23 @@ class TestErrors : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectation: XCTestExpectation
+
+        #if os(Linux)
+        return self.expectationWithDescription("TestErrors-\(index)")
+        #else
         return self.expectation(withDescription: "TestErrors-\(index)")
+        #endif
+
+        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        #if os(Linux)
+        self.waitForExpectationsWithTimeout(t, handler: handler)
+        #else
         self.waitForExpectations(withTimeout: t, handler: handler)
+        #endif
     }
 
     let router = Router()

--- a/Tests/Kitura/TestErrors.swift
+++ b/Tests/Kitura/TestErrors.swift
@@ -44,10 +44,11 @@ class TestErrors : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectationDescription = "TestErrors-\(index)"
         #if os(Linux)
-        return self.expectationWithDescription("TestErrors-\(index)")
+        return self.expectationWithDescription(expectationDescription)
         #else
-        return self.expectation(withDescription: "TestErrors-\(index)")
+        return self.expectation(withDescription: expectationDescription)
         #endif
     }
 

--- a/Tests/Kitura/TestErrors.swift
+++ b/Tests/Kitura/TestErrors.swift
@@ -44,15 +44,11 @@ class TestErrors : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
-        let expectation: XCTestExpectation
-
         #if os(Linux)
         return self.expectationWithDescription("TestErrors-\(index)")
         #else
         return self.expectation(withDescription: "TestErrors-\(index)")
         #endif
-
-        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {

--- a/Tests/Kitura/TestErrors.swift
+++ b/Tests/Kitura/TestErrors.swift
@@ -29,7 +29,7 @@ import XCTest
 #endif
 
 
-class TestErrors : XCTestCase, KituraTest {
+class TestErrors : XCTestCase {
 
     static var allTests : [(String, TestErrors -> () throws -> Void)] {
         return [
@@ -41,23 +41,6 @@ class TestErrors : XCTestCase, KituraTest {
 
     override func tearDown() {
         doTearDown()
-    }
-
-    func expectation(index index: Int) -> XCTestExpectation {
-        let expectationDescription = "TestErrors-\(index)"
-        #if os(Linux)
-        return self.expectationWithDescription(expectationDescription)
-        #else
-        return self.expectation(withDescription: expectationDescription)
-        #endif
-    }
-
-    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
-        #if os(Linux)
-        self.waitForExpectationsWithTimeout(t, handler: handler)
-        #else
-        self.waitForExpectations(withTimeout: t, handler: handler)
-        #endif
     }
 
     let router = Router()

--- a/Tests/Kitura/TestMultiplicity.swift
+++ b/Tests/Kitura/TestMultiplicity.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Kitura
 @testable import KituraNet
 
-class TestMultiplicity : XCTestCase, KituraTest {
+class TestMultiplicity : XCTestCase {
 
     static var allTests : [(String, TestMultiplicity -> () throws -> Void)] {
         return [
@@ -33,23 +33,6 @@ class TestMultiplicity : XCTestCase, KituraTest {
 
     override func tearDown() {
         doTearDown()
-    }
-
-    func expectation(index index: Int) -> XCTestExpectation {
-        let expectationDescription = "TestMultiplicity-\(index)"
-        #if os(Linux)
-        return self.expectationWithDescription(expectationDescription)
-        #else
-        return self.expectation(withDescription: expectationDescription)
-        #endif
-    }
-
-    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
-        #if os(Linux)
-        self.waitForExpectationsWithTimeout(t, handler: handler)
-        #else
-        self.waitForExpectations(withTimeout: t, handler: handler)
-        #endif
     }
 
     let router = TestMultiplicity.setupRouter()

--- a/Tests/Kitura/TestMultiplicity.swift
+++ b/Tests/Kitura/TestMultiplicity.swift
@@ -36,15 +36,11 @@ class TestMultiplicity : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
-        let expectation: XCTestExpectation
-
         #if os(Linux)
         return self.expectationWithDescription("TestMultiplicity-\(index)")
         #else
         return self.expectation(withDescription: "TestMultiplicity-\(index)")
         #endif
-
-        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {

--- a/Tests/Kitura/TestMultiplicity.swift
+++ b/Tests/Kitura/TestMultiplicity.swift
@@ -36,10 +36,11 @@ class TestMultiplicity : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectationDescription = "TestMultiplicity-\(index)"
         #if os(Linux)
-        return self.expectationWithDescription("TestMultiplicity-\(index)")
+        return self.expectationWithDescription(expectationDescription)
         #else
-        return self.expectation(withDescription: "TestMultiplicity-\(index)")
+        return self.expectation(withDescription: expectationDescription)
         #endif
     }
 

--- a/Tests/Kitura/TestMultiplicity.swift
+++ b/Tests/Kitura/TestMultiplicity.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  **/
 
+import Foundation
 import XCTest
 
 @testable import Kitura
@@ -35,11 +36,23 @@ class TestMultiplicity : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectation: XCTestExpectation
+
+        #if os(Linux)
+        return self.expectationWithDescription("TestMultiplicity-\(index)")
+        #else
         return self.expectation(withDescription: "TestMultiplicity-\(index)")
+        #endif
+
+        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        #if os(Linux)
+        self.waitForExpectationsWithTimeout(t, handler: handler)
+        #else
         self.waitForExpectations(withTimeout: t, handler: handler)
+        #endif
     }
 
     let router = TestMultiplicity.setupRouter()

--- a/Tests/Kitura/TestMultiplicity.swift
+++ b/Tests/Kitura/TestMultiplicity.swift
@@ -34,68 +34,88 @@ class TestMultiplicity : XCTestCase, KituraTest {
         doTearDown()
     }
 
+    func expectation(index index: Int) -> XCTestExpectation {
+        return self.expectation(withDescription: "TestMultiplicity-\(index)")
+    }
+
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        self.waitForExpectations(withTimeout: t, handler: handler)
+    }
+
     let router = TestMultiplicity.setupRouter()
 
     func testPlus() {
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/1/plus", callback: {response in
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Plus route did not match single path request")
+                expectation.fulfill()
             })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/1/plus/plus", callback: {response in
                     XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Plus route did not match multiple path request")
+                    expectation.fulfill()
                 })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/1", callback: {response in
                     XCTAssertEqual(response!.statusCode, HttpStatusCode.NOT_FOUND, "Plus route did not miss empty path request")
+                    expectation.fulfill()
                 })
         })
     }
 
 	func testStar() {
-		performServerTest(router, asyncTasks: {
+		performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/2/star", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Star route did not match single path request")
+                  expectation.fulfill()
             })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/2/star/star", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Star route did not match multiple path request")
+                  expectation.fulfill()
                 })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/2", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Star route did not match empty path request")
+                  expectation.fulfill()
                 })
         })
 	}
 
 	func testQuestion() {
-		performServerTest(router, asyncTasks: {
+		performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/3/question", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Question route did not match single path request")
+                  expectation.fulfill()
                 })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/3/question/question", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.NOT_FOUND, "Question route did not miss multiple path request")
+                  expectation.fulfill()
                 })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/3", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Question route did not match empty path request")
+                  expectation.fulfill()
                 })
         })
 	}
 
 	func testCombined() {
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/4/question/plus", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Complex route did not match dropped star ending")
+                  expectation.fulfill()
                 })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/4/plus/plus/star", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Complex route did not match dropped beginning with extra middle")
+                  expectation.fulfill()
                 })
-        }, {
+        }, { expectation in
             self.performRequest("get", path: "/4/question/plusssssss/plus/pluss/star/star", callback: {response in
                 	XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "Complex route did not match internal extra plus signs with multiple extras")
+                  expectation.fulfill()
                 })
         })
 	}
@@ -103,13 +123,13 @@ class TestMultiplicity : XCTestCase, KituraTest {
     static func setupRouter() -> Router {
     	let router = Router()
 
-    	router.get("/1/(plus)+") {_, response, next in 
+    	router.get("/1/(plus)+") {_, response, next in
     		do {
     			try response.status(HttpStatusCode.OK).end()
     		}
     		catch {}
 
-    		next()	
+    		next()
     	}
 
     	router.get("/2/(star)*") {_, response, next in

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -26,7 +26,7 @@ import XCTest
     import Darwin
 #endif
 
-class TestResponse : XCTestCase, KituraTest {
+class TestResponse : XCTestCase {
 
     static var allTests : [(String, TestResponse -> () throws -> Void)] {
         return [
@@ -42,23 +42,6 @@ class TestResponse : XCTestCase, KituraTest {
 
     override func tearDown() {
         doTearDown()
-    }
-
-    func expectation(index index: Int) -> XCTestExpectation {
-        let expectationDescription = "TestResponse-\(index)"
-        #if os(Linux)
-        return self.expectationWithDescription(expectationDescription)
-        #else
-        return self.expectation(withDescription: expectationDescription)
-        #endif
-    }
-
-    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
-        #if os(Linux)
-        self.waitForExpectationsWithTimeout(t, handler: handler)
-        #else
-        self.waitForExpectations(withTimeout: t, handler: handler)
-        #endif
     }
 
     let router = TestResponse.setupRouter()

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -45,15 +45,11 @@ class TestResponse : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
-        let expectation: XCTestExpectation
-
         #if os(Linux)
         return self.expectationWithDescription("TestResponse-\(index)")
         #else
         return self.expectation(withDescription: "TestResponse-\(index)")
         #endif
-
-        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -44,10 +44,18 @@ class TestResponse : XCTestCase, KituraTest {
         doTearDown()
     }
 
+    func expectation(index index: Int) -> XCTestExpectation {
+        return self.expectation(withDescription: "TestResponse-\(index)")
+    }
+
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        self.waitForExpectations(withTimeout: t, handler: handler)
+    }
+
     let router = TestResponse.setupRouter()
 
     func testSimpleResponse() {
-    	performServerTest(router) {
+    	performServerTest(router) { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
@@ -60,12 +68,13 @@ class TestResponse : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         }
     }
 
     func testPostRequest() {
-    	performServerTest(router) {
+    	performServerTest(router) { expectation in
             self.performRequest("post", path: "/bodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 //XCTAssertEqual(response!.method, "POST", "The request wasn't recognized as a post")
@@ -77,6 +86,7 @@ class TestResponse : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             }) {req in
                 req.write(from: "plover\n")
                 req.write(from: "xyzzy\n")
@@ -85,7 +95,7 @@ class TestResponse : XCTestCase, KituraTest {
     }
 
     func testParameter() {
-    	performServerTest(router) {
+    	performServerTest(router) { expectation in
             self.performRequest("get", path: "/zxcv/test?q=test2", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
@@ -95,12 +105,13 @@ class TestResponse : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         }
     }
 
     func testRedirect() {
-        performServerTest(router) {
+        performServerTest(router) { expectation in
             self.performRequest("get", path: "/redir", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
@@ -109,17 +120,18 @@ class TestResponse : XCTestCase, KituraTest {
                     XCTAssertNotNil(body!.rangeOfString("ibm"),"response does not contain IBM")
 #else
                     XCTAssertNotNil(body!.range(of: "ibm"),"response does not contain IBM")
-#endif 
+#endif
                 }
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         }
     }
 
     func testErrorHandler() {
-        performServerTest(router) {
+        performServerTest(router) { expectation in
             self.performRequest("get", path: "/error", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
@@ -134,12 +146,13 @@ class TestResponse : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         }
     }
 
     func testRouteFunc() {
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/route", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
@@ -150,8 +163,9 @@ class TestResponse : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
-        }, {
+        }, { expectation in
             self.performRequest("post", path: "/route", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
@@ -162,6 +176,7 @@ class TestResponse : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         })
     }
@@ -204,9 +219,10 @@ class TestResponse : XCTestCase, KituraTest {
             next()
         }
 
-        performServerTest(router) {
+        performServerTest(router) { expectation in
             self.performRequest("get", path: "/headerTest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                expectation.fulfill()
             })
         }
 
@@ -241,7 +257,7 @@ class TestResponse : XCTestCase, KituraTest {
             catch {}
             next()
         }
-    
+
         router.get("/redir") { _, response, next in
             do {
                 try response.redirect("http://www.ibm.com")
@@ -309,4 +325,3 @@ class TestResponse : XCTestCase, KituraTest {
 	return router
     }
 }
-

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -45,11 +45,23 @@ class TestResponse : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectation: XCTestExpectation
+
+        #if os(Linux)
+        return self.expectationWithDescription("TestResponse-\(index)")
+        #else
         return self.expectation(withDescription: "TestResponse-\(index)")
+        #endif
+
+        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        #if os(Linux)
+        self.waitForExpectationsWithTimeout(t, handler: handler)
+        #else
         self.waitForExpectations(withTimeout: t, handler: handler)
+        #endif
     }
 
     let router = TestResponse.setupRouter()

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -45,10 +45,11 @@ class TestResponse : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectationDescription = "TestResponse-\(index)"
         #if os(Linux)
-        return self.expectationWithDescription("TestResponse-\(index)")
+        return self.expectationWithDescription(expectationDescription)
         #else
-        return self.expectation(withDescription: "TestResponse-\(index)")
+        return self.expectation(withDescription: expectationDescription)
         #endif
     }
 

--- a/Tests/Kitura/TestSubrouter.swift
+++ b/Tests/Kitura/TestSubrouter.swift
@@ -42,11 +42,23 @@ class TestSubrouter : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
-        return self.expectation(withDescription: "TestResponse-\(index)")
+        let expectation: XCTestExpectation
+
+        #if os(Linux)
+        return self.expectationWithDescription("TestSubrouter-\(index)")
+        #else
+        return self.expectation(withDescription: "TestSubrouter-\(index)")
+        #endif
+
+        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        #if os(Linux)
+        self.waitForExpectationsWithTimeout(t, handler: handler)
+        #else
         self.waitForExpectations(withTimeout: t, handler: handler)
+        #endif
     }
 
     let router = TestSubrouter.setupRouter()

--- a/Tests/Kitura/TestSubrouter.swift
+++ b/Tests/Kitura/TestSubrouter.swift
@@ -42,15 +42,11 @@ class TestSubrouter : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
-        let expectation: XCTestExpectation
-
         #if os(Linux)
         return self.expectationWithDescription("TestSubrouter-\(index)")
         #else
         return self.expectation(withDescription: "TestSubrouter-\(index)")
         #endif
-
-        return expectation
     }
 
     func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {

--- a/Tests/Kitura/TestSubrouter.swift
+++ b/Tests/Kitura/TestSubrouter.swift
@@ -40,11 +40,19 @@ class TestSubrouter : XCTestCase, KituraTest {
     override func tearDown() {
         doTearDown()
     }
-    
+
+    func expectation(index index: Int) -> XCTestExpectation {
+        return self.expectation(withDescription: "TestResponse-\(index)")
+    }
+
+    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
+        self.waitForExpectations(withTimeout: t, handler: handler)
+    }
+
     let router = TestSubrouter.setupRouter()
 
     func testSimpleSub() {
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/sub", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
@@ -57,8 +65,9 @@ class TestSubrouter : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
-        }, {
+        }, { expectation in
         	self.performRequest("get", path:"/sub/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
@@ -68,6 +77,7 @@ class TestSubrouter : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         })
     }
@@ -75,7 +85,7 @@ class TestSubrouter : XCTestCase, KituraTest {
     func testExternSub() {
         router.all("/extern", middleware: ExternSubrouter.getRouter())
 
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/extern", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
@@ -88,8 +98,9 @@ class TestSubrouter : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
-        }, {
+        }, { expectation in
             self.performRequest("get", path:"/extern/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
@@ -99,12 +110,13 @@ class TestSubrouter : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         })
     }
 
     func testSubSubs() {
-        performServerTest(router, asyncTasks: {
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/sub/sub2", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
@@ -117,8 +129,9 @@ class TestSubrouter : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
-        }, {
+        }, { expectation in
             self.performRequest("get", path:"/sub/sub2/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
@@ -128,12 +141,13 @@ class TestSubrouter : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         })
     }
 
     func testMultipleMiddleware() {
-        performServerTest(router) {
+        performServerTest(router) { expectation in
             self.performRequest("get", path:"/middle/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
@@ -146,10 +160,11 @@ class TestSubrouter : XCTestCase, KituraTest {
                 catch{
                     XCTFail("No respose body")
                 }
+                expectation.fulfill()
             })
         }
     }
-    
+
     static func setupRouter() -> Router {
         let subsubRouter = Router()
         subsubRouter.get("/") { request, response, next in
@@ -172,7 +187,7 @@ class TestSubrouter : XCTestCase, KituraTest {
         }
 
         subRouter.all("/sub2", middleware: subsubRouter)
-        
+
         let router = Router()
         let middleware = RouterMiddlewareGenerator { (request: RouterRequest, response: RouterResponse, next: () -> Void) in
             response.status(HttpStatusCode.OK).send("first middle\n")
@@ -187,7 +202,7 @@ class TestSubrouter : XCTestCase, KituraTest {
         router.all("/middle", middleware: middleware2)
 
         router.all("/sub", middleware: subRouter)
-        
+
         return router
     }
 }

--- a/Tests/Kitura/TestSubrouter.swift
+++ b/Tests/Kitura/TestSubrouter.swift
@@ -26,7 +26,7 @@ import XCTest
     import Darwin
 #endif
 
-class TestSubrouter : XCTestCase, KituraTest {
+class TestSubrouter : XCTestCase {
 
     static var allTests : [(String, TestSubrouter -> () throws -> Void)] {
         return [
@@ -39,23 +39,6 @@ class TestSubrouter : XCTestCase, KituraTest {
 
     override func tearDown() {
         doTearDown()
-    }
-
-    func expectation(index index: Int) -> XCTestExpectation {
-        let expectationDescription = "TestSubrouter-\(index)"
-        #if os(Linux)
-        return self.expectationWithDescription(expectationDescription)
-        #else
-        return self.expectation(withDescription: expectationDescription)
-        #endif
-    }
-
-    func waitExpectation(timeout t: NSTimeInterval, handler: XCWaitCompletionHandler?) {
-        #if os(Linux)
-        self.waitForExpectationsWithTimeout(t, handler: handler)
-        #else
-        self.waitForExpectations(withTimeout: t, handler: handler)
-        #endif
     }
 
     let router = TestSubrouter.setupRouter()

--- a/Tests/Kitura/TestSubrouter.swift
+++ b/Tests/Kitura/TestSubrouter.swift
@@ -42,10 +42,11 @@ class TestSubrouter : XCTestCase, KituraTest {
     }
 
     func expectation(index index: Int) -> XCTestExpectation {
+        let expectationDescription = "TestSubrouter-\(index)"
         #if os(Linux)
-        return self.expectationWithDescription("TestSubrouter-\(index)")
+        return self.expectationWithDescription(expectationDescription)
         #else
-        return self.expectation(withDescription: "TestSubrouter-\(index)")
+        return self.expectation(withDescription: expectationDescription)
         #endif
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added XCTestExpectation to request handler. Changed how server tests is waiting for requests to finish.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IBM-Swift/Kitura#86

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [] If applicable, I have added tests to cover my changes.
