### PR TITLE
IBM-Swift/Kitura#836 Switch out deprecated server.listen calls and re…

### DIFF
--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -71,11 +71,19 @@ public class Kitura {
         Log.verbose("Starting Kitura framework...")
         for (server, port) in httpServersAndPorts {
             Log.verbose("Starting an HTTP Server on port \(port)...")
-            server.listen(port: port)
+            do {
+                try server.listen(on: port)
+            } catch {
+                Log.error("Error listening on port \(port). Use server.failed(callback:) to handle")
+            }
         }
         for (server, port) in fastCGIServersAndPorts {
             Log.verbose("Starting a FastCGI Server on port \(port)...")
-            server.listen(port: port)
+            do {
+                try server.listen(on: port)
+            } catch {
+                Log.error("Error listening on port \(port). Use server.failed(callback:) to handle")
+            }
         }
         ListenerGroup.waitForListeners()
     }
@@ -86,11 +94,19 @@ public class Kitura {
     public class func start() {
         for (server, port) in httpServersAndPorts {
             Log.verbose("Starting an HTTP Server on port \(port)...")
-            server.listen(port: port)
+            do {
+                try server.listen(on: port)
+            } catch {
+                Log.error("Error listening on port \(port). Use server.failed(callback:) to handle")
+            }
         }
         for (server, port) in fastCGIServersAndPorts {
             Log.verbose("Starting a FastCGI Server on port \(port)...")
-            server.listen(port: port)
+            do {
+                try server.listen(on: port)
+            } catch {
+                Log.error("Error listening on port \(port). Use server.failed(callback:) to handle")
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Switch out deprecated server.listen calls handling errors as needed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

…move now redundant sleep calls