### PR TITLE
Changed 'Server' to 'server' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Let's develop our first Kitura Web Application written in Swift!
 
   ```swift
   let server = HttpServer.listen(8090, delegate: router)
-  Server.run()
+  server.run()
   ```
 
 7. Sources/main.swift file should now look like this:
@@ -195,7 +195,7 @@ Let's develop our first Kitura Web Application written in Swift!
   }
 
   let server = HttpServer.listen(8090, delegate: router)
-  Server.run()
+  server.run()
   ```
 
 8. Compile your application:


### PR DESCRIPTION
Changed "Server" to "server'" in **README.md** sample code  

## Description
In [Developing Kitura applications](https://github.com/IBM-Swift/Kitura#developing-kitura-applications), the sample code `Server.run()` should be `server.run()` in *Sources/main.swift*  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
