### PR TITLE
Break request/response retain cycle. Intended to help #879

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -268,11 +268,23 @@ extension Router : ServerDelegate {
         let routeReq = RouterRequest(request: request)
         let routeResp = RouterResponse(response: response, router: self, request: routeReq)
 
-        process(request: routeReq, response: routeResp) { [unowned self] () in
+        process(request: routeReq, response: routeResp) { [weak self, weak routeReq, weak routeResp] () in
+            guard let strongSelf = self else {
+                Log.error("Found nil self at #file #line")
+                return
+            }
+            guard let routeReq = routeReq else {
+                Log.error("Found nil routeReq at #file #line")
+                return
+            }
+            guard let routeResp = routeResp else {
+                Log.error("Found nil routeResp at #file #line")
+                return
+            }
             do {
                 if  !routeResp.state.invokedEnd {
                     if  routeResp.statusCode == .unknown  && !routeResp.state.invokedSend {
-                        self.sendDefaultResponse(request: routeReq, response: routeResp)
+                        strongSelf.sendDefaultResponse(request: routeReq, response: routeResp)
                     }
                     try routeResp.end()
                 }

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -270,15 +270,15 @@ extension Router : ServerDelegate {
 
         process(request: routeReq, response: routeResp) { [weak self, weak routeReq, weak routeResp] () in
             guard let strongSelf = self else {
-                Log.error("Found nil self at #file #line")
+                Log.error("Found nil self at \(#file) \(#line)")
                 return
             }
             guard let routeReq = routeReq else {
-                Log.error("Found nil routeReq at #file #line")
+                Log.error("Found nil routeReq at \(#file) \(#line)")
                 return
             }
             guard let routeResp = routeResp else {
-                Log.error("Found nil routeResp at #file #line")
+                Log.error("Found nil routeResp at \(#file) \(#line)")
                 return
             }
             do {


### PR DESCRIPTION
Break strong retain cycles in the process() method

## Description
Code should be pretty self explanatory.
Graph changes below generated with this fix and https://github.com/IBM-Swift/Kitura-Compression/pull/26 and https://github.com/IBM-Swift/Kitura-Session/pull/29

## Motivation and Context
See leak graph posted in #879 

## How Has This Been Tested?
Test suite still passes.  In running on instruments, I get fewer leaks in "Cycles and Roots".

Before: 
![screen shot 2016-12-09 at 10 51 21 am](https://cloud.githubusercontent.com/assets/67206/21057003/79bf560e-bdfd-11e6-9c3c-8ac804543413.png)

After:
![screen shot 2016-12-09 at 10 51 06 am](https://cloud.githubusercontent.com/assets/67206/21057009/7f0a6db0-bdfd-11e6-9f71-1401ca891fc9.png)
