### PR TITLE
Add call site line number to XCTestExpectation description and…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       dist: trusty
       sudo: required
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.1
       sudo: required
 
 before_install:

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -23,7 +23,7 @@ import Foundation
 import Dispatch
 
 protocol KituraTest {
-    func expectation(_ index: Int) -> XCTestExpectation
+    func expectation(line: Int, index: Int) -> XCTestExpectation
     func waitExpectation(timeout t: TimeInterval, handler: XCWaitCompletionHandler?)
 }
 
@@ -34,27 +34,37 @@ extension KituraTest {
     }
 
     func doTearDown() {
-        // sleep(10)
     }
 
-    func performServerTest(_ router: ServerDelegate,
+    func performServerTest(_ router: ServerDelegate, line: Int = #line,
                            asyncTasks: @escaping (XCTestExpectation) -> Void...) {
-        Kitura.addHTTPServer(onPort: 8090, with: router)
+        let port = 8090
+        let server = Kitura.addHTTPServer(onPort: port, with: router)
+        defer {
+            Kitura.stop() // make sure to remove server from Kitura static list
+        }
+
+        var failed = false
+        server.failed { error in
+            failed = true
+            XCTFail("Error starting server on port \(port): \(error)")
+        }
+
         Kitura.start()
 
         let requestQueue = DispatchQueue(label: "Request queue")
-
-        for (index, asyncTask) in asyncTasks.enumerated() {
-            let expectation = self.expectation(index)
-            requestQueue.async() {
-                asyncTask(expectation)
+        if !failed {
+            for (index, asyncTask) in asyncTasks.enumerated() {
+                let expectation = self.expectation(line: line, index: index)
+                requestQueue.async() {
+                    asyncTask(expectation)
+                }
             }
-        }
 
-        waitExpectation(timeout: 10) { error in
-                // blocks test until request completes
-                Kitura.stop()
+            waitExpectation(timeout: 10) { error in
+                // wait for timeout or for all created expectations to be fulfilled
                 XCTAssertNil(error)
+            }
         }
     }
 
@@ -79,9 +89,8 @@ extension KituraTest {
 }
 
 extension XCTestCase: KituraTest {
-    func expectation(_ index: Int) -> XCTestExpectation {
-        let expectationDescription = "\(type(of: self))-\(index)"
-        return self.expectation(description: expectationDescription)
+    func expectation(line: Int, index: Int) -> XCTestExpectation {
+        return self.expectation(description: "\(type(of: self)):\(line)[\(index)]")
     }
 
     func waitExpectation(timeout t: TimeInterval, handler: XCWaitCompletionHandler?) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add call site line number to XCTestExpectation description
- Skip tests if server start fails
- Change osx image for travis to 8.1

## Motivation and Context
When a test makes several calls to performServerTest and one or more expectations timeout, it can be impossible to tell which one failed. By combining the line number of the code that calls performServerTest along with the async task index, we should always be able to narrow the failure to a specific task.

If the server start fails, there is no point in creating and waiting for expectations that will never be fulfilled, so fail right away with the server error.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.