### PR TITLE
Remove use of String.CompareOptions.regularExpression because of memory leak

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -76,6 +76,9 @@ public class RouterResponse {
 
     private var lifecycle = Lifecycle()
 
+    // regex used to sanitize javascript identifiers
+    private static var sanitizeJSIdentifierRegex: RegularExpressionType? = nil
+
     /// Set of cookies to return with the response.
     public var cookies = [String: HTTPCookie]()
     
@@ -239,9 +242,11 @@ public class RouterResponse {
     /// is the alphanumeric characters and `[]$._`).
     /// - Returns: this RouterResponse.
     public func send(jsonp: JSON, callbackParameter: String = "callback") throws -> RouterResponse {
+        if RouterResponse.sanitizeJSIdentifierRegex == nil {
+            RouterResponse.sanitizeJSIdentifierRegex = try RegularExpressionType(pattern: "[^\\[\\]\\w$.]", options: [])
+        }
         func sanitizeJSIdentifier(_ ident: String) -> String {
-            return ident.replacingOccurrences(of: "[^\\[\\]\\w$.]", with: "", options:
-                    NSString.CompareOptions.regularExpression)
+            return RouterResponse.sanitizeJSIdentifierRegex?.stringByReplacingMatches(in: ident, options: [], range: NSMakeRange(0, ident.utf16.count), withTemplate: "") ?? ""
         }
         func validJsonpCallbackName(_ name: String?) -> String? {
             if let name = name {

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -77,7 +77,14 @@ public class RouterResponse {
     private var lifecycle = Lifecycle()
 
     // regex used to sanitize javascript identifiers
-    private static var sanitizeJSIdentifierRegex: RegularExpressionType? = nil
+    private static let sanitizeJSIdentifierRegex: RegularExpressionType! = {
+        do {
+            return try RegularExpressionType(pattern: "[^\\[\\]\\w$.]", options: [])
+        } catch { // pattern is a known valid literal, should never throw
+            Log.error("Error initializing sanitizeJSIdentifierRegex: \(error)")
+            return nil
+        }
+    }()
 
     /// Set of cookies to return with the response.
     public var cookies = [String: HTTPCookie]()
@@ -241,11 +248,8 @@ public class RouterResponse {
     /// is the alphanumeric characters and `[]$._`).
     /// - Returns: this RouterResponse.
     public func send(jsonp: JSON, callbackParameter: String = "callback") throws -> RouterResponse {
-        if RouterResponse.sanitizeJSIdentifierRegex == nil {
-            RouterResponse.sanitizeJSIdentifierRegex = try RegularExpressionType(pattern: "[^\\[\\]\\w$.]", options: [])
-        }
         func sanitizeJSIdentifier(_ ident: String) -> String {
-            return RouterResponse.sanitizeJSIdentifierRegex!.stringByReplacingMatches(in: ident, options: [],
+            return RouterResponse.sanitizeJSIdentifierRegex.stringByReplacingMatches(in: ident, options: [],
                                     range: NSRange(location: 0, length: ident.utf16.count), withTemplate: "")
         }
         func validJsonpCallbackName(_ name: String?) -> String? {

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -246,7 +246,8 @@ public class RouterResponse {
             RouterResponse.sanitizeJSIdentifierRegex = try RegularExpressionType(pattern: "[^\\[\\]\\w$.]", options: [])
         }
         func sanitizeJSIdentifier(_ ident: String) -> String {
-            return RouterResponse.sanitizeJSIdentifierRegex?.stringByReplacingMatches(in: ident, options: [], range: NSMakeRange(0, ident.utf16.count), withTemplate: "") ?? ""
+            return RouterResponse.sanitizeJSIdentifierRegex!.stringByReplacingMatches(in: ident, options: [],
+                                    range: NSRange(location: 0, length: ident.utf16.count), withTemplate: "")
         }
         func validJsonpCallbackName(_ name: String?) -> String? {
             if let name = name {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace String.CompareOptions.regularExpression with a static regex.
This has the same memory leak issue described in #951

## Motivation and Context
See #951
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
With master branch, memory leak reported by massif for 10,000 calls is **155 MB**
This change drops it down to **96 KB** 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
