### PR TITLE
Fix for issue #474

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -71,10 +71,16 @@ public class BodyParser: RouterMiddleware {
     ///
     public class func parse(_ message: SocketReader, contentType: String?) -> ParsedBody? {
 
-        guard let contentType = contentType else {
+        guard var contentType = contentType else {
             return nil
         }
         
+        // Handle Content-Type with parameters.  For example, treat:
+        // "application/x-www-form-urlencoded; charset=UTF-8" as
+        // "application/x-www-form-urlencoded"
+        if let parameterStart = contentType.range(of: ";") {
+            contentType = contentType.substring(to: parameterStart.lowerBound)
+        }
         if let parser = getParsingFunction(contentType: contentType) {
             return parse(message, parser: parser)
         }


### PR DESCRIPTION
## Description
Fix for supporting Content-Type with parameters.  A previous Pull Request was generated for this issue, but it required a mer of recent changes. The old Pull Request was closed and replaced with this one.

## Motivation and Context
Many Internet services will send parameters with Content-Type. For example:

    POST /message HTTP/1.1
    Content-Type: application/x-www-form-urlencoded; charset=UTF-8

Fixes:
#474

## How Has This Been Tested?
Tested with both Mac and Linux.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

