### PR TITLE
Update dependency on Kitura-TemplateEngine

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,6 @@ let package = Package(
         dependencies: [
             .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 0, minor: 17),
             .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 8),
-            .Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 0, minor: 13)
+            .Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 0, minor: 16)
         ]
 )


### PR DESCRIPTION
## Description

Bump the version of Kitura-TemplateEngine dependency in Kitura to 0.16.x.

## Motivation and Context

Currently unable to resolve dependency graph with latest version of Kitura and Kitura-MustacheTemplateEngine due to conflicting dependent versions of Kitura-TemplateEngine (0.13.x vs 0.16.x).

## How Has This Been Tested?

I have not tested this yet.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
