### PR TITLE
replace git submodule init/update with clone --recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The latest version of Kitura works with the DEVELOPMENT-SNAPSHOT-2016-05-03-a ve
 
 3. Clone, build and install the libdispatch library.
 The complete instructions for building and installing this library are  [here](https://github.com/apple/swift-corelibs-libdispatch/blob/experimental/foundation/INSTALL), though, all you need to do is just this
- `git clone -b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch.git && cd swift-corelibs-libdispatch && git submodule init && git submodule update && sh ./autogen.sh && ./configure --with-swift-toolchain=<path-to-swift>/usr --prefix=<path-to-swift>/usr && make && make install`
+ `git clone --recursive -b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch.git && cd swift-corelibs-libdispatch && sh ./autogen.sh && ./configure --with-swift-toolchain=<path-to-swift>/usr --prefix=<path-to-swift>/usr && make && make install`
 
 4. Now you are ready to develop your first Kitura App. Check [Kitura Sample](https://github.com/IBM-Swift/Kitura-Sample) or see [Developing Kitura applications](#developing-kitura-applications).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The README.md contains instructions on how to clone, build and install libdispatch. That process can actually be simplified slightly by using 'git clone --recursive' rather than clone, submodule init, submodule update.

## Motivation and Context
This simplifies the documentation and install process.

## How Has This Been Tested?
New instructions run and tested locally

## Checklist:
- [X ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [X ] If applicable, I have updated the documentation accordingly.
- [NA ] If applicable, I have added tests to cover my changes.
