### PR TITLE
Eliminate potential reference loops within RouterResponse lifecycle functions

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -34,10 +34,10 @@ public class RouterResponse {
         var invokedSend = false
     }
 
-    /// A set of functions called durin the life cycle of a Request.
+    /// A set of functions called during the life cycle of a Request.
     /// As The life cycle functions/closures may capture various things including the
-    /// response object in question, each life cycle functions needs a reset function
-    /// to clear out any cycles.
+    /// response object in question, each life cycle function needs a reset function
+    /// to clear out any reference cycles that may have occurred.
     struct Lifecycle {
 
         /// Lifecycle hook called on end()

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -34,6 +34,10 @@ public class RouterResponse {
         var invokedSend = false
     }
 
+    /// A set of functions called durin the life cycle of a Request.
+    /// As The life cycle functions/closures may capture various things including the
+    /// response object in question, each life cycle functions needs a reset function
+    /// to clear out any cycles.
     struct Lifecycle {
 
         /// Lifecycle hook called on end()
@@ -42,6 +46,16 @@ public class RouterResponse {
         /// Current pre-write lifecycle handler
         var writtenDataFilter: WrittenDataFilter = { body in
             return body
+        }
+        
+        mutating func resetOnEndInvoked() {
+            onEndInvoked = {}
+        }
+        
+        mutating func resetWrittenDataFilter() {
+            writtenDataFilter = { body in
+                return body
+            }
         }
     }
 
@@ -103,6 +117,7 @@ public class RouterResponse {
     @discardableResult
     public func end() throws {
         lifecycle.onEndInvoked()
+        lifecycle.resetOnEndInvoked()
 
         // Sets status code if unset
         if statusCode == .unknown {
@@ -110,6 +125,8 @@ public class RouterResponse {
         }
 
         let content = lifecycle.writtenDataFilter(buffer.data)
+        lifecycle.resetWrittenDataFilter()
+        
         let contentLength = headers["Content-Length"]
         if  contentLength == nil {
             headers["Content-Length"] = String(content.count)


### PR DESCRIPTION
## Description
Kitura provides in RouterResponse life cycle hooks, i.e. places where functions/closures can be invoked during the life cycle of the request. In some cases the closures used to implement these hooks cause object reference loops. This in turn causes memory leaks. 

This PR provides a set of functions to reset the life cycle functions each back to their initial value, a no-op function. This breaks the reference loop and fixes the memory leak.

## Motivation and Context
Fix issue IBM-Swift/Kitura#879

## How Has This Been Tested?
@djones6 Ran memory leak tests and verified the leaks went away.
I also ran the Kitura unit tests on both macOS and Linux.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
