### PR TITLE
Parameter method for Router

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -606,11 +606,6 @@ public class Router {
 
     //MARK: Parameter
 
-    
-    public func parameter(_ name: String, handler: RouterParameterHandler) -> Router {
-        return self.parameter(name, handler: [handler])
-    }
-
     public func parameter(_ name: String, handler: RouterParameterHandler...) -> Router {
         return self.parameter(name, handler: handler)
     }

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -603,6 +603,23 @@ public class Router {
         self.all(route, middleware: subrouter)
         return subrouter
     }
+
+    //MARK: Parameter
+
+    
+    public func parameter(_ name: String, handler: RouterParameterHandler) -> Router {
+        return self.parameter(name, handler: [handler])
+    }
+
+    public func parameter(_ name: String, handler: RouterParameterHandler...) -> Router {
+        return self.parameter(name, handler: handler)
+    }
+
+    public func parameter(_ name: String, handler: [RouterParameterHandler]) -> Router {
+        let parameterMiddleware = RouterParameter(name: name, handlers: handler)
+        self.all(nil, middleware: parameterMiddleware)
+        return self
+    }
 }
 
 ///

--- a/Sources/Kitura/RouterParameter.swift
+++ b/Sources/Kitura/RouterParameter.swift
@@ -1,0 +1,47 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+
+import KituraSys
+import LoggerAPI
+
+import Foundation
+
+public class RouterParameter: RouterMiddleware {
+
+    private var name: String
+    private var handlers: [RouterParameterHandler]
+
+    public init(name: String, handlers: [RouterParameterHandler]) {
+        self.name = name
+        self.handlers = handlers
+    }
+
+    public func handle(request: RouterRequest, response: RouterResponse, next: () -> Void) {
+        guard let parameterValue = request.queryParams[self.name] else {
+            next()
+            return
+        }
+
+        let looper = RouterParameterWalker(handlers: handlers,
+          request: request,
+          response: response,
+          callback: next,
+          value: parameterValue)
+
+        looper.next()
+    }
+}

--- a/Sources/Kitura/RouterParameterHandler.swift
+++ b/Sources/Kitura/RouterParameterHandler.swift
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+
+///
+/// RouterParameterHandler is a closure
+///
+public typealias RouterParameterHandler = (request: RouterRequest,
+                                            response: RouterResponse,
+                                            next: ()->(),
+                                            value: String) -> Void

