### PR TITLE
Remove dependency on Kitura-sys

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "Kitura",
     dependencies: [
-        .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 0, minor: 30),
+        .Package(url: "https://github.com/IBM-Swift/Kitura-net.git", majorVersion: 0, minor: 31),
         .Package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", majorVersion: 14),
         .Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 0, minor: 30)
     ],

--- a/Sources/Kitura/RouteRegex.swift
+++ b/Sources/Kitura/RouteRegex.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import KituraSys
 import LoggerAPI
 
 import Foundation

--- a/Sources/Kitura/RouterElement.swift
+++ b/Sources/Kitura/RouterElement.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import KituraSys
 import LoggerAPI
 
 import Foundation

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -15,7 +15,6 @@
  */
 
 import KituraNet
-import KituraSys
 import SwiftyJSON
 
 import Foundation
@@ -149,7 +148,7 @@ public class RouterResponse {
     /// - Returns: this RouterResponse.
     @discardableResult
     public func send(_ str: String) -> RouterResponse {
-        if let data = StringUtils.toUtf8String(str) {
+        if let data = str.data(using: .utf8) {
             send(data: data)
         }
         return self


### PR DESCRIPTION
## Description
Replaced use of KituraSys.StringUtils with equivalent Foundation call.

## Motivation and Context
There is no longer a need for KituraSys.

## How Has This Been Tested?
Ran swift test on both Linux and macOS

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

