### PR TITLE
IBM-Swift/Kitura#417 Exploit the new waitOnListeners API in KituraNet.HTTPServer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "Kitura",
         dependencies: [
-            .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 0, minor: 20),
+            .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 0, minor: 21),
             .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 9),
             .Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 0, minor: 16)
         ]

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -46,7 +46,7 @@ public class Kitura {
             Log.verbose("Starting an HTTP Server on port \(port)...")
             server.listen(port: port, notOnMainQueue: false)
         }
-        dispatch_main()
+        HTTPServer.waitForListeners()
     }
     
     typealias Port = Int


### PR DESCRIPTION
Last piece of the fix for IBM-Swift/Kitura#417. Eliminate the use of dispatch_main

## Description
Exploit the new waitOnListeners API in KituraNet.HTTPServer instead of invoking dispatch_main.

**Note:** It is important that this PR not be merged before the PR https://github.com/IBM-Swift/Kitura-net/pull/43 is merged.

## Motivation and Context
On Linux processes running Kitura used to get marked as defunct. This prevented:
  1. The use of LLDB to debug
  2. Getting core files when Kitura crashed
  3. Tools like top didn't report useful information

This was apparently due to the way dispatch_main is implemented on Linux.

This is issue IBM-Swift/Kitura#417

## How Has This Been Tested?
Tested as part of the performance test work, ran Kitura under lldb, and have successfully gotten core files when Kitura processes crash.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.