### PR TITLE
Adjusted send(json:) to log a warning if conversion fails.

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -203,7 +203,9 @@ public class RouterResponse {
             headers.setType("json")
             send(data: jsonData)
         }
-        catch { } // Do nothing if the JSON to Data fails
+        catch {
+            Log.warning("Failed to convert JSON for sending: \(error.localizedDescription)")
+        }
             
         return self
     }


### PR DESCRIPTION
The `send(json:)` method of `RouterResponse` attempts to convert a SwiftyJSON object into a `Data` object using `rawData(options:.prettyPrinted)`. This is a throwing method, but in the current code nothing happens if an error is thrown. This patch calls `Log.warning()` to write a message to the logger, if there is one. Given that the user is attempting to send data and it's failing, `warning` seems like an appropriate log level.

## Description
I've added one line of code to `send(json:)` that logs the following string at "warning" level: `"Failed to convert JSON for sending: \(error.localizedDescription)"`.

## Motivation and Context
I lost 30 minutes of my evening because send(json:) was silently failing. It may be worth considering whether `send(json:)` should itself be a throwing method, but in the meantime adding a warning should help others who hit the same problem.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)

