### PR TITLE
IBM-Swift/Kitura#577 in BodyParser check if body is already parsed

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -52,7 +52,7 @@ public class BodyParser: RouterMiddleware {
     /// - Parameter next: the closure for the next execution block
     ///
     public func handle(request: RouterRequest, response: RouterResponse, next: () -> Void) throws {
-        if request.body != nil {
+        guard request.body == nil else {
             return next() // the body was already parsed
         }
 

--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -52,6 +52,10 @@ public class BodyParser: RouterMiddleware {
     /// - Parameter next: the closure for the next execution block
     ///
     public func handle(request: RouterRequest, response: RouterResponse, next: () -> Void) throws {
+        if request.body != nil {
+            return next() // the body was already parsed
+        }
+
         guard request.headers["Content-Length"] != nil,
             let contentType = request.headers["Content-Type"] else {
             return next()
@@ -71,14 +75,14 @@ public class BodyParser: RouterMiddleware {
         guard let contentType = contentType else {
             return nil
         }
-        
+
         if let parser = getParser(contentType: contentType) {
             return parse(message, parser: parser)
         }
-        
+
         return nil
     }
-    
+
     class func getParser(contentType: String) -> BodyParserProtocol? {
         // Handle Content-Type with parameters.  For example, treat:
         // "application/x-www-form-urlencoded; charset=UTF-8" as

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -32,6 +32,7 @@ class TestResponse : XCTestCase {
         return [
             ("testSimpleResponse", testSimpleResponse),
             ("testPostRequest", testPostRequest),
+            ("testPostRequestWithDoubleBodyParser", testPostRequestWithDoubleBodyParser),
             ("testPostRequestUrlEncoded", testPostRequestUrlEncoded),
             ("testMultipartFormParsing", testMultipartFormParsing),
             ("testParameter", testParameter),
@@ -91,7 +92,28 @@ class TestResponse : XCTestCase {
             }
         }
     }
-    
+
+    func testPostRequestWithDoubleBodyParser() {
+        performServerTest(router) { expectation in
+            self.performRequest("post", path: "/doublebodytest", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                //XCTAssertEqual(response!.method, "POST", "The request wasn't recognized as a post")
+                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                do {
+                    let body = try response!.readString()
+                    XCTAssertEqual(body!,"<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
+                }
+                catch{
+                    XCTFail("No response body")
+                }
+                expectation.fulfill()
+            }) {req in
+                req.write(from: "plover\n")
+                req.write(from: "xyzzy\n")
+            }
+        }
+    }
+
     func testPostRequestUrlEncoded() {
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/bodytest", callback: {response in
@@ -132,7 +154,7 @@ class TestResponse : XCTestCase {
 
     func dataComponentsTest(_ searchString: String, separator: String) {
         let stringFind = searchString.components(separatedBy: separator)
-        
+
         // test NSData.components extension
         var separatorData = NSData()
         if let data = separator.data(using: NSUTF8StringEncoding) {
@@ -145,7 +167,7 @@ class TestResponse : XCTestCase {
             searchData = data
         }
         let dataFind = searchData.components(separatedBy: separatorData)
-        
+
         // ensure we get the same sized array back
         XCTAssert(dataFind.count == stringFind.count)
         // test to ensure the strings are equal
@@ -154,16 +176,16 @@ class TestResponse : XCTestCase {
             XCTAssertEqual(stringFind[i], dataString)
         }
     }
-    
+
     func testMultipartFormParsing() {
-        
+
         // ensure NSData.components works just like String.components
         dataComponentsTest("AxAyAzA", separator: "A")
         dataComponentsTest("HelloWorld", separator: "World")
         dataComponentsTest("ababababababababababa", separator: "b")
         dataComponentsTest("Invalid separator", separator: "")
         dataComponentsTest("", separator: "Invalid search string")
-        
+
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/multibodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
@@ -243,7 +265,7 @@ class TestResponse : XCTestCase {
                     "--ZZZY70gRGgDPOiChzXcmW3psiU7HlnC--")
             }
         }
-        
+
         // Negative test case - valid boundary but an invalid body
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/multibodytest", callback: {response in
@@ -645,9 +667,7 @@ class TestResponse : XCTestCase {
             next()
         }
 
-        router.all("/bodytest", middleware: BodyParser())
-
-        router.post("/bodytest") { request, response, next in
+        let bodyTestHandler: RouterHandler =  { request, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             guard let requestBody = request.body else {
                 next ()
@@ -671,9 +691,17 @@ class TestResponse : XCTestCase {
 
             next()
         }
-        
+
+        router.all("/bodytest", middleware: BodyParser())
+        router.post("/bodytest", handler: bodyTestHandler)
+
+        router.all("/doublebodytest", middleware: BodyParser())
+        router.all("/doublebodytest", middleware: BodyParser())
+        router.post("/doublebodytest", handler: bodyTestHandler)
+
+
         router.all("/multibodytest", middleware: BodyParser())
-        
+
         router.post("/multibodytest") { request, response, next in
             guard let requestBody = request.body else {
                 next ()
@@ -689,14 +717,14 @@ class TestResponse : XCTestCase {
             }
             next()
         }
-        
+
         router.post("/bodytest") { request, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             guard let requestBody = request.body else {
                 next ()
                 return
             }
-            
+
             print(requestBody)
         }
 

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -695,6 +695,7 @@ class TestResponse : XCTestCase {
         router.all("/bodytest", middleware: BodyParser())
         router.post("/bodytest", handler: bodyTestHandler)
 
+        //intentially BodyParser is added twice, to check how two body parsers work together
         router.all("/doublebodytest", middleware: BodyParser())
         router.all("/doublebodytest", middleware: BodyParser())
         router.post("/doublebodytest", handler: bodyTestHandler)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

return the body is already parsed, e.g. request.body is not nil
added a test case