### PR TITLE
Attempt to fix #879: Once we've called the lifecycle methods, clear t…

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -120,6 +120,9 @@ public class RouterResponse {
             try response.write(from: content)
         }
         state.invokedEnd = true
+        
+        //Now that we've called the lifecycle methods, clear them to avoid retain cycles
+        self.lifecycle = Lifecycle()
         try response.end()
     }
 


### PR DESCRIPTION
I don't know that this is the way we want to go, but this dramatically helps https://github.com/IBM-Swift/Kitura/issues/879 on my machine.

`swift test` passes for me (at least on Darwin).  I'm expecting that creating a Pull Request will kick off a Travis build to test it on Linux, too.