### PR TITLE
IBM-Swift/Kitura#524 Added response end hook

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -66,6 +66,8 @@ public class RouterResponse {
     /// Set of cookies to return with the response
     ///
     public var cookies = [String: NSHTTPCookie]()
+    
+    public var onResponseEnd: (() -> Void)?
 
     ///
     /// Optional error value
@@ -107,6 +109,10 @@ public class RouterResponse {
     /// - Returns: a RouterResponse instance
     ///
     public func end() throws {
+        
+        if let onResponseEnd = onResponseEnd {
+            onResponseEnd()
+        }
 
         preFlush(request: request, response: self)
         

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -58,16 +58,14 @@ public class RouterResponse {
     var invokedSend = false
 
     //
-    // Current pre-flush lifecycle handler
+    // Lifecycle hook called on end()
     //
-    private var preFlush: PreFlushLifecycleHandler = {request, response in }
+    private var onEndInvoked: LifecycleHandler = {}
 
     ///
     /// Set of cookies to return with the response
     ///
     public var cookies = [String: NSHTTPCookie]()
-    
-    public var onResponseEnd: (() -> Void)?
 
     ///
     /// Optional error value
@@ -109,12 +107,8 @@ public class RouterResponse {
     /// - Returns: a RouterResponse instance
     ///
     public func end() throws {
-        
-        if let onResponseEnd = onResponseEnd {
-            onResponseEnd()
-        }
 
-        preFlush(request: request, response: self)
+        onEndInvoked()
         
         // Sets status code if unset
         if statusCode == .unknown {
@@ -403,10 +397,10 @@ public class RouterResponse {
     /// Sets the pre-flush lifecycle handler and returns the previous one
     ///
     /// - Parameter newPreFlush: The new pre-flush lifecycle handler
-    public func setPreFlushHandler(_ newPreFlush: PreFlushLifecycleHandler) -> PreFlushLifecycleHandler {
-        let oldPreFlush = preFlush
-        preFlush = newPreFlush
-        return oldPreFlush
+    public func setOnEndInvoked(_ newOnEndInvoked: LifecycleHandler) -> LifecycleHandler {
+        let oldOnEndInvoked = onEndInvoked
+        onEndInvoked = newOnEndInvoked
+        return oldOnEndInvoked
     }
 
 
@@ -455,4 +449,4 @@ public class RouterResponse {
 
 ///
 /// Type alias for "Before flush" (i.e. before headers and body are written) lifecycle handler
-public typealias PreFlushLifecycleHandler = (request: RouterRequest, response: RouterResponse) -> Void
+public typealias LifecycleHandler = () -> Void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added as PR so we can discuss. This PR adds an overridable method that will be called when `response.end` is called

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is used for #524. By overriding `onResponseEnd` the middleware can do additional work later in the response lifecycle.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

