### PR TITLE
Link method for RouterResponse

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -501,17 +501,55 @@ public class RouterResponse {
     }
 
     ///
-    /// Sets Link HTTP header
+    /// Adds a link with specified parameters to Link HTTP header
     ///
-    /// - Parameter links: a dictionary that maps link rel parameter to actual link value
+    /// - Parameter link: link value
+    /// - Parameter rel:
+    /// - Parameter anchor:
+    /// - Parameter rev:
+    /// - Parameter hreflang:
+    /// - Parameter media:
+    /// - Parameter title:
+    /// - Parameter type:
     ///
-    public func link(_ links: [String: String]) {
-        var headerValue: [String] = []
-        for (rel, link) in links {
-            let value = "<\(link)>; rel=\"\(rel)\""
-            headerValue.append(value)
+    /// - Returns: a RouterResponse instance
+    ///
+    public func link(_ link: String, rel: String? = nil, anchor: String? = nil,
+      rev: String? = nil, hreflang: String? = nil, media: String? = nil,
+      title: String? = nil, type: String? = nil) -> RouterResponse {
+        var headerValue = "<\(link)>"
+
+        if let rel = rel {
+            headerValue += "; rel=\"\(rel)\""
         }
-        setHeader("Link", value: headerValue)
+
+        if let anchor = anchor {
+            headerValue += "; anchor=\"\(anchor)\""
+        }
+
+        if let rev = rev {
+            headerValue += "; rev=\"\(rev)\""
+        }
+
+        if let hreflang = hreflang {
+            headerValue += "; hreflang=\"\(hreflang)\""
+        }
+
+        if let media = media {
+            headerValue += "; media=\"\(media)\""
+        }
+
+        if let title = title {
+            headerValue += "; title=\"\(title)\""
+        }
+
+        if let type = type {
+            headerValue += "; type=\(type)"
+        }
+
+        self.append("Link", value: headerValue)
+
+        return self
     }
 }
 

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -475,15 +475,15 @@ public class RouterResponse {
         preFlush = newPreFlush
         return oldPreFlush
     }
-    
-    
+
+
     ///
     /// Performs content-negotiation on the Accept HTTP header on the request, when present. It uses
     /// request.accepts() to select a handler for the request, based on the acceptable types ordered by their
     /// quality values. If the header is not specified, the default callback is invoked. When no match is found,
     /// the server invokes the default callback if exists, or responds with 406 “Not Acceptable”.
     /// The Content-Type response header is set when a callback is selected.
-    /// 
+    ///
     /// - Parameter callbacks: a dictionary that maps content types to handlers
     ///
     public func format(callbacks: [String : ((RouterRequest, RouterResponse) -> Void)]) throws {
@@ -500,6 +500,19 @@ public class RouterResponse {
         }
     }
 
+    ///
+    /// Sets Link HTTP header
+    ///
+    /// - Parameter links: a dictionary that maps link rel parameter to actual link value
+    ///
+    public func link(_ links: [String: String]) {
+        var headerValue: [String] = []
+        for (rel, link) in links {
+            let value = "<\(link)>; rel=\"\(rel)\""
+            headerValue.append(value)
+        }
+        setHeader("Link", value: headerValue)
+    }
 }
 
 ///

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -327,7 +327,7 @@ class TestResponse : XCTestCase {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/single_link", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
                 let header = response!.headers["Link"]
                 XCTAssertNotNil(header, "Link header should not be nil")
                 XCTAssertEqual(header, "<https://developer.ibm.com/swift>; rel=\"root\"")
@@ -338,7 +338,7 @@ class TestResponse : XCTestCase {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/multiple_links", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
                 let firstLink = "<https://developer.ibm.com/swift/products/ibm-swift-sandbox/>; rel=\"next\""
                 let secondLink = "<https://developer.ibm.com/swift/products/ibm-bluemix/>; rel=\"prev\""
                 let header = response!.headers["Link"]

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -347,13 +347,8 @@ class TestResponse : XCTestCase {
                 let secondLink = "<https://developer.ibm.com/swift/products/ibm-bluemix/>; rel=\"prev\""
                 let header = response!.headers["Link"]
                 XCTAssertNotNil(header, "Link header should not be nil")
-                #if os(Linux)
-                    XCTAssertNotNil(header!.rangeOfString(firstLink), "link header should contain first link")
-                    XCTAssertNotNil(header!.rangeOfString(secondLink), "link header should contain secon link")
-                #else
-                    XCTAssertNotNil(header!.range(of: firstLink), "link header should contain first link")
-                    XCTAssertNotNil(header!.range(of: secondLink), "link header should contain secon link")
-                #endif
+                XCTAssertNotNil(header!.range(of: firstLink), "link header should contain first link")
+                XCTAssertNotNil(header!.range(of: secondLink), "link header should contain second link")
                 expectation.fulfill()
             })
         }
