### PR TITLE
Enabled FastCGI Support in Kitura

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,37 @@ Let's develop our first Kitura Web Application written in Swift!
 
 11. Open your browser at [http://localhost:8090](http://localhost:8090)
 
+## FastCGI Support
+
+Kitura includes an Apache/mod_proxy_fastcgi and Nginx compatible FastCGI server. To enable FastCGI support, simply add a FastCGI server to Kitura framework:
+
+```swift
+  Kitura.addFastCGIServer(onPort: 9000, with: router)
+```
+
+Based on the example outlined above, your Sources/main.swift would now look like this:
+
+   ```swift
+   import Kitura
+   import HeliumLogger
+
+   HeliumLogger.use()
+
+   let router = Router()
+
+   router.get("/") {
+       request, response, next in
+       response.send("Hello, World!")
+       next()
+   }
+
+   Kitura.addHTTPServer(onPort: 8090, with: router)
+   Kitura.addFastCGIServer(onPort: 9000, with: router)
+   Kitura.run()
+   ```
+
+You can then configure your web server to forward requests to Kitura via FastCGI on the specified port (in this example, 9000. 
+
 ## Kitura Wiki
 Feel free to visit our [Wiki](https://github.com/IBM-Swift/Kitura/wiki) for our roadmap and some tutorials.
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Based on the example outlined above, your Sources/main.swift would now look like
    Kitura.run()
    ```
 
-You can then configure your web server to forward requests to Kitura via FastCGI on the specified port (in this example, 9000. 
+You can then configure your web server to forward requests to Kitura via FastCGI on the specified port (in this example, port 9000).
 
 ## Kitura Wiki
 Feel free to visit our [Wiki](https://github.com/IBM-Swift/Kitura/wiki) for our roadmap and some tutorials.

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -35,6 +35,18 @@ public class Kitura {
         httpServersAndPorts.append(server: server, port: port)
         return server
     }
+    
+    //
+    // add a FastCGIServer on a port with a delegate. The server is only registered with the framework,
+    // it does not start listening on the port until Kitura.run() is called
+    //
+    @discardableResult
+    public class func addFastCGIServer(onPort port: Int, with delegate: ServerDelegate) -> FastCGIServer {
+        let server = FastCGI.createServer()
+        server.delegate = delegate
+        fastCGIServersAndPorts.append(server: server, port: port)
+        return server
+    }
 
     //
     // Start Kitura framework - make all the registered servers to start listening on their port
@@ -46,10 +58,15 @@ public class Kitura {
             Log.verbose("Starting an HTTP Server on port \(port)...")
             server.listen(port: port, notOnMainQueue: false)
         }
-        HTTPServer.waitForListeners()
+        for (server, port) in fastCGIServersAndPorts {
+            Log.verbose("Starting a FastCGI Server on port \(port)...")
+            server.listen(port: port)
+        }
+        ListenerGroup.waitForListeners()
     }
     
     typealias Port = Int
     private static var httpServersAndPorts = [(server: HTTPServer, port: Port)]()
+    private static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port)]()
 
 }


### PR DESCRIPTION
Enabled FastCGI support in Kitura, including documentation changes to README.md.

## Description
- Updated Kitura.swift to add add an ```addFastCGIServer(onPort port: Int, with delegate: ServerDelegate)``` method to enable FastCGI.
- Added related data structures. 
- Modified the ```run()``` method in Kitura.swift to start any FastCGI servers configured.
- Modified the ```run()``` command to wait on the centralized ```ListenerGroup.waitForListeners``` rather than calling ```HTTPServer.waitForListeners```.

## Motivation and Context
Enables FastCGI support, per #565 

## How Has This Been Tested?
Minimal code changes to Kitura. The underlying FastCGI support has been tested via both test units in IBM-Swift/Kitura-net as well as demo code running at http://swift.codeandstrings.com (tested with various benchmarking tools with Nginx and Apache talking to Kitura over FastCGI).

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
