### PR TITLE
Forward port on Docker host to the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ This branch of Kitura requires the **`DEVELOPMENT-SNAPSHOT-2016-06-06-a`** versi
 
   `docker pull ibmcom/kitura-ubuntu:latest`
 
-3. Create a Docker container using the `kitura-ubuntu` image you just downloaded:
+3. Create a Docker container using the `kitura-ubuntu` image you just downloaded and forward port 8090 on host to the container:
 
-  `docker run -i -t ibmcom/kitura-ubuntu:latest /bin/bash`
+  `docker run -i -p 8090:8090 -t ibmcom/kitura-ubuntu:latest /bin/bash`
 
 4. From within the Docker container, execute the `clone_build_test_kitura.sh` script to build Kitura and execute the test cases:
 


### PR DESCRIPTION
To access the web server it's necessary to forward port 8090 on Docker host to the container.

## Description
The Docker description is not complete as the port is not connected to the container. This is rectified by adding a command to forward the port to the Docker container.

## Motivation and Context
It makes it possible for someone to follow the step by step Docker instructions and get the server responding.

## How Has This Been Tested?
The command was tested with Docker.
Tested on macOS version 10.12 beta running Docker version 1.12.0-rc2-beta17

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.