### PR TITLE
Improved the directions for installing libDispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,13 @@ Kitura is tested on Ubuntu 14.04 LTS and Ubuntu 15.10.
  Follow the instructions provided on that page. After installing it (i.e. uncompressing the tar file), make sure you update your PATH environment variable so that it includes the extracted tools: `export PATH=/<path to uncompress tar contents>/usr/bin:$PATH`. To update the PATH env variable, you can update your [.bashrc file](http://www.joshstaiger.org/archives/2005/07/bash_profile_vs.html).
 
 3. Clone, build and install the libdispatch library.
-The complete instructions for building and installing this library are  [here](https://github.com/apple/swift-corelibs-libdispatch/blob/experimental/foundation/INSTALL), though, all you need to do is just this
- `$ git clone --recursive -b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch.git && cd swift-corelibs-libdispatch && sh ./autogen.sh && ./configure --with-swift-toolchain=<path-to-swift>/usr --prefix=<path-to-swift>/usr && make && make install`
+
+ The complete instructions for building and installing this library are shown [here](https://github.com/apple/swift-corelibs-libdispatch/blob/experimental/foundation/INSTALL). For convenience, the command to compile is:
+
+ ```
+ $ export SWIFT_HOME=<path-to-swift-toolchain e.g. /home/user/swift-toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-06-20-a-ubuntu15.10>
+ $ git clone --recursive -b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch.git && cd swift-corelibs-libdispatch && sh ./autogen.sh && ./configure --with-swift-toolchain=$SWIFT_HOME/usr --prefix=$SWIFT_HOME/usr && make && make install
+ ```
 
 Now you are ready to develop your first Kitura app. Check [Kitura Sample](https://github.com/IBM-Swift/Kitura-Sample) or see [Getting Started](#getting-started).
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,12 @@ Kitura is tested on Ubuntu 14.04 LTS and Ubuntu 15.10.
  The complete instructions for building and installing this library are shown [here](https://github.com/apple/swift-corelibs-libdispatch/blob/experimental/foundation/INSTALL). For convenience, the command to compile is:
 
  ```
- $ export SWIFT_HOME=<path-to-swift-toolchain e.g. /home/user/swift-toolchains/swift-DEVELOPMENT-SNAPSHOT-2016-06-20-a-ubuntu15.10>
- $ git clone --recursive -b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch.git && cd swift-corelibs-libdispatch && sh ./autogen.sh && ./configure --with-swift-toolchain=$SWIFT_HOME/usr --prefix=$SWIFT_HOME/usr && make && make install
+ $ export SWIFT_HOME=<path-to-swift-toolchain 
+ $ git clone --recursive -b experimental/foundation https://github.com/apple/swift-corelibs-libdispatch.git \
+  && cd swift-corelibs-libdispatch \
+  && sh ./autogen.sh \
+  && ./configure --with-swift-toolchain=$SWIFT_HOME/usr --prefix=$SWIFT_HOME/usr \
+  && make && make install
  ```
 
 Now you are ready to develop your first Kitura app. Check [Kitura Sample](https://github.com/IBM-Swift/Kitura-Sample) or see [Getting Started](#getting-started).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The instructions for installing libDispatch was good in the sense it was simple for copying and pasting into the Terminal. However, with each toolchain path being different, it might be easier to define the path to the toolchain outside of the configuration command.

Idea comes from lots of experience simplifying the process for myself and others. @chiahuang 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

