### PR TITLE
Issue 942: Lazy parsedURL for better performance

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -231,8 +231,8 @@ extension Router : RouterMiddleware {
     /// - Parameter next: The closure to invoke to cause the router to inspect the
     ///                  path in the list of paths.
     public func handle(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
-        guard let urlPath = request.parsedURL.path else {
-            Log.error("request.parsedURL.path is nil. Failed to handle request")
+        guard let urlPath = request.parsedURLPath.path else {
+            Log.error("request.parsedURLPath.path is nil. Failed to handle request")
             return
         }
 
@@ -249,11 +249,11 @@ extension Router : RouterMiddleware {
 
             let index = urlPath.index(urlPath.startIndex, offsetBy: mountpath.characters.count)
 
-            request.parsedURL.path = urlPath.substring(from: index)
+            request.parsedURLPath.path = urlPath.substring(from: index)
         }
 
         process(request: request, response: response) {
-            request.parsedURL.path = urlPath
+            request.parsedURLPath.path = urlPath
             next()
         }
     }
@@ -308,8 +308,8 @@ extension Router : ServerDelegate {
     /// - Parameter callback: The closure to invoke to cause the router to inspect the
     ///                  path in the list of paths.
     fileprivate func process(request: RouterRequest, response: RouterResponse, callback: @escaping () -> Void) {
-        guard let urlPath = request.parsedURL.path else {
-            Log.error("request.parsedURL.path is nil. Failed to process request")
+        guard let urlPath = request.parsedURLPath.path else {
+            Log.error("request.parsedURLPath.path is nil. Failed to process request")
             return
         }
 
@@ -335,11 +335,11 @@ extension Router : ServerDelegate {
     /// - Parameter response: The `RouterResponse` object used to send responses
     ///                      to the HTTP request.
     private func sendDefaultResponse(request: RouterRequest, response: RouterResponse) {
-        if request.parsedURL.path == "/" {
+        if request.parsedURLPath.path == "/" {
             fileResourceServer.sendIfFound(resource: "index.html", usingResponse: response)
         } else {
             do {
-                let errorMessage = "Cannot \(request.method) \(request.parsedURL.path ?? "")."
+                let errorMessage = "Cannot \(request.method) \(request.parsedURLPath.path ?? "")."
                 try response.status(.notFound).send(errorMessage).end()
             } catch {
                 Log.error("Error sending default not found message: \(error)")

--- a/Sources/Kitura/RouterElement.swift
+++ b/Sources/Kitura/RouterElement.swift
@@ -86,7 +86,7 @@ class RouterElement {
     /// - Parameter response: the response
     /// - Parameter next: the callback
     func process(request: RouterRequest, response: RouterResponse, parameterWalker: RouterParameterWalker, next: @escaping () -> Void) {
-        guard let path = request.parsedURL.path else {
+        guard let path = request.parsedURLPath.path else {
             Log.error("Failed to process request (path is nil)")
             return
         }

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -162,7 +162,7 @@ public class RouterRequest {
     /// - Parameter request: the server request
     init(request: ServerRequest) {
         serverRequest = request
-        parsedURL = URLParser(url: request.urlURL.absoluteString.data(using: .utf8)!, isConnect: false)
+        parsedURL = URLParser(url: request.url, isConnect: false)
         httpVersion = HTTPVersion(major: serverRequest.httpVersionMajor ?? 1, minor: serverRequest.httpVersionMinor ?? 1)
         method = RouterMethod(fromRawValue: serverRequest.method)
         headers = Headers(headers: serverRequest.headers)

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -79,8 +79,19 @@ public class RouterRequest {
     /// The method of the request.
     public let method: RouterMethod
 
+    private var _parsedURL: URLParser?
+    internal let parsedURLPath: URLParser
+
     /// The parsed URL.
-    public let parsedURL: URLParser
+    public private(set) lazy var parsedURL: URLParser = { [unowned self] in
+        if let result = self._parsedURL {
+            return result
+        } else {
+            let result = URLParser(url: self.serverRequest.urlURL.absoluteString.data(using: .utf8)!, isConnect: false)
+            self._parsedURL = result
+            return result
+        }
+    }()
 
     /// The router as a String.
     public internal(set) var route: String?
@@ -162,7 +173,7 @@ public class RouterRequest {
     /// - Parameter request: the server request
     init(request: ServerRequest) {
         serverRequest = request
-        parsedURL = URLParser(url: request.url, isConnect: false)
+        parsedURLPath = URLParser(url: request.url, isConnect: false)
         httpVersion = HTTPVersion(major: serverRequest.httpVersionMajor ?? 1, minor: serverRequest.httpVersionMinor ?? 1)
         method = RouterMethod(fromRawValue: serverRequest.method)
         headers = Headers(headers: serverRequest.headers)

--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -49,7 +49,7 @@ extension StaticFileServer {
 
         func getFilePath(from request: RouterRequest) -> String? {
             var filePath = servingFilesPath
-            guard let requestPath = request.parsedURL.path else {
+            guard let requestPath = request.parsedURLPath.path else {
                 return nil
             }
             var matchedPath = request.matchedPath

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -110,7 +110,7 @@ public class StaticFileServer: RouterMiddleware {
             return next()
         }
 
-        guard let requestPath = request.parsedURL.path else {
+        guard let requestPath = request.parsedURLPath.path else {
             return next()
         }
 


### PR DESCRIPTION
## Description
Lazily construct the `parsedURL` in `RouterRequest`, to avoid the performance penalty of constructing a `URL` in Kitura-Net until we need it (such as retrieving the full URL of a request, or the query params).

For simple cases such as loading static content, we can skip this cost altogether.

A more comprehensive solution would be to avoid the cost of construction for accessing the query params, however since the long-term solution is to use `URLComponents`, this change is sufficient to solve the regression for the most frequent cases without requiring more changes to the public API.

## Motivation and Context
Part of the solution to #942 (the other part is a change to IBM-Swift/Kitura-net, which makes the construction of the `URL` in `HTTPIncomingMessage` lazy).

## How Has This Been Tested?
I ran the Kitura tests on Linux and they passed.  I ran local performance tests to establish that performance recovers to the level we had at Kitura 1.2.0 (as long as query parameters are not accessed).