### PR TITLE
Added RawBodyParser for BodyParser default parsing method (#908).

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -95,8 +95,9 @@ public class BodyParser: RouterMiddleware {
                 boundary = boundary.substring(to: parameterStart.lowerBound)
             }
             return MultiPartBodyParser(boundary: boundary)
+        } else { //Default: parse body as `.raw(Data)`
+            return RawBodyParser()
         }
-        return nil
     }
 
     /// Read incoming message for Parse

--- a/Sources/Kitura/bodyParser/RawBodyParser.swift
+++ b/Sources/Kitura/bodyParser/RawBodyParser.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+class RawBodyParser: BodyParserProtocol {
+    func parse(_ data: Data) -> ParsedBody? {
+        return ParsedBody.raw(data)
+    }
+}

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -320,7 +320,40 @@ class TestResponse: XCTestCase {
                 req.write(from: "This does not contain any valid boundary")
             }
         }
-
+        
+    }
+    
+    func testRawDataPost() {
+        performServerTest(router) { expectation in
+            self.performRequest("post",
+                                path: "/bodytest",
+                                callback: {
+                                    (response) in
+                                    guard let response = response else {
+                                        XCTFail("Client response was nil on raw data post.")
+                                        expectation.fulfill()
+                                        return
+                                    }
+                                    
+                                    XCTAssertNotNil(response.headers["Date"], "There was No Date header in the response")
+                                    do {
+                                        let responseString = try response.readString()
+                                        XCTAssertEqual("length: 2048", responseString)
+                                    }
+                                    catch {
+                                        XCTFail("Failed posting raw data")
+                                    }
+                                    expectation.fulfill()
+            },
+                                headers: ["Content-Type": "application/octet-stream"],
+                                requestModifier: {
+                                    (request) in
+                                    let length = 2048
+                                    let bytes = [UInt32](repeating: 0, count: length).map { _ in 0 }
+                                    let randomData = Data(bytes: bytes, count: length)
+                                    request.write(from: randomData)
+            })
+        }
     }
 
     private func runTestParameters(pathParameter: String, queryParameter: String,
@@ -906,7 +939,13 @@ class TestResponse: XCTestCase {
                 } catch {
                     XCTFail("caught error: \(error)")
                 }
-            } else {
+            } else if case let .raw(data) = requestBody {
+                XCTAssertNotNil(data)
+                let length = "2048"
+                _ = response.send("length: \(length)")
+                next()
+            }
+            else {
                 response.error = Error.failedToParseRequestBody(body: "\(request.body)")
             }
 


### PR DESCRIPTION
`BodyParser` should default a `ParsedBody.raw(Data)` when the `Content-Type` isn't known.

## Description
`BodyParser` has a [`parserMap`](https://github.com/IBM-Swift/Kitura/blob/master/Sources/Kitura/bodyParser/BodyParser.swift#L31-L34) which designates that text-based `Content-Type`s correspond to a specialized parser (e.g., `application/json` -> `JSONBodyParser`).

If the `Content-Type` was not any of those types, it would fall-through and `nil` out the data from the `RouterRequest` instead of storing the raw data in [`.raw(Data)`](https://github.com/IBM-Swift/Kitura/blob/master/Sources/Kitura/bodyParser/ParsedBody.swift#L42) on `ParsedBody`.

I fixed this by following pattern and creating `RawBodyParser` which just slots the data into `.raw(Data)`. `BodyParser` now defaults to passing the RouterRequest body into `RawBodyParser`.

## Motivation and Context
This is in response to [Issue 908](https://github.com/IBM-Swift/Kitura/issues/908). While exploring @rfdickerson's [Kitura Protobuf Sample](https://github.com/IBM-Swift/Kitura-Protobuf-Sample), I notice that `POST`ing did not work when sending a protobuf file. The `RouterRequest`'s body was `nil` not `application/json`. @rfdickerson [assumed](https://github.com/IBM-Swift/Kitura-Protobuf-Sample/commit/0475ab18045593e9d5a0b9fff511ce4c5adf2f8d#diff-c59d9b61114ad3468cfbb3a6a44fa297L59), as I would have, that the body could have been accessed using `.raw(Data)` on the `ParsedBody`. This was not the case.


## How Has This Been Tested?

I wrote a unit test that tests whether raw data being sent passes through the `router` properly and can be accessed using `.raw(Data)`.

I only ran tests locally on Mac OS X since I do not have access to a Linux environment immediately.

This would only have impact on existing code if the end user _knew_ that `BodyParser` would `nil` out the body and wrote against that scenario.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
