### PR TITLE
Refactored Kitura-Net HTTPServerDelegate to ServerDelegate

### DIFF
--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -29,7 +29,7 @@ public class Kitura {
     // it does not start listening on the port until Kitura.run() is called
     //
     @discardableResult
-    public class func addHTTPServer(onPort port: Int, with delegate: HTTPServerDelegate) -> HTTPServer {
+    public class func addHTTPServer(onPort port: Int, with delegate: ServerDelegate) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         httpServersAndPorts.append(server: server, port: port)

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -153,7 +153,7 @@ extension Router : RouterMiddleware {
 ///
 /// HTTPServerDelegate extensions
 ///
-extension Router : HTTPServerDelegate {
+extension Router : ServerDelegate {
 
     ///
     /// Handle the request

--- a/Tests/Kitura/KituraTest.swift
+++ b/Tests/Kitura/KituraTest.swift
@@ -32,7 +32,7 @@ extension KituraTest {
   //       sleep(10)
     }
 
-    func performServerTest(_ router: HTTPServerDelegate, asyncTasks: (expectation: XCTestExpectation) -> Void...) {
+    func performServerTest(_ router: ServerDelegate, asyncTasks: (expectation: XCTestExpectation) -> Void...) {
         let server = setupServer(port: 8090, delegate: router)
         let requestQueue = Queue(type: .serial)
 
@@ -65,7 +65,7 @@ extension KituraTest {
         req.end()
     }
 
-    private func setupServer(port: Int, delegate: HTTPServerDelegate) -> HTTPServer {
+    private func setupServer(port: Int, delegate: ServerDelegate) -> HTTPServer {
         return HTTPServer.listen(port: port, delegate: delegate,
                            notOnMainQueue:true)
     }


### PR DESCRIPTION
As the title describes, this is a refactoring / renaming of the HTTPServerDelegate class protocol in Kitura-net to simply ServerDelegate. Changes apply to both Kitura and Kitura-net, both on the master branch.

In relation to #565 - adding FastCGI to Kitura.

## Description
- Pulled HTTPServerDelegate from the HTTPServer class.
- Placed it in it's own file, ServerDelegate.swift in Kitura-net.
- Replaced all uses of HTTPServerDelegate with ServerDelegate system wide. This affects both the Kitura-Net and Kitura projects.

## Motivation and Context
This class will ultimately be used to provide server protocols other than HTTP and will be used by a forthcoming pull request related to adding a FastCGI server implementation to Kitura. For clarity, this refactor makes it obvious that the ServerDelegate handles more than HTTP and moves it out of the HTTPServer class in the process.

## How Has This Been Tested?
Change is relatively trivial in terms of a refactor. Did a full rebuild of current test projects I'm working on and everything builds and runs as always. There is no real code changes here - just renames for the most part.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
