### PR TITLE
URL matching fix for middleware

### DIFF
--- a/Scripts/generate_router_verbs.sh
+++ b/Scripts/generate_router_verbs.sh
@@ -57,13 +57,13 @@ cat <<EOF >> ${OUTPUT_FILE}
     }
 
     @discardableResult
-    public func $VERB_LOW_CASE(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.$VERB_LOW_CASE, pattern: path, middleware: middleware)
+    public func $VERB_LOW_CASE(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.$VERB_LOW_CASE, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func $VERB_LOW_CASE(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.$VERB_LOW_CASE, pattern: path, middleware: middleware)
+    public func $VERB_LOW_CASE(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.$VERB_LOW_CASE, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 EOF
 done

--- a/Sources/Kitura/RouteRegex.swift
+++ b/Sources/Kitura/RouteRegex.swift
@@ -27,7 +27,7 @@ import Foundation
 
 public class RouteRegex {
     public static let sharedInstance = RouteRegex()
-    
+
     private let namedCaptureRegex: RegularExpressionType
     private let unnamedCaptureRegex: RegularExpressionType
     private let keyRegex: RegularExpressionType
@@ -44,7 +44,7 @@ public class RouteRegex {
             exit(1)
         }
     }
-    
+
     /// Builds a regular expression from a String pattern
     ///
     /// - Parameter pattern: Optional string
@@ -59,18 +59,18 @@ public class RouteRegex {
         var regexStr = "^"
         var keys = [String]()
         var nonKeyIndex = 0
-        
+
         if allowPartialMatch && pattern.hasSuffix("*") {
             pattern = String(pattern.characters.dropLast())
         }
-        
+
         let paths = pattern.bridge().components(separatedBy: "/")
-        
+
         // Special case where only back slashes are specified
         if paths.filter({$0 != ""}).isEmpty {
             regexStr.append("/")
         }
-        
+
         for path in paths {
             (regexStr, keys, nonKeyIndex) =
                 handlePath(path, regexStr: regexStr, keys: keys, nonKeyIndex: nonKeyIndex)
@@ -163,7 +163,7 @@ public class RouteRegex {
     #else
     typealias TextCheckingResultType = NSTextCheckingResult
     #endif
-    
+
     func extract(fromPath path: String, with match: TextCheckingResultType, at index: Int,
                  to string: inout String) {
         #if os(Linux)

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -53,8 +53,11 @@ public class Router {
         return self
     }
 
-    func routingHelper(_ method: RouterMethod, pattern: String?, middleware: [RouterMiddleware]) -> Router {
-        elements.append(RouterElement(method: method, pattern: pattern, middleware: middleware))
+    func routingHelper(_ method: RouterMethod, pattern: String?, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        elements.append(RouterElement(method: method,
+            pattern: pattern,
+            middleware: middleware,
+            allowPartialMatch: allowPartialMatch))
         return self
     }
 

--- a/Sources/Kitura/RouterElement.swift
+++ b/Sources/Kitura/RouterElement.swift
@@ -35,7 +35,7 @@ class RouterElement {
     #else
         private var regex: NSRegularExpression?
     #endif
-    
+
     /// The list of keys
     private var keys: [String]?
 

--- a/Sources/Kitura/RouterHTTPVerbs_generated.swift
+++ b/Sources/Kitura/RouterHTTPVerbs_generated.swift
@@ -30,13 +30,13 @@ extension Router {
     }
 
     @discardableResult
-    public func all(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.all, pattern: path, middleware: middleware)
+    public func all(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.all, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func all(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.all, pattern: path, middleware: middleware)
+    public func all(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.all, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Get
 
@@ -51,13 +51,13 @@ extension Router {
     }
 
     @discardableResult
-    public func get(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.get, pattern: path, middleware: middleware)
+    public func get(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.get, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func get(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.get, pattern: path, middleware: middleware)
+    public func get(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.get, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Head
 
@@ -72,13 +72,13 @@ extension Router {
     }
 
     @discardableResult
-    public func head(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.head, pattern: path, middleware: middleware)
+    public func head(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.head, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func head(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.head, pattern: path, middleware: middleware)
+    public func head(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.head, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Post
 
@@ -93,13 +93,13 @@ extension Router {
     }
 
     @discardableResult
-    public func post(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.post, pattern: path, middleware: middleware)
+    public func post(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.post, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func post(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.post, pattern: path, middleware: middleware)
+    public func post(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.post, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Put
 
@@ -114,13 +114,13 @@ extension Router {
     }
 
     @discardableResult
-    public func put(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.put, pattern: path, middleware: middleware)
+    public func put(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.put, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func put(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.put, pattern: path, middleware: middleware)
+    public func put(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.put, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Delete
 
@@ -135,13 +135,13 @@ extension Router {
     }
 
     @discardableResult
-    public func delete(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.delete, pattern: path, middleware: middleware)
+    public func delete(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.delete, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func delete(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.delete, pattern: path, middleware: middleware)
+    public func delete(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.delete, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Options
 
@@ -156,13 +156,13 @@ extension Router {
     }
 
     @discardableResult
-    public func options(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.options, pattern: path, middleware: middleware)
+    public func options(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.options, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func options(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.options, pattern: path, middleware: middleware)
+    public func options(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.options, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Trace
 
@@ -177,13 +177,13 @@ extension Router {
     }
 
     @discardableResult
-    public func trace(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.trace, pattern: path, middleware: middleware)
+    public func trace(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.trace, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func trace(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.trace, pattern: path, middleware: middleware)
+    public func trace(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.trace, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Copy
 
@@ -198,13 +198,13 @@ extension Router {
     }
 
     @discardableResult
-    public func copy(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.copy, pattern: path, middleware: middleware)
+    public func copy(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.copy, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func copy(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.copy, pattern: path, middleware: middleware)
+    public func copy(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.copy, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Lock
 
@@ -219,13 +219,13 @@ extension Router {
     }
 
     @discardableResult
-    public func lock(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.lock, pattern: path, middleware: middleware)
+    public func lock(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.lock, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func lock(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.lock, pattern: path, middleware: middleware)
+    public func lock(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.lock, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: MkCol
 
@@ -240,13 +240,13 @@ extension Router {
     }
 
     @discardableResult
-    public func mkCol(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.mkCol, pattern: path, middleware: middleware)
+    public func mkCol(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.mkCol, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func mkCol(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.mkCol, pattern: path, middleware: middleware)
+    public func mkCol(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.mkCol, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Move
 
@@ -261,13 +261,13 @@ extension Router {
     }
 
     @discardableResult
-    public func move(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.move, pattern: path, middleware: middleware)
+    public func move(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.move, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func move(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.move, pattern: path, middleware: middleware)
+    public func move(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.move, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Purge
 
@@ -282,13 +282,13 @@ extension Router {
     }
 
     @discardableResult
-    public func purge(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.purge, pattern: path, middleware: middleware)
+    public func purge(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.purge, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func purge(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.purge, pattern: path, middleware: middleware)
+    public func purge(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.purge, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: PropFind
 
@@ -303,13 +303,13 @@ extension Router {
     }
 
     @discardableResult
-    public func propFind(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.propFind, pattern: path, middleware: middleware)
+    public func propFind(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.propFind, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func propFind(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.propFind, pattern: path, middleware: middleware)
+    public func propFind(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.propFind, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: PropPatch
 
@@ -324,13 +324,13 @@ extension Router {
     }
 
     @discardableResult
-    public func propPatch(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.propPatch, pattern: path, middleware: middleware)
+    public func propPatch(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.propPatch, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func propPatch(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.propPatch, pattern: path, middleware: middleware)
+    public func propPatch(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.propPatch, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Unlock
 
@@ -345,13 +345,13 @@ extension Router {
     }
 
     @discardableResult
-    public func unlock(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.unlock, pattern: path, middleware: middleware)
+    public func unlock(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.unlock, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func unlock(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.unlock, pattern: path, middleware: middleware)
+    public func unlock(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.unlock, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Report
 
@@ -366,13 +366,13 @@ extension Router {
     }
 
     @discardableResult
-    public func report(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.report, pattern: path, middleware: middleware)
+    public func report(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.report, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func report(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.report, pattern: path, middleware: middleware)
+    public func report(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.report, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: MkActivity
 
@@ -387,13 +387,13 @@ extension Router {
     }
 
     @discardableResult
-    public func mkActivity(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.mkActivity, pattern: path, middleware: middleware)
+    public func mkActivity(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.mkActivity, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func mkActivity(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.mkActivity, pattern: path, middleware: middleware)
+    public func mkActivity(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.mkActivity, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Checkout
 
@@ -408,13 +408,13 @@ extension Router {
     }
 
     @discardableResult
-    public func checkout(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.checkout, pattern: path, middleware: middleware)
+    public func checkout(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.checkout, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func checkout(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.checkout, pattern: path, middleware: middleware)
+    public func checkout(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.checkout, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Merge
 
@@ -429,13 +429,13 @@ extension Router {
     }
 
     @discardableResult
-    public func merge(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.merge, pattern: path, middleware: middleware)
+    public func merge(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.merge, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func merge(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.merge, pattern: path, middleware: middleware)
+    public func merge(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.merge, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: MSearch
 
@@ -450,13 +450,13 @@ extension Router {
     }
 
     @discardableResult
-    public func mSearch(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.mSearch, pattern: path, middleware: middleware)
+    public func mSearch(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.mSearch, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func mSearch(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.mSearch, pattern: path, middleware: middleware)
+    public func mSearch(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.mSearch, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Notify
 
@@ -471,13 +471,13 @@ extension Router {
     }
 
     @discardableResult
-    public func notify(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.notify, pattern: path, middleware: middleware)
+    public func notify(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.notify, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func notify(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.notify, pattern: path, middleware: middleware)
+    public func notify(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.notify, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Subscribe
 
@@ -492,13 +492,13 @@ extension Router {
     }
 
     @discardableResult
-    public func subscribe(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.subscribe, pattern: path, middleware: middleware)
+    public func subscribe(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.subscribe, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func subscribe(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.subscribe, pattern: path, middleware: middleware)
+    public func subscribe(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.subscribe, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Unsubscribe
 
@@ -513,13 +513,13 @@ extension Router {
     }
 
     @discardableResult
-    public func unsubscribe(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.unsubscribe, pattern: path, middleware: middleware)
+    public func unsubscribe(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.unsubscribe, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func unsubscribe(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.unsubscribe, pattern: path, middleware: middleware)
+    public func unsubscribe(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.unsubscribe, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Patch
 
@@ -534,13 +534,13 @@ extension Router {
     }
 
     @discardableResult
-    public func patch(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.patch, pattern: path, middleware: middleware)
+    public func patch(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.patch, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func patch(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.patch, pattern: path, middleware: middleware)
+    public func patch(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.patch, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Search
 
@@ -555,13 +555,13 @@ extension Router {
     }
 
     @discardableResult
-    public func search(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.search, pattern: path, middleware: middleware)
+    public func search(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.search, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func search(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.search, pattern: path, middleware: middleware)
+    public func search(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.search, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
     // MARK: Connect
 
@@ -576,12 +576,12 @@ extension Router {
     }
 
     @discardableResult
-    public func connect(_ path: String?=nil, middleware: RouterMiddleware...) -> Router {
-        return routingHelper(.connect, pattern: path, middleware: middleware)
+    public func connect(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: RouterMiddleware...) -> Router {
+        return routingHelper(.connect, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 
     @discardableResult
-    public func connect(_ path: String?=nil, middleware: [RouterMiddleware]) -> Router {
-        return routingHelper(.connect, pattern: path, middleware: middleware)
+    public func connect(_ path: String?=nil, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+        return routingHelper(.connect, pattern: path, allowPartialMatch: allowPartialMatch, middleware: middleware)
     }
 }

--- a/Tests/Kitura/TestRequests.swift
+++ b/Tests/Kitura/TestRequests.swift
@@ -80,7 +80,7 @@ class TestRequests : XCTestCase {
 
         let router = Router()
 
-        router.get("/user/:id", middleware: CustomMiddleware())
+        router.get("/user/:id", allowPartialMatch: false, middleware: CustomMiddleware())
         router.get("/user/:id") { request, response, next in
             let id = request.parameters["id"]
             XCTAssertNotNil(id, "URL parameter 'id' in middleware handler was nil")

--- a/Tests/Kitura/TestRequests.swift
+++ b/Tests/Kitura/TestRequests.swift
@@ -20,28 +20,30 @@ import Foundation
 @testable import Kitura
 @testable import KituraNet
 
-class TestRequest : XCTestCase {
-    
-    static var allTests : [(String, (TestRequest) -> () throws -> Void)] {
+class TestRequests : XCTestCase {
+
+    static var allTests : [(String, (TestRequests) -> () throws -> Void)] {
         return [
-                   ("testURLParameters", testURLParameters)
+                   ("testURLParameters", testURLParameters),
+                   ("testCustomMiddlewareURLParameter", testCustomMiddlewareURLParameter),
+                   ("testCustomMiddlewareURLParameterWithQueryParam", testCustomMiddlewareURLParameterWithQueryParam)
         ]
     }
-    
+
     override func setUp() {
         doSetUp()
     }
-    
+
     override func tearDown() {
         doTearDown()
     }
-    
-    let router = TestRequest.setupRouter()
-    
+
+    let router = TestRequests.setupRouter()
+
     func testURLParameters() {
         // Set up router for this test
         let router = Router()
-        
+
         router.get("/zxcv/:p1") { request, _, next in
             let parameter = request.parameters["p1"]
             XCTAssertNotNil(parameter, "URL parameter p1 was nil")
@@ -56,18 +58,56 @@ class TestRequest : XCTestCase {
             response.status(.OK).send("OK")
             next()
         }
-        
+
         performServerTest(router) { expectation in
-            self.performRequest("get", path: "/zxcv/ploni", callback: {response in
+            self.performRequest("get", path: "/zxcv/ploni", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
             })
         }
     }
-    
+
+    private func runMiddlewareTest(path: String) {
+        class CustomMiddleware: RouterMiddleware {
+            func handle(request: RouterRequest, response: RouterResponse, next: () -> Void) {
+                let id = request.parameters["id"]
+                XCTAssertNotNil(id, "URL parameter 'id' in custom middleware was nil")
+                XCTAssertEqual("my_custom_id", id, "URL parameter 'id' in custom middleware was wrong")
+                response.status(.OK)
+                next()
+            }
+        }
+
+        let router = Router()
+
+        router.get("/user/:id", middleware: CustomMiddleware())
+        router.get("/user/:id") { request, response, next in
+            let id = request.parameters["id"]
+            XCTAssertNotNil(id, "URL parameter 'id' in middleware handler was nil")
+            XCTAssertEqual("my_custom_id", id, "URL parameter 'id' in middleware handler was wrong")
+            response.status(.OK)
+            next()
+        }
+
+        performServerTest(router) { expectation in
+            self.performRequest("get", path: path, callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                expectation.fulfill()
+            })
+        }
+    }
+
+    func testCustomMiddlewareURLParameter() {
+        runMiddlewareTest(path: "/user/my_custom_id")
+    }
+
+    func testCustomMiddlewareURLParameterWithQueryParam() {
+        runMiddlewareTest(path: "/user/my_custom_id?some_param=value")
+    }
+
     static func setupRouter() -> Router {
         let router = Router()
-        
+
         router.get("/zxcv/:p1") { request, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             let p1 = request.parameters["p1"] ?? "(nil)"
@@ -79,10 +119,9 @@ class TestRequest : XCTestCase {
             catch {}
             next()
         }
-        
-        
-        
+
+
+
         return router
     }
 }
-

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -19,11 +19,12 @@ import XCTest
 @testable import KituraTestSuite
 
 XCTMain([
-	testCase(TestContentType.allTests),
-	testCase(TestErrors.allTests),
-	testCase(TestResponse.allTests),
-	testCase(TestMultiplicity.allTests),
-	testCase(TestCookies.allTests),
-    testCase(TestSubrouter.allTests),
-    testCase(TestRouteRegex.allTests)
+		testCase(TestContentType.allTests),
+		testCase(TestErrors.allTests),
+		testCase(TestRequests.allTests),
+		testCase(TestResponse.allTests),
+		testCase(TestMultiplicity.allTests),
+		testCase(TestCookies.allTests),
+	  testCase(TestSubrouter.allTests),
+	  testCase(TestRouteRegex.allTests)
 ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix for url matching problem described in IBM-Swift/Kitura#668. 

This fix adds a ```allowPartialMatch``` parameter for ```Router``` methods that uses middleware as parameter, so it can be passed down to ```RouterElement``` initializer.

Other possible fix is to add query parameters regex expression as attribute to ```RouterElement``` and use it to match set ```queryParameters``` attribute.

Also changed ```LinuxMain.swift``` so it will perform ```TestRequests``` tests on linux.

## Motivation and Context
IBM-Swift/Kitura#668

## How Has This Been Tested?
Added tests (```testCustomMiddlewareURLParameter``` and ```testCustomMiddlewareURLParameterWithQueryParam```) to ```TestRequests``` to check parameters parsing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.