### PR TITLE
Modified MultiPartBodyParser so that it reads a filename if present

### DIFF
--- a/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
+++ b/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
@@ -107,6 +107,11 @@ class MultiPartBodyParser: BodyParserProtocol {
                 let valueEndIndex = line.range(of: "\"", range: valueStartIndex..<line.endIndex)
                 part.name = line.substring(with: valueStartIndex..<(valueEndIndex?.lowerBound ?? line.endIndex))
             }
+            if let filenameRange = line.range(of: "filename=", options: caseInsensitiveSearch, range: labelRange.upperBound..<line.endIndex) {
+                let valueStartIndex = line.index(after: filenameRange.upperBound)
+                let valueEndIndex = line.range(of: "\"", range: valueStartIndex..<line.endIndex)
+                part.filename = line.substring(with: valueStartIndex..<(valueEndIndex?.lowerBound ?? line.endIndex))
+            }
             part.headers[.disposition] = line
             return
         }

--- a/Sources/Kitura/bodyParser/Part.swift
+++ b/Sources/Kitura/bodyParser/Part.swift
@@ -23,6 +23,9 @@ public struct Part {
     
     /// The name attribute of the part.
     public internal(set) var name = ""
+
+    /// The filename attribute of the part.
+    public internal(set) var filename = ""
     
     /// Content type of the data in the part.
     public internal(set) var type = "text/plain"

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -227,7 +227,7 @@ class TestResponse: XCTestCase {
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
                     let body = try response!.readString()
-                    XCTAssertEqual(body!, "text text(\"text default\") file1 text(\"Content of a.txt.\") file2 text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
+                    XCTAssertEqual(body!, "text  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -254,7 +254,7 @@ class TestResponse: XCTestCase {
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
                     let body = try response!.readString()
-                    XCTAssertEqual(body!, " text(\"text default\") file1 text(\"Content of a.txt.\") file2 text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
+                    XCTAssertEqual(body!, "  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -284,7 +284,7 @@ class TestResponse: XCTestCase {
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
                     let body = try response!.readString()
-                    XCTAssertEqual(body!, " text(\"text default\") ")
+                    XCTAssertEqual(body!, "  text(\"text default\") ")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -887,7 +887,7 @@ class TestResponse: XCTestCase {
                 return
             }
             for part in parts {
-                response.send("\(part.name) \(part.body) ")
+                response.send("\(part.name) \(part.filename) \(part.body) ")
             }
             
             next()


### PR DESCRIPTION
This modifies `MultiPartBodyParser` so that the `filename` section of `Content-Disposition` is read and stored correctly, if present.

## Description
I've duplicated the existing `MultiPartBodyParser` code to parse `name`, and created a new `filename` property in `Part` also based on `name`. I've also modified the multi-part tests to check filename is parsed correctly.

## Motivation and Context
Content-Disposition can optionally include a `filename` field ([more info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)), but this was being ignored by `MultiPartBodyParser`. This change reads and stores `filename` if it's present.

## How Has This Been Tested?
`swift test` passes with no errors. I've modified `testMultipartFormParsing()` to ensure `filename` is being parsed correctly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