--- a/Sources/Kitura/RouterParameterWalker.swift
+++ b/Sources/Kitura/RouterParameterWalker.swift
@@ -1,0 +1,61 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+class RouterParameterWalker
+{
+    /// The array of handlers
+    private let handlers: [RouterParameterHandler]
+
+    /// The current router request
+    private let request: RouterRequest
+
+    /// The current router response
+    private let response: RouterResponse
+
+    /// Callback to call once all handlers have been processed
+    private let callback: () -> Void
+
+    /// The current query parameter value
+    private let value: String
+
+    /// Index of the current handler
+    private var handlerIndex = -1
+
+    init(handlers: [RouterParameterHandler], request: RouterRequest, response: RouterResponse, callback: () -> Void, value: String) {
+        self.handlers = handlers
+        self.request = request
+        self.response = response
+        self.callback = callback
+        self.value = value
+    }
+
+    ///
+    /// Handle the next middleware
+    ///
+    func next() {
+        handlerIndex += 1
+
+        if handlerIndex < handlers.count && response.error == nil {
+            let handlerCallback = { [unowned self] in
+                self.next()
+            }
+            handlers[handlerIndex](request: request, response: response, next: handlerCallback, value: value)
+        } else {
+            request.params = [:]
+            callback()
+        }
+    }
+}

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -32,12 +32,16 @@ public class RouterRequest: SocketReader {
     ///
     /// The hostname of the request
     ///
-    public private(set) lazy var hostname: String = {[unowned self] () in
+    public private(set) lazy var hostname: String = { [unowned self] () in
         guard let host = self.headers["host"] else {
             return self.parsedUrl.host ?? ""
         }
-        let range = host.range(of: ":")
-        return  range == nil ? host : host.substring(to: range!.lowerBound)
+
+        guard let range = host.range(of: ":") else {
+            return host
+        }
+
+        return  host.substring(to: range.lowerBound)
     }()
 
     ///
@@ -85,7 +89,7 @@ public class RouterRequest: SocketReader {
     //
     // Parsed Cookies, used to do a lazy parsing of the appropriate headers
     //
-    private lazy var _cookies: Cookies = {[unowned self] in
+    private lazy var _cookies: Cookies = { [unowned self] in
         return Cookies(headers: self.serverRequest.headers)
     }()
 
@@ -226,7 +230,7 @@ public class RouterRequest: SocketReader {
                         criteriaMatches[type] = (priority: 3, qValue: parsedHeaderValue.qValue)
                     }
                 } else {
-                    
+
                     if let _ = mimeType.range(of: parsedHeaderValue.type, options: .regularExpressionSearch) { // partial match, e.g. text/html == text/*
                         if criteriaMatches[type]?.priority > 2 || criteriaMatches[type] == nil {
                             criteriaMatches[type] = (priority: 2, qValue: parsedHeaderValue.qValue)

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -66,7 +66,7 @@ public class RouterResponse {
     /// Optional error value
     ///
     public var error: ErrorProtocol?
-    
+
     public var headers: Headers
 
     public var statusCode: HTTPStatusCode {
@@ -407,9 +407,10 @@ public class RouterResponse {
     ///
     public func format(callbacks: [String : ((RouterRequest, RouterResponse) -> Void)]) throws {
         let callbackTypes = Array(callbacks.keys)
-        if let acceptType = request.accepts(callbackTypes) {
+        if let acceptType = request.accepts(callbackTypes),
+          callback = callbacks[acceptType] {
             headers["Content-Type"] = acceptType
-            callbacks[acceptType]!(request, self)
+            callback(request, self)
         }
         else if let defaultCallback = callbacks["default"] {
             defaultCallback(request, self)

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -39,7 +39,8 @@ class TestResponse : XCTestCase {
             ("testRouteFunc", testRouteFunc),
             ("testAcceptTypes", testAcceptTypes),
             ("testFormat", testFormat),
-            ("testLink", testLink)
+            ("testLink", testLink),
+            ("testRouterParameter", testRouterParameter)
         ]
     }
 
@@ -349,9 +350,83 @@ class TestResponse : XCTestCase {
         }
     }
 
+    func testRouterParameter() {
+      performServerTest(router) { expectation in
+          self.performRequest("get", path: "/single_link?user=guest", callback: { response in
+              XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+              XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+              let header = response!.headers["User"]?.first
+              XCTAssertNotNil(header, "User header should not be nil in single_link request")
+              XCTAssertEqual(header, "guest")
+              let linkHeader = response!.headers["Link"]?.first
+              XCTAssertNotNil(linkHeader, "Link header should not be nil")
+              XCTAssertEqual(linkHeader, "<https://developer.ibm.com/swift>; rel=\"root\"")
+              expectation.fulfill()
+          })
+      }
+
+      performServerTest(router) { expectation in
+          self.performRequest("post", path: "/bodytest?user=guest", callback: { response in
+              XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+              XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+              let header = response!.headers["User"]?.first
+              XCTAssertNotNil(header, "User header should not be nil in bodytest request")
+              XCTAssertEqual(header, "guest")
+              do {
+                  let body = try response!.readString()
+                  XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
+              }
+              catch{
+                  XCTFail("No response body")
+              }
+              expectation.fulfill()
+          }) {req in
+              req.write(from: "plover\n")
+              req.write(from: "xyzzy\n")
+          }
+        }
+
+      performServerTest(router) { expectation in
+          self.performRequest("get", path: "/qwer?var=123124", callback: { response in
+              XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+              XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+              let firstHeader = response!.headers["Var-1"]?.first
+              XCTAssertNotNil(firstHeader, "Var-1 header should not be nil")
+              XCTAssertEqual(firstHeader, "123124")
+              let secondHeader = response!.headers["Var-2"]?.first
+              XCTAssertNotNil(secondHeader, "Var-2 header should not be nil")
+              XCTAssertEqual(secondHeader, "random")
+
+              do {
+                  let body = try response!.readString()
+                  XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n")
+              }
+              catch{
+                  XCTFail("No response body")
+              }
+
+              expectation.fulfill()
+          })
+      }
+    }
+
 
     static func setupRouter() -> Router {
         let router = Router()
+
+        //parameter handling example
+        router.parameter("var", handler: { request, response, next, value in
+            response.headers["Var-1"] = value
+            next()
+        }, { request, response, next, value in
+            response.headers["Var-2"] = "random"
+            next()
+        })
+
+        router.parameter("user") { request, response, next, value in
+            response.headers["User"] = value
+            next()
+        }
 
         // the same router definition is used for all these test cases
         router.all("/zxcv/:p1") { request, _, next in
@@ -410,7 +485,6 @@ class TestResponse : XCTestCase {
             response.status(HTTPStatusCode.OK).send("get 2\n")
             next()
         }
-
 
         router.all("/bodytest", middleware: BodyParser())
 
@@ -474,6 +548,8 @@ class TestResponse : XCTestCase {
             catch {}
         }
 
+
+
         router.get("/single_link") { request, response, next in
             do {
                 try response.link("https://developer.ibm.com/swift", rel: "root").status(.OK).end()
@@ -505,6 +581,6 @@ class TestResponse : XCTestCase {
             next()
         }
 
-	return router
+	       return router
     }
 }


### PR DESCRIPTION
## Description
Implementer ```parameter``` method for ```Router``` class that can be used to specify handlers for specific request parameters.

## Motivation and Context
IBM-Swift/Kitura#295

## How Has This Been Tested?
Added test ```testRouterParameter``` that cover this changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
