### PR TITLE
IBM-Swift/Kitura#951 Remove regex for matching accept headers, fix wrong specs ...

### DIFF
--- a/Sources/Kitura/MimeTypeAcceptor.swift
+++ b/Sources/Kitura/MimeTypeAcceptor.swift
@@ -62,9 +62,10 @@ extension RouterRequest {
         ///
         /// - Parameter headerValues: Array of Accept header values.
         /// - Parameter types: Array of content/mime type strings.
+        /// - Parameter wildcard: Special value that matches any value. For example "*" or "*/*"
         /// - Returns: Most acceptable type or nil if there are none
-        static func accepts(headerValues: [String], types: [String]) -> String? {
-            let criteriaMatches = getCriteriaMatches(headerValues: headerValues, types: types)
+        static func accepts(headerValues: [String], types: [String], wildcard: String) -> String? {
+            let criteriaMatches = getCriteriaMatches(headerValues: headerValues, types: types, wildcard: wildcard)
 
             // sort by priority and by qValue to determine best type to return
             let sortedMatches = Array(criteriaMatches).sorted {
@@ -83,51 +84,58 @@ extension RouterRequest {
 
         private typealias CriteriaMatches = [String : (priority: Int, qValue: Double)]
 
-        private static func getCriteriaMatches(headerValues: [String], types: [String]) -> CriteriaMatches {
+        private static func getCriteriaMatches(headerValues: [String], types: [String], wildcard: String) -> CriteriaMatches {
             var criteriaMatches = [String : (priority: Int, qValue: Double)]()
 
             for rawHeaderValue in headerValues {
                 for type in types {
-                    handleMatch(rawHeaderValue: rawHeaderValue, type: type,
+                    handleMatch(rawHeaderValue: rawHeaderValue, type: type, wildcard: wildcard,
                                 criteriaMatches: &criteriaMatches)
                 }
             }
             return criteriaMatches
         }
 
-        private static func handleMatch(rawHeaderValue: String, type: String,
+        private static func handleMatch(rawHeaderValue: String, type: String, wildcard: String,
                                         criteriaMatches: inout CriteriaMatches) {
             let parsedHeaderValue = parse(mediaType: rawHeaderValue)
+            let headerType = parsedHeaderValue.type
+            guard !headerType.isEmpty && parsedHeaderValue.qValue > 0.0 else {
+                // quality value of 0 indicates not acceptable
+                return
+            }
+
             let mimeType = getMimeType(forExtension: type)
-            
+
             func setMatch(withPriority priority: Int, qValue: Double, in criteriaMatches: inout CriteriaMatches) {
                 criteriaMatches[type] = (priority: priority, qValue: qValue)
             }
 
-            if parsedHeaderValue.type == mimeType { // exact match, e.g. text/html == text/html
+            if headerType == mimeType { // exact match, e.g. text/html == text/html
                 setMatch(withPriority: 1, qValue: parsedHeaderValue.qValue, in: &criteriaMatches)
                 return
             }
 
-            if parsedHeaderValue.type == "*/*" {
+            if headerType == wildcard {
                 if criteriaMatches[type] == nil { // else do nothing
                     setMatch(withPriority: 3, qValue: parsedHeaderValue.qValue, in: &criteriaMatches)
                 }
                 return
             }
-            let regularExpressionSearch = String.CompareOptions.regularExpression
-            if nil == mimeType.range(of: parsedHeaderValue.type,
-                                     options: regularExpressionSearch) {
-                return
-            }
 
-            // partial match, e.g. text/html == text/*
-            if let match = criteriaMatches[type] {
-                if match.priority > 2 {
-                    setMatch(withPriority: 2, qValue: parsedHeaderValue.qValue, in: &criteriaMatches)
+            if headerType.hasSuffix("/*") {
+                let index = headerType.index(headerType.endIndex, offsetBy: -1)
+                let headerTypePrefix = headerType.substring(to: index) // strip the trailing *
+                if mimeType.hasPrefix(headerTypePrefix) {
+                    // partial match, e.g. text/html == text/*
+                    if let match = criteriaMatches[type] {
+                        if match.priority > 2 {
+                            setMatch(withPriority: 2, qValue: parsedHeaderValue.qValue, in: &criteriaMatches)
+                        }
+                    } else {
+                        setMatch(withPriority: 2, qValue: parsedHeaderValue.qValue, in: &criteriaMatches)
+                    }
                 }
-            } else {
-                setMatch(withPriority: 2, qValue: parsedHeaderValue.qValue, in: &criteriaMatches)
             }
         }
     }

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -208,7 +208,8 @@ public class RouterRequest {
         }
 
         let headerValues = acceptHeaderValue.characters.split(separator: ",").map(String.init)
-        return MimeTypeAcceptor.accepts(headerValues: headerValues, types: types)
+        let wildcard = (header == "Accept" ? "*/*" : "*")
+        return MimeTypeAcceptor.accepts(headerValues: headerValues, types: types, wildcard: wildcard)
     }
 
     /// Check if passed in types are acceptable based on the request's header field

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -208,8 +208,14 @@ public class RouterRequest {
         }
 
         let headerValues = acceptHeaderValue.characters.split(separator: ",").map(String.init)
-        let wildcard = (header == "Accept" ? "*/*" : "*")
-        return MimeTypeAcceptor.accepts(headerValues: headerValues, types: types, wildcard: wildcard)
+        // special header value that matches all types
+        let matchAllPattern: String
+        if header.caseInsensitiveCompare("Accept") == .orderedSame {
+            matchAllPattern = "*/*"
+        } else {
+            matchAllPattern = "*"
+        }
+        return MimeTypeAcceptor.accepts(headerValues: headerValues, types: types, matchAllPattern: matchAllPattern)
     }
 
     /// Check if passed in types are acceptable based on the request's header field

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -50,6 +50,7 @@ class TestResponse: XCTestCase {
             ("testHeaderModifiers", testHeaderModifiers),
             ("testRouteFunc", testRouteFunc),
             ("testAcceptTypes", testAcceptTypes),
+            ("testAcceptEncodingTypes", testAcceptEncodingTypes),
             ("testFormat", testFormat),
             ("testLink", testLink),
             ("testSubdomains", testSubdomains),
@@ -589,7 +590,57 @@ class TestResponse: XCTestCase {
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
             }) {req in
-                req.headers = ["Accept" : "application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain, */*;q=.7"]
+                req.headers = ["Accept" : "*/*;q=.1, application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain"]
+            }
+        })
+    }
+
+    func testAcceptEncodingTypes() {
+        router.get("/customPage") { request, response, next in
+            XCTAssertEqual(request.accepts(header: "Accept-Encoding", type: "gzip"), "gzip", "Accepts did not return expected value")
+            XCTAssertEqual(request.accepts(header: "Accept-Encoding", types: "compress"), "compress", "Accepts did not return expected value")
+            XCTAssertEqual(request.accepts(header: "Accept-Encoding", types: ["compress", "gzip"]), "gzip", "Accepts did not return expected value")
+
+            // should NOT match "*" here as q = 0
+            XCTAssertNil(request.accepts(header: "Accept-Encoding", types: "deflate"), "Request accepts this type when it shouldn't")
+
+            do {
+                try response.status(HTTPStatusCode.OK).send("<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n").end()
+            } catch {}
+            next()
+        }
+
+        router.get("/customPage2") { request, response, next in
+            XCTAssertEqual(request.accepts(header: "Accept-Encoding", type: "gzip"), "gzip", "Accepts did not return expected value")
+            XCTAssertEqual(request.accepts(header: "Accept-Encoding", types: "compress"), "compress", "Accepts did not return expected value")
+            //should match compress instead of gzip here as q value is greater
+            XCTAssertEqual(request.accepts(header: "Accept-Encoding", types: ["compress", "gzip"]), "compress", "Accepts did not return expected value")
+
+            // should match "*" here as q > 0
+            XCTAssertEqual(request.accepts(header: "Accept-Encoding", types: "deflate"), "deflate", "Accepts did not return expected value")
+
+            // should NOT match here as header is incorrect
+            XCTAssertNil(request.accepts(header: "Accept-Charset", types: "deflate"), "Request accepts this type when it shouldn't")
+
+            do {
+                try response.status(HTTPStatusCode.OK).send("<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n").end()
+            } catch {}
+            next()
+        }
+
+        performServerTest(router, asyncTasks: { expectation in
+            self.performRequest("get", path: "/customPage", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                expectation.fulfill()
+            }) {req in
+                req.headers = ["Accept-Encoding" : "compress;q=0.5, gzip;q=1.0, *;q=0"]
+            }
+        }, { expectation in
+            self.performRequest("get", path:"/customPage2", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                expectation.fulfill()
+            }) {req in
+                req.headers = ["Accept-Encoding" : "gzip;q=0.5, compress;q=1.0, *;q=0.1"]
             }
         })
     }

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -590,7 +590,7 @@ class TestResponse: XCTestCase {
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
             }) {req in
-                req.headers = ["Accept" : "*/*;q=.1, application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain"]
+                req.headers = ["accept" : "*/*;q=.001, application/*;q=0.2, image/jpeg;q=0.8, text/html, text/plain"]
             }
         })
     }
@@ -640,7 +640,7 @@ class TestResponse: XCTestCase {
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
             }) {req in
-                req.headers = ["Accept-Encoding" : "gzip;q=0.5, compress;q=1.0, *;q=0.1"]
+                req.headers = ["accept-encoding" : "gzip;q=0.5, compress;q=1.0, *;q=0.001"]
             }
         })
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Remove `String.range()` call with `.regularExpression` option for matching wildcard accept headers and replace with `hasPrefix()`
- fix multiple incorrect spec implementations
    - Wildcard to accept all types is `*/*` for `Accept` header and `*` for others like `Accept-Charset`  and `Accept-Encoding`
    - quality value of 0 indicates not acceptable and should not be used as a match
    - `application/xml` should match `application/*` but not a pattern like `application.xml`
- add tests for these conditions

## Motivation and Context
See #951
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- Test suite on osx and linux
- Additional tests added to cover missing conditions
- Confirm linux memory leak is gone when checking accept headers with type/*

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ x] If applicable, I have added tests to cover my changes.
