### PR TITLE
Easier access to ParsedBody elements

### DIFF
--- a/Sources/Kitura/bodyParser/ParsedBody.swift
+++ b/Sources/Kitura/bodyParser/ParsedBody.swift
@@ -50,14 +50,12 @@ public indirect enum ParsedBody {
     /// - Returns: The parsed body as a JSON object, or nil if the body wasn't in
     ///           JSON format.
     public var asJSON: JSON? {
-        let result: JSON?
         switch(self) {
         case .json(let body):
-            result = body
+            return body
         default:
-            result = nil
+            return nil
         }
-        return result
     }
     
     /// Extract a "multipart" body from the `ParsedBody` enum
@@ -65,28 +63,24 @@ public indirect enum ParsedBody {
     /// - Returns: The parsed body as an array of `Part` structs, or nil if the body wasn't in
     ///           multi-part form format.
     public var asMultiPart: [Part]? {
-        let result: [Part]?
         switch(self) {
         case .multipart(let body):
-            result = body
+            return body
         default:
-            result = nil
+            return nil
         }
-        return result
     }
     
     /// Extract a "text" body from the `ParsedBody` enum
     ///
     /// - Returns: The "text" body as a String, or nil if the body wasn't in text format.
     public var asText: String? {
-        let result: String?
         switch(self) {
         case .text(let body):
-            result = body
+            return body
         default:
-            result = nil
+            return nil
         }
-        return result
     }
     
     /// Extract a "urlEncoded" body from the `ParsedBody` enum
@@ -94,13 +88,11 @@ public indirect enum ParsedBody {
     /// - Returns: The parsed body as a Dictionary<String, String>, or nil if the body wasn't in
     ///           url encoded form format.
     public var asURLEncoded: [String:String]? {
-        let result: [String:String]?
         switch(self) {
         case .urlEncoded(let body):
-            result = body
+            return body
         default:
-            result = nil
+            return nil
         }
-        return result
     }
 }

--- a/Sources/Kitura/bodyParser/ParsedBody.swift
+++ b/Sources/Kitura/bodyParser/ParsedBody.swift
@@ -50,7 +50,7 @@ public indirect enum ParsedBody {
     /// - Returns: The parsed body as a JSON object, or nil if the body wasn't in
     ///           JSON format.
     public var asJSON: JSON? {
-        switch(self) {
+        switch self {
         case .json(let body):
             return body
         default:
@@ -63,7 +63,7 @@ public indirect enum ParsedBody {
     /// - Returns: The parsed body as an array of `Part` structs, or nil if the body wasn't in
     ///           multi-part form format.
     public var asMultiPart: [Part]? {
-        switch(self) {
+        switch self {
         case .multipart(let body):
             return body
         default:
@@ -75,7 +75,7 @@ public indirect enum ParsedBody {
     ///
     /// - Returns: The "text" body as a String, or nil if the body wasn't in text format.
     public var asText: String? {
-        switch(self) {
+        switch self {
         case .text(let body):
             return body
         default:
@@ -88,7 +88,7 @@ public indirect enum ParsedBody {
     /// - Returns: The parsed body as a Dictionary<String, String>, or nil if the body wasn't in
     ///           url encoded form format.
     public var asURLEncoded: [String:String]? {
-        switch(self) {
+        switch self {
         case .urlEncoded(let body):
             return body
         default:

--- a/Sources/Kitura/bodyParser/ParsedBody.swift
+++ b/Sources/Kitura/bodyParser/ParsedBody.swift
@@ -44,4 +44,63 @@ public indirect enum ParsedBody {
     /// If the content type was "multipart/form-data" this associated value will
     /// contain an array of parts of multi-part respresentation of the body.
     case multipart([Part])
+    
+    /// Extract a "JSON" body from the `ParsedBody` enum
+    ///
+    /// - Returns: The parsed body as a JSON object, or nil if the body wasn't in
+    ///           JSON format.
+    public var asJSON: JSON? {
+        let result: JSON?
+        switch(self) {
+        case .json(let body):
+            result = body
+        default:
+            result = nil
+        }
+        return result
+    }
+    
+    /// Extract a "multipart" body from the `ParsedBody` enum
+    ///
+    /// - Returns: The parsed body as an array of `Part` structs, or nil if the body wasn't in
+    ///           multi-part form format.
+    public var asMultiPart: [Part]? {
+        let result: [Part]?
+        switch(self) {
+        case .multipart(let body):
+            result = body
+        default:
+            result = nil
+        }
+        return result
+    }
+    
+    /// Extract a "text" body from the `ParsedBody` enum
+    ///
+    /// - Returns: The "text" body as a String, or nil if the body wasn't in text format.
+    public var asText: String? {
+        let result: String?
+        switch(self) {
+        case .text(let body):
+            result = body
+        default:
+            result = nil
+        }
+        return result
+    }
+    
+    /// Extract a "urlEncoded" body from the `ParsedBody` enum
+    ///
+    /// - Returns: The parsed body as a Dictionary<String, String>, or nil if the body wasn't in
+    ///           url encoded form format.
+    public var asURLEncoded: [String:String]? {
+        let result: [String:String]?
+        switch(self) {
+        case .urlEncoded(let body):
+            result = body
+        default:
+            result = nil
+        }
+        return result
+    }
 }


### PR DESCRIPTION
## Description
Eliminate the need to use a switch statement to gain access to the information in the ParsedBody enum.

## Motivation and Context
Consumability of Kitura.

## How Has This Been Tested?
Some of Kitura's tests have been modified to use the new APIs.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
