### PR TITLE
Update vagrantfile to Swift 3.0.2

### DIFF
--- a/vagrantfile
+++ b/vagrantfile
@@ -1,10 +1,10 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_URL =  'https://cloud-images.ubuntu.com/vagrant/wily/current/wily-server-cloudimg-amd64-vagrant-disk1.box'.freeze
+BOX_URL =  'https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box'.freeze
 
-SWIFT_PATH = 'https://swift.org/builds/swift-3.0-release/ubuntu1510/swift-3.0-RELEASE'.freeze
-SWIFT_DIRECTORY = 'swift-3.0-RELEASE-ubuntu15.10'.freeze
+SWIFT_PATH = 'https://swift.org/builds/swift-3.0.2-release/ubuntu1404/swift-3.0.2-RELEASE'.freeze
+SWIFT_DIRECTORY = 'swift-3.0.2-RELEASE-ubuntu14.04'.freeze
 SWIFT_FILE = "#{SWIFT_DIRECTORY}.tar.gz".freeze
 SWIFT_HOME = "/home/vagrant/#{SWIFT_DIRECTORY}".freeze
 
@@ -25,7 +25,7 @@ Vagrant.configure(2) do |config|
 
 ### Install packages
 # 1. Install compiler, autotools
-    sudo apt-get --assume-yes install clang libicu-dev uuid-dev
+    sudo apt-get --assume-yes install clang libicu-dev uuid-dev git
 # 2. Install dtrace (to generate provider.h)
     sudo apt-get --assume-yes install systemtap-sdt-dev
 # 3. Kitura packages


### PR DESCRIPTION
## Description
Use Ubuntu 14.04 as there isn't a Swift 3.0.2 packaged download
for Ubuntu 15.10. Add git to the package install as it isn't part
of the Ubuntu 14.04 base image.

## Motivation and Context
The vagrantfile only installs Swift 3.0 GA, not the latest Swift 3.0.2 build.
https://github.com/IBM-Swift/Kitura/issues/967

## How Has This Been Tested?
I checked that there were no error messages when I created a Ubuntu 14.04 environment using the new vagrantfile (which was tested on macOS).

## Checklist:
None of these are required in this instance.