### PR TITLE
Convert from String to UTF-8 without a Data struct

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -149,8 +149,9 @@ public class RouterResponse {
     @discardableResult
     public func send(_ str: String) -> RouterResponse {
         let utf8Length = str.lengthOfBytes(using: .utf8)
-        var utf8: [CChar] = Array<CChar>(repeating: 0, count: utf8Length + 1) // Add room for the NULL terminator
-        if str.getCString(&utf8, maxLength: utf8Length + 10, encoding: .utf8) {
+        let bufferLength = utf8Length + 1  // Add room for the NULL terminator
+        var utf8: [CChar] = Array<CChar>(repeating: 0, count: bufferLength)
+        if str.getCString(&utf8, maxLength: bufferLength, encoding: .utf8) {
             let rawBytes = UnsafeRawPointer(UnsafePointer(utf8))
             buffer.append(bytes: rawBytes.assumingMemoryBound(to: UInt8.self), length: utf8Length)
             state.invokedSend = true

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -149,7 +149,7 @@ public class RouterResponse {
     @discardableResult
     public func send(_ str: String) -> RouterResponse {
         let utf8Length = str.lengthOfBytes(using: .utf8)
-        var utf8: [CChar] = Array<CChar>(repeating: 0, count: utf8Length + 10) // A little bit of padding
+        var utf8: [CChar] = Array<CChar>(repeating: 0, count: utf8Length + 1) // Add room for the NULL terminator
         if str.getCString(&utf8, maxLength: utf8Length + 10, encoding: .utf8) {
             let rawBytes = UnsafeRawPointer(UnsafePointer(utf8))
             buffer.append(bytes: rawBytes.assumingMemoryBound(to: UInt8.self), length: utf8Length)

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -148,8 +148,12 @@ public class RouterResponse {
     /// - Returns: this RouterResponse.
     @discardableResult
     public func send(_ str: String) -> RouterResponse {
-        if let data = str.data(using: .utf8) {
-            send(data: data)
+        let utf8Length = str.lengthOfBytes(using: .utf8)
+        var utf8: [CChar] = Array<CChar>(repeating: 0, count: utf8Length + 10) // A little bit of padding
+        if str.getCString(&utf8, maxLength: utf8Length + 10, encoding: .utf8) {
+            let rawBytes = UnsafeRawPointer(UnsafePointer(utf8))
+            buffer.append(bytes: rawBytes.assumingMemoryBound(to: UInt8.self), length: utf8Length)
+            state.invokedSend = true
         }
         return self
     }


### PR DESCRIPTION
Convert Strings to UTF-8 in alternate way that doesn't involve a "temporary" Data strut that is a poor performer on Linux.

## Description
Use APIs other than String.data() to convert a String to UTF-8.

## Motivation and Context
Improve performance by removing internal uses of Data.

## How Has This Been Tested?
Kitura Unit tests and TechEmpower performance test.

## Checklist:

- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
