### PR TITLE
Remove dummy content type handling code on Linux

### DIFF
--- a/Sources/Kitura/contentType/ContentType.swift
+++ b/Sources/Kitura/contentType/ContentType.swift
@@ -23,13 +23,6 @@ import LoggerAPI
 /// or to determine if it's an acceptable value.
 public class ContentType {
 
-    /// Whether to use the local mime-type definitions or the ones in the file
-    #if os(Linux)
-        private let mimeTypeEmbedded: Bool = true
-    #else
-        private let mimeTypeEmbedded: Bool = false
-    #endif
-
     /// A dictionary of extensions to MIME type descriptions
     private var extToContentType = [String:String]()
 
@@ -38,20 +31,6 @@ public class ContentType {
 
     /// The following function loads the MIME types from an external file
     private init () {
-        // MARK: Remove this when Linux reading of JSON files works.
-        if mimeTypeEmbedded {
-
-            Log.warning("Loading embedded MIME types.")
-
-            for (contentType, exts) in rawTypes {
-                for ext in exts {
-                    extToContentType[ext] = contentType
-                }
-            }
-
-            return
-        }
-
         let contentTypesData = contentTypesString.data(using: .utf8)
         guard contentTypesData != nil else {
             Log.error("Error parsing \(contentTypesString)")
@@ -168,29 +147,5 @@ public class ContentType {
             return type
         }
     }
-
-    /// The raw types
-    /// *Note*: This will be removed once JSON parsing and the types.json file can be read.
-    private var rawTypes = [
-        "text/plain": ["txt", "text", "conf", "def", "list", "log", "in", "ini"],
-        "text/html": ["html", "htm"],
-        "text/css": ["css"],
-        "text/csv": ["csv"],
-        "text/xml": [],
-        "text/javascript": [],
-        "text/markdown": [],
-        "text/x-markdown": ["markdown", "md", "mkd"],
-
-        "application/json": ["json", "map"],
-        "application/x-www-form-urlencoded": [],
-        "application/xml": ["xml", "xsl", "xsd"],
-        "application/javascript": ["js"],
-
-        "image/bmp": ["bmp"],
-        "image/png": ["png"],
-        "image/gif": ["gif"],
-        "image/jpeg": ["jpeg", "jpg", "jpe"],
-        "image/svg+xml": ["svg", "svgz"]
-    ]
 
 }


### PR DESCRIPTION
## Description
Now that we can parse the entire content-type list onLinux, we shouldn't use the dummy list

## Motivation and Context
Eliminate platform specific code where possible

## How Has This Been Tested?
Ran Kitura unit tests on both macOS and Linux.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
