### PR TITLE
Added ServerInfo and Server response header

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -79,6 +79,8 @@ public class RouterResponse {
         self.router = router
         self.request = request
         status(HttpStatusCode.NOT_FOUND)
+        
+        setHeader("Server", value: ServerInfo.description)
     }
 
     ///

--- a/Sources/Kitura/ServerInfo.swift
+++ b/Sources/Kitura/ServerInfo.swift
@@ -1,0 +1,34 @@
+
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+ 
+public struct ServerInfo {
+   
+   public static let kituraVersion: String = "0.8.0" 
+    
+   #if os(OSX)
+   public static let os = "Mac OS X"
+   #elseif os(Linux)
+   public static let os = "Linux"
+   #else 
+   public static let os = "Unknown"
+   #endif
+   
+   public static var description: String {
+        return "Kitura/\(kituraVersion) (\(os))"  
+    }
+    
+}


### PR DESCRIPTION
Added a class for containing the version of Kitura and also the operating system.

## Description

Added a string that returns "Kitura/0.8.0 (Linux)" if running on Linux.

## Motivation and Context

It is common that in the response headers in HTTP that you include a string representing the Server used like Apache 2, the version, and the platform. 

## How Has This Been Tested?


## Checklist:

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm-swift/kitura/352)
<!-- Reviewable:end -->
