### PR TITLE
IBM-Swift/Kitura#782 Add @discardableResult

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -290,6 +290,7 @@ public class RouterResponse {
     /// - Returns: this RouterResponse.
     ///
     // influenced by http://expressjs.com/en/4x/api.html#app.render
+    @discardableResult
     public func render(_ resource: String, context: [String:Any]) throws -> RouterResponse {
         let renderedResource = try router.render(template: resource, context: context)
         return send(renderedResource)


### PR DESCRIPTION
`RouterResponse.render()` lacks a `@discardableResult` annotation.

This means that `try response.render("data", context: ["name": "George"])` gives this warning:

`warning: result of call to 'render(_:context:)' is unused`