### PR TITLE
Deprecate urlComponents because of memory leak and compute it when needed

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -231,7 +231,11 @@ extension Router : RouterMiddleware {
     /// - Parameter next: The closure to invoke to cause the router to inspect the
     ///                  path in the list of paths.
     public func handle(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
-        let urlPath = request.urlComponents.percentEncodedPath
+        guard let urlPath = request.parsedURL.path else {
+            Log.error("request.parsedURL.path is nil. Failed to handle request")
+            return
+        }
+
         if request.allowPartialMatch {
             let mountpath = request.matchedPath
 
@@ -245,11 +249,11 @@ extension Router : RouterMiddleware {
 
             let index = urlPath.index(urlPath.startIndex, offsetBy: mountpath.characters.count)
 
-            request.urlComponents.percentEncodedPath = urlPath.substring(from: index)
+            request.parsedURL.path = urlPath.substring(from: index)
         }
 
         process(request: request, response: response) {
-            request.urlComponents.percentEncodedPath = urlPath
+            request.parsedURL.path = urlPath
             next()
         }
     }
@@ -292,7 +296,10 @@ extension Router : ServerDelegate {
     /// - Parameter callback: The closure to invoke to cause the router to inspect the
     ///                  path in the list of paths.
     fileprivate func process(request: RouterRequest, response: RouterResponse, callback: @escaping () -> Void) {
-        let urlPath = request.urlComponents.percentEncodedPath
+        guard let urlPath = request.parsedURL.path else {
+            Log.error("request.parsedURL.path is nil. Failed to process request")
+            return
+        }
 
         if  urlPath.hasPrefix(kituraResourcePrefix) {
             let resource = urlPath.substring(from: kituraResourcePrefix.endIndex)
@@ -316,11 +323,11 @@ extension Router : ServerDelegate {
     /// - Parameter response: The `RouterResponse` object used to send responses
     ///                      to the HTTP request.
     private func sendDefaultResponse(request: RouterRequest, response: RouterResponse) {
-        if request.urlComponents.percentEncodedPath == "/" {
+        if request.parsedURL.path == "/" {
             fileResourceServer.sendIfFound(resource: "index.html", usingResponse: response)
         } else {
             do {
-                let errorMessage = "Cannot \(request.method) \(request.urlComponents.percentEncodedPath)."
+                let errorMessage = "Cannot \(request.method) \(request.parsedURL.path ?? "")."
                 try response.status(.notFound).send(errorMessage).end()
             } catch {
                 Log.error("Error sending default not found message: \(error)")

--- a/Sources/Kitura/RouterElement.swift
+++ b/Sources/Kitura/RouterElement.swift
@@ -86,7 +86,10 @@ class RouterElement {
     /// - Parameter response: the response
     /// - Parameter next: the callback
     func process(request: RouterRequest, response: RouterResponse, parameterWalker: RouterParameterWalker, next: @escaping () -> Void) {
-        let path = request.urlComponents.percentEncodedPath
+        guard let path = request.parsedURL.path else {
+            Log.error("Failed to process request (path is nil)")
+            return
+        }
 
         guard (response.error != nil && method == .error)
             || (response.error == nil && (method == request.method || method == .all)) else {

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -102,14 +102,12 @@ public class RouterRequest {
 
     /// The URL.
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" for the full URL
+    /// Use "urlURL" or "urlComponents" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
     public var url : String { return serverRequest.urlString }
 
     /// The URL from the request as URLComponents
-    @available(*, deprecated, message:
-        "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
     public var urlComponents: URLComponents { return serverRequest.urlComponents }
 
     /// The URL from the request

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -102,12 +102,15 @@ public class RouterRequest {
 
     /// The URL.
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlURL" or "urlComponents" for the full URL
+    /// Use 'urlURL' for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlURL' or 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var url : String { return serverRequest.urlString }
 
     /// The URL from the request as URLComponents
+    /// URLComponents has a memory leak on linux as of swift 3.0.1. Use 'urlURL' instead
+    @available(*, deprecated, message:
+        "URLComponents has a memory leak on linux as of swift 3.0.1. use 'urlURL' instead")
     public var urlComponents: URLComponents { return serverRequest.urlComponents }
 
     /// The URL from the request

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -30,12 +30,12 @@ public class RouterRequest {
 
     /// The hostname of the request.
     public var hostname: String {
-        return urlComponents.host ?? ""
+        return urlURL.host ?? ""
     }
 
     ///The port of the request.
     public var port: Int {
-        return urlComponents.port ?? (urlComponents.scheme == "https" ? 443 : 80)
+        return urlURL.port ?? (urlURL.scheme == "https" ? 443 : 80)
     }
 
     /// The domain name of the request.
@@ -84,15 +84,7 @@ public class RouterRequest {
     public let method: RouterMethod
 
     /// The parsed URL.
-    @available(*, deprecated, message: "use 'urlComponents' instead")
-    public var parsedURL: URLParser {
-        var path = urlComponents.percentEncodedPath
-        if let query = urlComponents.percentEncodedQuery {
-            path += "?" + query
-        }
-        let pathData = path.data(using: .utf8) ?? Data()
-        return URLParser(url: pathData, isConnect: false)
-    }
+    public let parsedURL: URLParser
 
     /// The router as a String.
     public internal(set) var route: String?
@@ -106,17 +98,22 @@ public class RouterRequest {
     var allowPartialMatch = true
 
     /// The original URL as a string.
-    public var originalURL : String { return serverRequest.urlComponents.string ?? "" }
+    public var originalURL : String { return serverRequest.urlURL.absoluteString }
 
     /// The URL.
     /// This contains just the path and query parameters starting with '/'
-    /// Use "urlComponents" for the full URL
+    /// Use "urlURL" for the full URL
     @available(*, deprecated, message:
-        "This contains just the path and query parameters starting with '/'. use 'urlComponents' instead")
+        "This contains just the path and query parameters starting with '/'. use 'urlURL' instead")
     public var url : String { return serverRequest.urlString }
 
     /// The URL from the request as URLComponents
-    public internal(set) var urlComponents = URLComponents()
+    @available(*, deprecated, message:
+        "URLComponents has a memory leak as of swift 3.0.1. use 'urlURL' instead")
+    public var urlComponents: URLComponents { return serverRequest.urlComponents }
+
+    /// The URL from the request
+    public var urlURL : URL { return serverRequest.urlURL }
 
     /// List of HTTP headers with simple String values.
     public let headers: Headers
@@ -140,7 +137,7 @@ public class RouterRequest {
     /// List of query parameters.
     public lazy var queryParameters: [String:String] = { [unowned self] in
         var decodedParameters: [String:String] = [:]
-        if let query = self.urlComponents.percentEncodedQuery {
+        if let query = self.urlURL.query {
             for item in query.components(separatedBy: "&") {
                 if let range = item.range(of: "=") {
                     let key = item.substring(to: range.lowerBound)
@@ -173,7 +170,7 @@ public class RouterRequest {
     /// - Parameter request: the server request
     init(request: ServerRequest) {
         serverRequest = request
-        urlComponents = serverRequest.urlComponents
+        parsedURL = URLParser(url: request.urlURL.absoluteString.data(using: .utf8)!, isConnect: false)
         httpVersion = HTTPVersion(major: serverRequest.httpVersionMajor ?? 1, minor: serverRequest.httpVersionMinor ?? 1)
         method = RouterMethod(fromRawValue: serverRequest.method)
         headers = Headers(headers: serverRequest.headers)

--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -49,7 +49,9 @@ extension StaticFileServer {
 
         func getFilePath(from request: RouterRequest) -> String? {
             var filePath = servingFilesPath
-            let requestPath = request.urlComponents.percentEncodedPath
+            guard let requestPath = request.parsedURL.path else {
+                return nil
+            }
             var matchedPath = request.matchedPath
             if matchedPath.hasSuffix("*") {
                 matchedPath = String(matchedPath.characters.dropLast())

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -110,7 +110,9 @@ public class StaticFileServer: RouterMiddleware {
             return next()
         }
 
-        let requestPath = request.urlComponents.percentEncodedPath
+        guard let requestPath = request.parsedURL.path else {
+            return next()
+        }
 
         fileServer.serveFile(filePath, requestPath: requestPath, response: response)
         next()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Deprecate urlComponents because of memory leak and compute it when needed
- Use urlURL instead

Depends on IBM-Swift/Kitura-net#153

## Motivation and Context
See IBM-Swift/Kitura#901

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

…a memory leak