### PR TITLE
Add JSONP support

### DIFF
--- a/Sources/Kitura/JSONPError.swift
+++ b/Sources/Kitura/JSONPError.swift
@@ -16,12 +16,12 @@
 
 import Foundation
 
-enum JSONPError: ErrorProtocol {
+public enum JSONPError: ErrorProtocol {
     case invalidCallbackName(name: String?)
 }
 
 extension JSONPError: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         switch self {
         case .invalidCallbackName(let name):
             return "Invalid callback name \(name)"

--- a/Sources/Kitura/JSONPError.swift
+++ b/Sources/Kitura/JSONPError.swift
@@ -1,0 +1,30 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+enum JSONPError: ErrorProtocol {
+    case invalidCallbackName(name: String?)
+}
+
+extension JSONPError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .invalidCallbackName(let name):
+            return "Invalid callback name \(name)"
+        }
+    }
+}

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -303,7 +303,7 @@ public class RouterResponse {
         let jsonStr = jsonp.description
         let taintedJSCallbackName = request.queryParameters[callbackParameter]
         if let jsCallbackName = validJsonpCallbackName(taintedJSCallbackName) {
-            type("json")
+            type("js")
             // Set header "X-Content-Type-Options: nosniff" and prefix body with
             // "/**/ " as security mitigation for Flash vulnerability
             // CVE-2014-4671, CVE-2014-5333 "Abusing JSONP with Rosetta Flash"

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -271,9 +271,8 @@ public class RouterResponse {
     /// Sends JSON with JSONP callback
     ///
     /// - Parameter json: the JSON object to send
-    /// - Parameter callbackParameter: (optional, default "callback") the
-    /// name of the URL query parameter that contains the callback
-    /// function name
+    /// - Parameter callbackParameter: the name of the URL query
+    /// parameter whose value contains the JSONP callback function
     ///
     /// - Throws: `JSONPError.invalidCallbackName` if the the callback
     /// query parameter of the request URL is missing or its value is

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -271,7 +271,7 @@ public class RouterResponse {
     /// Sends JSON with JSONP callback
     ///
     /// - Parameter json: the JSON object to send
-    /// - Parameter callbackParam: (optional, default "callback") the
+    /// - Parameter callbackParameter: (optional, default "callback") the
     /// name of the URL query parameter that contains the callback
     /// function name
     ///
@@ -281,7 +281,7 @@ public class RouterResponse {
     /// is the alphanumeric characters and `[]$._`).
     /// - Returns: a RouterResponse instance
     ///
-    public func send(jsonp: JSON, callbackParam: String = "callback") throws -> RouterResponse {
+    public func send(jsonp: JSON, callbackParameter: String = "callback") throws -> RouterResponse {
         func sanitizeJSIdentifier(_ ident: String) -> String {
             return ident.replacingOccurrences(of: "[^\\[\\]\\w$.]", with: "", options:
                 NSStringCompareOptions.regularExpressionSearch)
@@ -301,7 +301,7 @@ public class RouterResponse {
         }
 
         let jsonStr = jsonp.description
-        let taintedJSCallbackName = request.queryParams[callbackParam]
+        let taintedJSCallbackName = request.queryParameters[callbackParameter]
         if let jsCallbackName = validJsonpCallbackName(taintedJSCallbackName) {
             type("json")
             // Set header "X-Content-Type-Options: nosniff" and prefix body with

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -491,14 +491,7 @@ class TestResponse : XCTestCase {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp?callback=test+fn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!,"/**/ testfn({\n  \"some\": \"json\"\n})")
-                }
-                catch{
-                    XCTFail("No response body")
-                }
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response!.statusCode)")
                 expectation.fulfill()
             })
         }
@@ -744,7 +737,11 @@ class TestResponse : XCTestCase {
         router.get("/jsonp") { request, response, next in
             let json = JSON([ "some": "json" ])
             do {
-                try response.status(.OK).jsonp(json: json).end();
+                try response.status(.OK).send(jsonp: json).end();
+            } catch JSONPError.invalidCallbackName {
+                do {
+                    try response.send(status: .badRequest).end();
+                } catch {}
             } catch {}
         }
 

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -485,6 +485,7 @@ class TestResponse : XCTestCase {
                     let expected = "{\n  \"some\" : \"json\"\n}"
 #endif
                     XCTAssertEqual(body!,"/**/ testfn(\(expected))")
+                    XCTAssertEqual(response!.headers["Content-Type"]!.first!, "application/javascript")
                 }
                 catch{
                     XCTFail("No response body")
@@ -521,6 +522,7 @@ class TestResponse : XCTestCase {
                     let expected = "{\n  \"some\" : \"json\"\n}"
 #endif
                     XCTAssertEqual(body!,"/**/ testfn(\(expected))")
+                    XCTAssertEqual(response!.headers["Content-Type"]!.first!, "application/javascript")
                 }
                 catch{
                     XCTFail("No response body")
@@ -541,6 +543,7 @@ class TestResponse : XCTestCase {
                     let expected = "{\n  \"some\" : \"json with bad js chars \\u2028 \\u2029 \\u2028 \\u2029\"\n}"
 #endif
                     XCTAssertEqual(body!,"/**/ testfn(\(expected))")
+                    XCTAssertEqual(response!.headers["Content-Type"]!.first!, "application/javascript")
                 }
                 catch{
                     XCTFail("No response body")


### PR DESCRIPTION
Add jsonp support to RouterResponse send()

## Description
Added a new overload to `send(jsonp:callbackParam:="callback")` which writes a JSONP response.
Throws a JSONPError if no valid parameter is provided by the request that matches the JSONP callback param name.

## Motivation and Context
Issue #310

## How Has This Been Tested?
The changes include a test route and 3 test cases that check the generated response.
I ran these tests on Linux using the Kitura vagrant image, with Swift snapshot 2016-05-09.
There should probably be some testing in the browser before this is landed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
