### PR TITLE
Change Kitura branch in vagrantfile to master

### DIFF
--- a/vagrantfile
+++ b/vagrantfile
@@ -11,7 +11,7 @@ SWIFT_HOME = "/home/vagrant/#{SWIFT_DIRECTORY}".freeze
 LIBDISPATCH_URL = '-b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch'.freeze
 
 KITURA_URL = 'https://github.com/IBM-Swift/Kitura.git'.freeze
-KITURA_BRANCH = 'develop'.freeze
+KITURA_BRANCH = 'master'.freeze
 
 Vagrant.configure(2) do |config|
   config.vm.box = BOX_URL


### PR DESCRIPTION
Using the vagrantfile to bring up a development image doesn't work - it's looking for the devel branch of Kitura which doesn't exist

## Description
Altered the vagrantfile to pull from master instead of devel

## Motivation and Context
Making the install work from vagrant

## How Has This Been Tested?
Installed a system using vagrant up; system came up.

## Checklist:
- [N/A ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [N/A ] If applicable, I have updated the documentation accordingly.
- [N/A ] If applicable, I have added tests to cover my changes.

