### PR TITLE
Fixed KituraTemplateEngine import error in Xcode

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -18,7 +18,12 @@ import KituraNet
 import KituraSys
 import LoggerAPI
 import Foundation
+
+#if Xcode
+import Kitura_TemplateEngine
+#else
 import KituraTemplateEngine
+#endif
 
 // MARK Router
 


### PR DESCRIPTION
## Description
Because of a dash in the template engine's name, Xcode automatically changes `-` to `_`. Using the `Xcode` compiler macro, that is present in all projects generated using the SPM command line tool, to reflect this change and provide the correct module name in Xcode fixes the compiling issue, without breaking existing source or impacting command line builds.

## Motivation and Context
When using Xcode to build a Kitura-based project, compiling fails because the module `KituraTemplateEngine` can't be found. Not only does this error affect the building process and the dependency tree, but it also leads to crash/hangs and _Xcode internal errors._

## How Has This Been Tested?
As mentioned above, this patch does not impact the code itself, performing functional tests was not relevant. However I did perform building tests :

- Building with `swift build` : succeeded
- Building inside Xcode : succeeds

Building on Linux should pass too, wasn't able to test it though.

## Checklist:

- [X] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly. (not applicable)
- [ ] If applicable, I have added tests to cover my changes. (not applicable)