@@ -486,20 +481,16 @@ class TestResponse : XCTestCase {
 
         router.get("/single_link") { request, response, next in
             do {
-                response.link([
-                    "root" : "https://developer.ibm.com/swift"
-                ])
-                try response.status(.OK).end()
+                try response.link("https://developer.ibm.com/swift", rel: "root").status(.OK).end()
             } catch {}
         }
 
         router.get("/multiple_links") { request, response, next in
             do {
-                response.link([
-                    "prev" : "https://developer.ibm.com/swift/products/ibm-bluemix/",
-                    "next" : "https://developer.ibm.com/swift/products/ibm-swift-sandbox/"
-                ])
-                try response.status(.OK).end()
+              try response
+              .link("https://developer.ibm.com/swift/products/ibm-bluemix/", rel: "prev")
+              .link("https://developer.ibm.com/swift/products/ibm-swift-sandbox/", rel: "next")
+              .status(.OK).end()
             } catch {}
         }
 

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -38,7 +38,8 @@ class TestResponse : XCTestCase {
             ("testHeaderModifiers", testHeaderModifiers),
             ("testRouteFunc", testRouteFunc),
             ("testAcceptTypes", testAcceptTypes),
-            ("testFormat", testFormat)
+            ("testFormat", testFormat),
+            ("testLink", testLink)
         ]
     }
 
@@ -263,14 +264,14 @@ class TestResponse : XCTestCase {
             self.performRequest("get", path: "/customPage", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
-            }) {req in 
+            }) {req in
                 req.headers = ["Accept" : "text/*;q=.5, application/json, application/*;q=.3"]
             }
         }, { expectation in
             self.performRequest("get", path:"/customPage2", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
-            }) {req in 
+            }) {req in
                 req.headers = ["Accept" : "application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain, */*;q=.7"]
             }
         })
@@ -292,7 +293,7 @@ class TestResponse : XCTestCase {
                 expectation.fulfill()
                 }, headers: ["Accept" : "text/html"])
         }
-        
+
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/format", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
@@ -326,7 +327,39 @@ class TestResponse : XCTestCase {
 
     }
 
-    
+    func testLink() {
+        performServerTest(router) { expectation in
+            self.performRequest("get", path: "/single_link", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                let header = response!.headers["Link"]
+                XCTAssertNotNil(header, "Link header should not be nil")
+                XCTAssertEqual(header, "<https://developer.ibm.com/swift>; rel=\"root\"")
+                expectation.fulfill()
+            })
+        }
+
+        performServerTest(router) { expectation in
+            self.performRequest("get", path: "/multiple_links", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response!.statusCode, HttpStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                let firstLink = "<https://developer.ibm.com/swift/products/ibm-swift-sandbox/>; rel=\"next\""
+                let secondLink = "<https://developer.ibm.com/swift/products/ibm-bluemix/>; rel=\"prev\""
+                let header = response!.headers["Link"]
+                XCTAssertNotNil(header, "Link header should not be nil")
+                #if os(Linux)
+                    XCTAssertNotNil(header!.rangeOfString(firstLink), "link header should contain first link")
+                    XCTAssertNotNil(header!.rangeOfString(secondLink), "link header should contain secon link")
+                #else
+                    XCTAssertNotNil(header!.range(of: firstLink), "link header should contain first link")
+                    XCTAssertNotNil(header!.range(of: secondLink), "link header should contain secon link")
+                #endif
+                expectation.fulfill()
+            })
+        }
+    }
+
+
     static func setupRouter() -> Router {
         let router = Router()
 
@@ -410,7 +443,7 @@ class TestResponse : XCTestCase {
                     catch {}
                 default:
                     response.error = Error.FailedToParseRequestBody(body: "\(request.body)")
-                
+
             }
 
             next()
@@ -421,26 +454,26 @@ class TestResponse : XCTestCase {
                 try response.status(HttpStatusCode.OK).send("Hi from Kitura!").end()
             }
             catch {}
-            
+
         }
-        
+
         func callbackHtml(request: RouterRequest, response: RouterResponse) {
             do {
                 try response.status(HttpStatusCode.OK).send("<!DOCTYPE html><html><body>Hi from Kitura!</body></html>\n\n").end()
             }
             catch {}
-            
+
         }
-        
+
         func callbackDefault(request: RouterRequest, response: RouterResponse) {
             do {
                 response.setHeader("Content-Type", value: "text/plain; charset=utf-8")
                 try response.status(HttpStatusCode.OK).send("default").end()
             }
             catch {}
-            
+
         }
-        
+
         router.get("/format") { request, response, next in
             do {
                 try response.format(callbacks: [
@@ -449,6 +482,25 @@ class TestResponse : XCTestCase {
                                                    "default" : callbackDefault])
             }
             catch {}
+        }
+
+        router.get("/single_link") { request, response, next in
+            do {
+                response.link([
+                    "root" : "https://developer.ibm.com/swift"
+                ])
+                try response.status(.OK).end()
+            } catch {}
+        }
+
+        router.get("/multiple_links") { request, response, next in
+            do {
+                response.link([
+                    "prev" : "https://developer.ibm.com/swift/products/ibm-bluemix/",
+                    "next" : "https://developer.ibm.com/swift/products/ibm-swift-sandbox/"
+                ])
+                try response.status(.OK).end()
+            } catch {}
         }
 
         router.error { request, response, next in


### PR DESCRIPTION
## Description

Added ```link``` method for RouterResponse class.

## Motivation and Context

IBM-Swift/Kitura#311

## How Has This Been Tested?

Added a test in TestResponse.swift file that checks received Link header value for both single and multiple links.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
