### PR TITLE
Fix for issue #474 + unit test

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -83,7 +83,14 @@ public class BodyParser: RouterMiddleware {
     }
     
     private class func getParsingFunction(contentType: String) -> ((NSMutableData) -> ParsedBody?)? {
-        if let parser = parserMap[contentType] {
+        // Handle Content-Type with parameters.  For example, treat:
+        // "application/x-www-form-urlencoded; charset=UTF-8" as
+        // "application/x-www-form-urlencoded"
+        var contentTypeWithoutParameters = contentType
+        if let parameterStart = contentTypeWithoutParameters.range(of: ";") {
+            contentTypeWithoutParameters = contentType.substring(to: parameterStart.lowerBound)
+        }
+        if let parser = parserMap[contentTypeWithoutParameters] {
             return parser
         } else if let parser = parserMap["text"]
             where contentType.hasPrefix("text/") {

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -32,6 +32,7 @@ class TestResponse : XCTestCase {
         return [
             ("testSimpleResponse", testSimpleResponse),
             ("testPostRequest", testPostRequest),
+            ("testPostRequestUrlEncoded", testPostRequestUrlEncoded),
             ("testMultipartFormParsing", testMultipartFormParsing),
             ("testParameter", testParameter),
             ("testRedirect", testRedirect),
@@ -91,6 +92,44 @@ class TestResponse : XCTestCase {
         }
     }
     
+    func testPostRequestUrlEncoded() {
+        performServerTest(router) { expectation in
+            self.performRequest("post", path: "/bodytest", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                do {
+                    let body = try response!.readString()
+                    XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
+                }
+                catch{
+                    XCTFail("No response body")
+                }
+                expectation.fulfill()
+            }) {req in
+                req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+                req.write(from: "swift=rocks")
+            }
+        }
+        // repeat the same test with a Content-Type parameter of charset=UTF-8
+        performServerTest(router) { expectation in
+            self.performRequest("post", path: "/bodytest", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                do {
+                    let body = try response!.readString()
+                    XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
+                }
+                catch{
+                    XCTFail("No response body")
+                }
+                expectation.fulfill()
+            }) {req in
+                req.headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+                req.write(from: "swift=rocks")
+            }
+        }
+    }
+
     func testMultipartFormParsing() {
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/multibodytest", callback: {response in


### PR DESCRIPTION
## Description
Fix for supporting Content-Type with parameters.  Third time's a charm.

## Motivation and Context
Many Internet services will send parameters with Content-Type. For example:

    POST /message HTTP/1.1
    Content-Type: application/x-www-form-urlencoded; charset=UTF-8

Fixes:
#474

## How Has This Been Tested?
Added unit test testPostRequestUrlEncoded() which tests UrlEncoded POST with and without a Content-Type parameters.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ x ] If applicable, I have added tests to cover my changes.

