### PR TITLE
MultiPartBodyParser using extension NSData.components

### DIFF
--- a/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
+++ b/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
@@ -21,11 +21,13 @@ class MultiPartBodyParser: BodyParserProtocol {
     let boundaryData: NSData
     let endBoundaryData: NSData
     let newLineData: NSData
+    let endHeaderData: NSData
 
     init(boundary: String) {
         guard let boundaryData = String("--" + boundary).data(using: NSUTF8StringEncoding),
-            let endBoundaryData = String("--" + boundary + "--").data(using: NSUTF8StringEncoding),
-            let newLineData = "\r\n".data(using: NSUTF8StringEncoding)
+            let endBoundaryData = "--".data(using: NSUTF8StringEncoding),
+            let newLineData = "\r\n".data(using: NSUTF8StringEncoding),
+            let endHeaderData = "\r\n\r\n".data(using: NSUTF8StringEncoding)
             else {
                 Log.error("Error converting strings to data for multipart parsing")
                 exit(1)
@@ -33,67 +35,56 @@ class MultiPartBodyParser: BodyParserProtocol {
         self.boundaryData = boundaryData
         self.endBoundaryData = endBoundaryData
         self.newLineData = newLineData
+        self.endHeaderData = endHeaderData
     }
 
     func parse(_ data: NSData) -> ParsedBody? {
         var parts: [Part] = []
-        let bodyLines = divideDataByNewLines(data: data, newLineData: newLineData)
-
-        var bodyLineIterator = bodyLines.makeIterator()
-        skipPreamble(bodyLineIterator: &bodyLineIterator)
-
+        // split the body into component parts separated by the boundary
+        let componentParts = data.components(separatedBy: boundaryData)
+        var skippedPreamble = false
         var endBoundaryEncountered = false
-        var lastPartSeen: Part?
-        repeat {
-            (endBoundaryEncountered, lastPartSeen) =
-                getNextPart(bodyLineIterator: &bodyLineIterator)
-            if let part = lastPartSeen {
+        for componentPart in componentParts {
+            // skip the first component part - it's the preamble
+            if skippedPreamble == false {
+                skippedPreamble = true
+                continue
+            }
+            // end when we see a component starting with endBoundaryData
+            if componentPart.hasPrefix(endBoundaryData) {
+                endBoundaryEncountered = true
+                break
+            }
+            
+            if let part = getPart(componentPart) {
                 parts.append(part)
             }
         }
-        while !endBoundaryEncountered && lastPartSeen != nil
-
         return endBoundaryEncountered ? .multipart(parts) : nil
     }
 
-    private func skipPreamble(bodyLineIterator: inout IndexingIterator<Array<NSData>>) {
-        while let bodyLine = bodyLineIterator.next() {
-            if bodyLine.hasPrefix(boundaryData) {
-                break
-            }
+    private func getPart(_ componentPart: NSData) -> Part? {
+        let found = componentPart.range(of: endHeaderData, in: NSRange(location: 0, length: componentPart.length))
+        if found.location == NSNotFound {
+            return nil
         }
-    }
-
-    private func getNextPart(bodyLineIterator: inout IndexingIterator<Array<NSData>>) -> (Bool, Part?){
         var part = Part()
-        let partData = NSMutableData()
-
-        while let bodyLine = bodyLineIterator.next() {
-            // process bodyLine as String for headers
-            guard let line = String(data: bodyLine, encoding: NSUTF8StringEncoding) else {
+        let headers = componentPart.subdata(with: NSRange(location: 0, length: found.location))
+        let headerLines = headers.components(separatedBy: newLineData)
+        // process the headers
+        for header in headerLines {
+            guard let header = String(data: header, encoding: NSUTF8StringEncoding) else {
                 break
             }
-            if handleHeaderLine(line, part: &part) == false {
-                break
-            }
+            handleHeaderLine(header, part: &part)
         }
-        // now process the body
-        while let bodyLine = bodyLineIterator.next() {
-            if bodyLine.hasPrefix(boundaryData) {
-                return handleBoundary(line: bodyLine, partData: partData, part: &part)
-            }
-            // is data, add to data object
-            if partData.length > 0 {
-                // data is multiline, add linebreaks back in
-                partData.append(newLineData)
-            }
-            partData.append(bodyLine)
+        // process the body
+        var length = componentPart.length - (found.location + endHeaderData.length)
+        // if the part ends with a \r\n, we delete it since it is part of the next boundary
+        if componentPart.hasSuffix(newLineData) {
+            length -= newLineData.length
         }
-
-        return (false, nil)
-    }
-
-    private func handleBoundary(line: NSData, partData: NSData, part: inout Part) -> (Bool, Part?) {
+        let partData = componentPart.subdata(with: NSRange(location: found.location + endHeaderData.length, length: length))
         if partData.length > 0 {
             if let parser = BodyParser.getParser(contentType: part.type),
                 let parsedBody = parser.parse(partData) {
@@ -102,18 +93,15 @@ class MultiPartBodyParser: BodyParserProtocol {
                 part.body = .raw(partData)
             }
         }
-        if line.hasPrefix(endBoundaryData) {
-            return (true, part)
-        }
-        return (false, part)
+        return part
     }
 
     // returns true if it was header line
-    private func handleHeaderLine(_ line: String, part: inout Part) -> Bool {
+    private func handleHeaderLine(_ line: String, part: inout Part) {
         if let labelRange = getLabelRange(of: "content-type:", in: line) {
             part.type = line.substring(from: line.index(after: labelRange.upperBound))
             part.headers[.type] = line
-            return true
+            return
         }
 
         if let labelRange = getLabelRange(of: "content-disposition:", in: line) {
@@ -123,21 +111,16 @@ class MultiPartBodyParser: BodyParserProtocol {
                 part.name = line.substring(with: valueStartIndex..<(valueEndIndex?.lowerBound ?? line.endIndex))
             }
             part.headers[.disposition] = line
-            return true
+            return
         }
 
         if line.range(of: "content-transfer-encoding:", options: [.anchoredSearch, .caseInsensitiveSearch], range: line.startIndex..<line.endIndex) != nil {
             //TODO: Deal with this
             part.headers[.transferEncoding] = line
-            return true
+            return
         }
 
-        if line.isEmpty == false {
-            // custom headers could be handed here
-            return true
-        }
-        // any empty line denotes the end of headers
-        return false
+        // custom headers could be handed here
     }
 
     private func getLabelRange(of searchedString: String, in containingString: String) ->
@@ -146,26 +129,37 @@ class MultiPartBodyParser: BodyParserProtocol {
                                       options: [.anchoredSearch, .caseInsensitiveSearch],
                                       range: containingString.startIndex..<containingString.endIndex)
     }
-
-    private func divideDataByNewLines(data: NSData, newLineData: NSData) -> [NSData] {
-        var dataLines = [NSData]()
-        var lineStart = 0
-        var currentPosition = 0
-        while currentPosition < data.length - 1 {
-            let newLineCanidate = data.subdata(with: NSRange(location: currentPosition, length: 2))
-            if newLineCanidate.isEqual(to: newLineData) {
-                dataLines.append(data.subdata(with: NSRange(location: lineStart, length: currentPosition - lineStart)))
-                // skip new line characters
-                currentPosition += 2
-                lineStart = currentPosition
-            } else {
-                currentPosition += 1
-            }
-        }
-        if lineStart != data.length {
-            dataLines.append(data.subdata(with: NSRange(location: lineStart, length: data.length - lineStart)))
-        }
-        return dataLines
-    }
 }
 
+
+extension NSData {
+    
+    func hasSuffix(_ data: NSData) -> Bool {
+        if data.length > self.length {
+            return false
+        }
+        return self.subdata(with: NSRange(location: self.length - data.length, length: data.length)).isEqual(to: data)
+    }
+
+    // mimic String.components(separatedBy separator: String) -> [String]
+    func components(separatedBy separator: NSData) -> [NSData] {
+        var parts: [NSData] = []
+        
+        var search = NSRange(location: 0, length: self.length)
+        while true {
+            // search for the next occurence of the separator
+            let found = self.range(of: separator, in: search)
+            if found.location == NSNotFound {
+                parts.append(self.subdata(with: search))
+                break
+            }
+            // add a part up to the found location
+            let part = NSRange(location: search.location, length: found.location - search.location)
+            parts.append(self.subdata(with: part))
+            
+            search.location = found.location + found.length
+            search.length = self.length - search.location
+        }
+        return parts
+    }
+}

--- a/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
+++ b/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
@@ -40,16 +40,11 @@ class MultiPartBodyParser: BodyParserProtocol {
 
     func parse(_ data: NSData) -> ParsedBody? {
         var parts: [Part] = []
-        // split the body into component parts separated by the boundary
-        let componentParts = data.components(separatedBy: boundaryData)
-        var skippedPreamble = false
+        // split the body into component parts separated by the boundary, drop the preamble part
+        let componentParts = data.components(separatedBy: boundaryData).dropFirst()
+        
         var endBoundaryEncountered = false
         for componentPart in componentParts {
-            // skip the first component part - it's the preamble
-            if skippedPreamble == false {
-                skippedPreamble = true
-                continue
-            }
             // end when we see a component starting with endBoundaryData
             if componentPart.hasPrefix(endBoundaryData) {
                 endBoundaryEncountered = true


### PR DESCRIPTION
## Description
The refactor centers around the addition of an NSData extension function "components". It operates similar to String.components where NSData can be split into an array of NSData elements using a separator. In the case of MultiPart parsing, the separator is the boundary.

String components function:
`func components(separatedBy separator: String) -> [String] { ... }`

New NSData components extension:
`func components(separatedBy separator: NSData) -> [NSData] { ... }`

The new components function may be useful in other parts of Kiitura.

## Motivation and Context
During development of MultiPartBodyParser.swift, there was a goal of an eventual refactor. No functionality was changed.

## How Has This Been Tested?
Tested on Mac and Linux. A new negative test case was added as well.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

