### PR TITLE
Allow developer to point static file server to system root. (#936)

### DIFF
--- a/Sources/Kitura/staticFileServer/ResourcePathHandler.swift
+++ b/Sources/Kitura/staticFileServer/ResourcePathHandler.swift
@@ -26,7 +26,7 @@ extension StaticFileServer {
 
         static func getAbsolutePath(for path: String) -> String {
             var path = path
-            if path.hasSuffix(separator) {
+            if path.hasSuffix(separator) && path != separator {
                 path = String(path.characters.dropLast())
             }
 

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -221,4 +221,8 @@ class TestStaticFileServer: XCTestCase {
         runGetResponseTest(path: "/@@Kitura-router@@/missing.file", expectedStatusCode: HTTPStatusCode.notFound)
     }
 
+    func testAbsolutePathFunction() {
+        XCTAssertEqual(StaticFileServer.ResourcePathHandler.getAbsolutePath(for: "/"), "/", "Absolute path did not resolve to system root")
+    }
+
 }


### PR DESCRIPTION
## Description

- Added a check for the case when the path input is equal to the separator "/".
- Added a unit test to see the getAbsolutePath function would return "/".

## Motivation and Context
#936 

## How Has This Been Tested?
Change includes a unit test to see that when given the input "/", the function returns "/"

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
