### PR TITLE
IBM-Swift/Kitura#662 Added a logger to the tests

### DIFF
--- a/Tests/Kitura/KituraTest.swift
+++ b/Tests/Kitura/KituraTest.swift
@@ -34,8 +34,12 @@ protocol KituraTest {
 
 extension KituraTest {
 
-   func doTearDown() {
-  //       sleep(10)
+    func doSetUp() {
+        PrintLogger.use()
+    }
+    
+    func doTearDown() {
+        // sleep(10)
     }
 
     func performServerTest(_ router: ServerDelegate, asyncTasks: (expectation: XCTestExpectation) -> Void...) {

--- a/Tests/Kitura/PrintLogger.swift
+++ b/Tests/Kitura/PrintLogger.swift
@@ -1,0 +1,31 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+import LoggerAPI
+
+public class PrintLogger: Logger {
+    public func log(_ type: LoggerMessageType, msg: String,
+                    functionName: String, lineNum: Int, fileName: String ) {
+        print("\(type): \(functionName) \(fileName) line \(lineNum) - \(msg)")
+    }
+    
+    public static func use() {
+        Log.logger = PrintLogger()
+        setbuf(stdout, nil)
+    }
+}

--- a/Tests/Kitura/TestCookies.swift
+++ b/Tests/Kitura/TestCookies.swift
@@ -50,6 +50,10 @@ class TestCookies : XCTestCase {
             ("testCookieFromServer", testCookieFromServer)
         ]
     }
+    
+    override func setUp() {
+        doSetUp()
+    }
 
     override func tearDown() {
         doTearDown()

--- a/Tests/Kitura/TestErrors.swift
+++ b/Tests/Kitura/TestErrors.swift
@@ -37,6 +37,10 @@ class TestErrors : XCTestCase {
             ("testInvalidHeader", testInvalidHeader)
         ]
     }
+    
+    override func setUp() {
+        doSetUp()
+    }
 
     override func tearDown() {
         doTearDown()

--- a/Tests/Kitura/TestMultiplicity.swift
+++ b/Tests/Kitura/TestMultiplicity.swift
@@ -29,6 +29,10 @@ class TestMultiplicity : XCTestCase {
             ("testCombined", testCombined)
         ]
     }
+    
+    override func setUp() {
+        doSetUp()
+    }
 
     override func tearDown() {
         doTearDown()

--- a/Tests/Kitura/TestRequests.swift
+++ b/Tests/Kitura/TestRequests.swift
@@ -28,6 +28,10 @@ class TestRequest : XCTestCase {
         ]
     }
     
+    override func setUp() {
+        doSetUp()
+    }
+    
     override func tearDown() {
         doTearDown()
     }

--- a/Tests/Kitura/TestResponse.swift
+++ b/Tests/Kitura/TestResponse.swift
@@ -48,6 +48,10 @@ class TestResponse : XCTestCase {
             ("testJsonp", testJsonp)
         ]
     }
+    
+    override func setUp() {
+        doSetUp()
+    }
 
     override func tearDown() {
         doTearDown()

--- a/Tests/Kitura/TestSubrouter.swift
+++ b/Tests/Kitura/TestSubrouter.swift
@@ -35,6 +35,10 @@ class TestSubrouter : XCTestCase {
             ("testMultipleMiddleware", testMultipleMiddleware)
         ]
     }
+    
+    override func setUp() {
+        doSetUp()
+    }
 
     override func tearDown() {
         doTearDown()


### PR DESCRIPTION
In order to fix the failing tests we need some logs.

## Description
Added a trivial logger (simpler than HeliumLogger) to the tests. Every test now invokes the doSetUp function to set the logger.

## Motivation and Context
Get a start on fixing or failing builds

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

