### PR TITLE
State guards for RouterResponse end() and send() functions and use SSL tests

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -301,7 +301,9 @@ extension Router : ServerDelegate {
                     if  routeResp.statusCode == .unknown  && !routeResp.state.invokedSend {
                         strongSelf.sendDefaultResponse(request: routeReq, response: routeResp)
                     }
-                    try routeResp.end()
+                    if  !routeResp.state.invokedEnd {
+                        try routeResp.end()
+                    }
                 }
             } catch {
                 // Not much to do here

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -65,7 +65,7 @@ class KituraTest: XCTestCase {
         PrintLogger.use(colored: true)
     }
 
-    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both,
+    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.httpOnly,
                            line: Int = #line, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
         if sslOption != SSLOption.httpsOnly {
             self.port = KituraTest.httpPort

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -24,7 +24,7 @@ import Dispatch
 
 class KituraTest: XCTestCase {
 
-    static let useSSLDefault = false
+    static let useSSLDefault = true
     static let portDefault = 8090
 
     var useSSL = useSSLDefault

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -43,14 +43,6 @@ class TestCookies: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     let router = TestCookies.setupRouter()
 
     func testCookieToServerWithSemiColonSeparator() {

--- a/Tests/KituraTests/TestErrors.swift
+++ b/Tests/KituraTests/TestErrors.swift
@@ -37,14 +37,6 @@ class TestErrors: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     let router = Router()
 
     func testInvalidMethod() {

--- a/Tests/KituraTests/TestMultiplicity.swift
+++ b/Tests/KituraTests/TestMultiplicity.swift
@@ -30,14 +30,6 @@ class TestMultiplicity: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     let router = TestMultiplicity.setupRouter()
 
     func testPlus() {

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -63,7 +63,7 @@ class TestRequests: KituraTest {
             let parameter = request.parameters["p1"]
             XCTAssertNotNil(parameter, "URL parameter p1 was nil")
             XCTAssertEqual(request.hostname, "localhost", "RouterRequest.hostname wasn't localhost, it was \(request.hostname)")
-            XCTAssertEqual(request.port, self.port, "RouterRequest.port wasn't \(self.port), it was \(request.port)")
+            XCTAssertEqual(request.port, KituraTest.port, "RouterRequest.port wasn't \(KituraTest.port), it was \(request.port)")
             XCTAssertEqual(request.remoteAddress, "127.0.0.1", "RouterRequest.remoteAddress wasn't 127.0.0.1, it was \(request.remoteAddress)")
             next()
         }

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -25,37 +25,16 @@ class TestRequests: KituraTest {
     static var allTests: [(String, (TestRequests) -> () throws -> Void)] {
         return [
                    ("testURLParameters", testURLParameters),
-                   ("testURLParametersSSL", testURLParametersSSL),
                    ("testCustomMiddlewareURLParameter", testCustomMiddlewareURLParameter),
-                   ("testCustomMiddlewareURLParameterSSL", testCustomMiddlewareURLParameterSSL),
                    ("testCustomMiddlewareURLParameterWithQueryParam", testCustomMiddlewareURLParameterWithQueryParam),
-                   ("testCustomMiddlewareURLParameterWithQueryParamSSL", testCustomMiddlewareURLParameterWithQueryParamSSL),
                    ("testParameters", testParameters),
-                   ("testParametersSSL", testParametersSSL),
-                   ("testParameterExit", testParameterExit),
-                   ("testParameterExitSSL", testParameterExitSSL)
+                   ("testParameterExit", testParameterExit)
         ]
-    }
-
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
     }
 
     let router = TestRequests.setupRouter()
 
     func testURLParameters() {
-        testURLParameters(useSSL: false)
-    }
-
-    func testURLParametersSSL() {
-        testURLParameters(useSSL: true)
-    }
-
-    func testURLParameters(useSSL: Bool) {
         // Set up router for this test
         let router = Router()
 
@@ -63,7 +42,7 @@ class TestRequests: KituraTest {
             let parameter = request.parameters["p1"]
             XCTAssertNotNil(parameter, "URL parameter p1 was nil")
             XCTAssertEqual(request.hostname, "localhost", "RouterRequest.hostname wasn't localhost, it was \(request.hostname)")
-            XCTAssertEqual(request.port, KituraTest.port, "RouterRequest.port wasn't \(KituraTest.port), it was \(request.port)")
+            XCTAssertEqual(request.port, self.port, "RouterRequest.port wasn't \(self.port), it was \(request.port)")
             XCTAssertEqual(request.remoteAddress, "127.0.0.1", "RouterRequest.remoteAddress wasn't 127.0.0.1, it was \(request.remoteAddress)")
             next()
         }
@@ -77,7 +56,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router, useSSL: useSSL) { expectation in
+        performServerTest(router) { expectation in
             self.performRequest("get", path: "/zxcv/ploni", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
@@ -85,7 +64,7 @@ class TestRequests: KituraTest {
         }
     }
 
-    private func runMiddlewareTest(path: String, useSSL: Bool) {
+    private func runMiddlewareTest(path: String) {
         // swiftlint:disable nesting
         class CustomMiddleware: RouterMiddleware {
         // swiftlint:enable nesting
@@ -109,7 +88,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router, useSSL: useSSL) { expectation in
+        performServerTest(router) { expectation in
             self.performRequest("get", path: path, callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
@@ -118,19 +97,11 @@ class TestRequests: KituraTest {
     }
 
     func testCustomMiddlewareURLParameter() {
-        runMiddlewareTest(path: "/user/my_custom_id", useSSL: false)
-    }
-
-    func testCustomMiddlewareURLParameterSSL() {
-        runMiddlewareTest(path: "/user/my_custom_id", useSSL: true)
+        runMiddlewareTest(path: "/user/my_custom_id")
     }
 
     func testCustomMiddlewareURLParameterWithQueryParam() {
-        runMiddlewareTest(path: "/user/my_custom_id?some_param=value", useSSL: false)
-    }
-
-    func testCustomMiddlewareURLParameterWithQueryParamSSL() {
-        runMiddlewareTest(path: "/user/my_custom_id?some_param=value", useSSL: true)
+        runMiddlewareTest(path: "/user/my_custom_id?some_param=value")
     }
 
     static func setupRouter() -> Router {
@@ -151,14 +122,6 @@ class TestRequests: KituraTest {
     }
 
     func testParameters() {
-        testParameters(useSSL: false)
-    }
-
-    func testParametersSSL() {
-        testParameters(useSSL: true)
-    }
-
-    func testParameters(useSSL: Bool) {
         let router = Router()
 
         router.parameter("user") { request, response, value, next in
@@ -205,7 +168,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router, useSSL: useSSL, asyncTasks: { expectation in
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "users/random/1000", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertNotNil(response!.headers["User"])
@@ -235,14 +198,6 @@ class TestRequests: KituraTest {
     }
 
     func testParameterExit() {
-        testParameterExit(useSSL: false)
-    }
-
-    func testParameterExitSSL() {
-        testParameterExit(useSSL: true)
-    }
-
-    func testParameterExit(useSSL: Bool) {
         let router = Router()
 
         router.parameter("id") { request, response, value, next in
@@ -265,7 +220,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router, useSSL: useSSL, asyncTasks: { expectation in
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "users/random/1000", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertNotNil(response!.headers["User-Id"])

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -25,10 +25,15 @@ class TestRequests: KituraTest {
     static var allTests: [(String, (TestRequests) -> () throws -> Void)] {
         return [
                    ("testURLParameters", testURLParameters),
+                   ("testURLParametersSSL", testURLParametersSSL),
                    ("testCustomMiddlewareURLParameter", testCustomMiddlewareURLParameter),
+                   ("testCustomMiddlewareURLParameterSSL", testCustomMiddlewareURLParameterSSL),
                    ("testCustomMiddlewareURLParameterWithQueryParam", testCustomMiddlewareURLParameterWithQueryParam),
+                   ("testCustomMiddlewareURLParameterWithQueryParamSSL", testCustomMiddlewareURLParameterWithQueryParamSSL),
                    ("testParameters", testParameters),
-                   ("testParameterExit", testParameterExit)
+                   ("testParametersSSL", testParametersSSL),
+                   ("testParameterExit", testParameterExit),
+                   ("testParameterExitSSL", testParameterExitSSL)
         ]
     }
 
@@ -43,6 +48,14 @@ class TestRequests: KituraTest {
     let router = TestRequests.setupRouter()
 
     func testURLParameters() {
+        testURLParameters(useSSL: false)
+    }
+
+    func testURLParametersSSL() {
+        testURLParameters(useSSL: true)
+    }
+
+    func testURLParameters(useSSL: Bool) {
         // Set up router for this test
         let router = Router()
 
@@ -64,7 +77,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router) { expectation in
+        performServerTest(router, useSSL: useSSL) { expectation in
             self.performRequest("get", path: "/zxcv/ploni", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
@@ -72,7 +85,7 @@ class TestRequests: KituraTest {
         }
     }
 
-    private func runMiddlewareTest(path: String) {
+    private func runMiddlewareTest(path: String, useSSL: Bool) {
         // swiftlint:disable nesting
         class CustomMiddleware: RouterMiddleware {
         // swiftlint:enable nesting
@@ -96,7 +109,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router) { expectation in
+        performServerTest(router, useSSL: useSSL) { expectation in
             self.performRequest("get", path: path, callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()
@@ -105,11 +118,19 @@ class TestRequests: KituraTest {
     }
 
     func testCustomMiddlewareURLParameter() {
-        runMiddlewareTest(path: "/user/my_custom_id")
+        runMiddlewareTest(path: "/user/my_custom_id", useSSL: false)
+    }
+
+    func testCustomMiddlewareURLParameterSSL() {
+        runMiddlewareTest(path: "/user/my_custom_id", useSSL: true)
     }
 
     func testCustomMiddlewareURLParameterWithQueryParam() {
-        runMiddlewareTest(path: "/user/my_custom_id?some_param=value")
+        runMiddlewareTest(path: "/user/my_custom_id?some_param=value", useSSL: false)
+    }
+
+    func testCustomMiddlewareURLParameterWithQueryParamSSL() {
+        runMiddlewareTest(path: "/user/my_custom_id?some_param=value", useSSL: true)
     }
 
     static func setupRouter() -> Router {
@@ -130,6 +151,14 @@ class TestRequests: KituraTest {
     }
 
     func testParameters() {
+        testParameters(useSSL: false)
+    }
+
+    func testParametersSSL() {
+        testParameters(useSSL: true)
+    }
+
+    func testParameters(useSSL: Bool) {
         let router = Router()
 
         router.parameter("user") { request, response, value, next in
@@ -176,7 +205,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router, asyncTasks: { expectation in
+        performServerTest(router, useSSL: useSSL, asyncTasks: { expectation in
             self.performRequest("get", path: "users/random/1000", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertNotNil(response!.headers["User"])
@@ -206,6 +235,14 @@ class TestRequests: KituraTest {
     }
 
     func testParameterExit() {
+        testParameterExit(useSSL: false)
+    }
+
+    func testParameterExitSSL() {
+        testParameterExit(useSSL: true)
+    }
+
+    func testParameterExit(useSSL: Bool) {
         let router = Router()
 
         router.parameter("id") { request, response, value, next in
@@ -228,7 +265,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router, asyncTasks: { expectation in
+        performServerTest(router, useSSL: useSSL, asyncTasks: { expectation in
             self.performRequest("get", path: "users/random/1000", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertNotNil(response!.headers["User-Id"])

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -61,14 +61,6 @@ class TestResponse: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     let router = TestResponse.setupRouter()
 
     func testSimpleResponse() {

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -56,7 +56,8 @@ class TestResponse: KituraTest {
             ("testSubdomains", testSubdomains),
             ("testJsonp", testJsonp),
             ("testLifecycle", testLifecycle),
-            ("testSend", testSend)
+            ("testSend", testSend),
+            ("testSendAfterEnd", testSendAfterEnd)
         ]
     }
 
@@ -911,6 +912,22 @@ class TestResponse: KituraTest {
 
     }
 
+    func testSendAfterEnd() {
+        performServerTest(router) { expectation in
+            self.performRequest("get", path: "/send_after_end", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response!.statusCode, HTTPStatusCode.forbidden, "HTTP Status code was \(response!.statusCode)")
+                do {
+                    let body = try response!.readString()
+                    XCTAssertEqual(body?.lowercased(), "forbidden<!DOCTYPE html><html><body><b>forbidden</b></body></html>\n\n".lowercased())
+                } catch {
+                    XCTFail("No response body")
+                }
+                expectation.fulfill()
+            })
+        }
+    }
+
     static func setupRouter() -> Router {
         let router = Router()
 
@@ -1184,6 +1201,21 @@ class TestResponse: KituraTest {
             next()
         }
 
+        router.get("/send_after_end") { _, response, next in
+            do {
+                let json = JSON([ "some": "json" ])
+                try response.send(status: HTTPStatusCode.forbidden).send(data: "<!DOCTYPE html><html><body><b>forbidden</b></body></html>\n\n".data(using: .utf8)!).end()
+                try response.send(status: HTTPStatusCode.OK).end()
+                response.send("string")
+                response.send(json: json)
+                try response.send(jsonp: json, callbackParameter: "cb").end()
+                try response.send(data: json.rawData())
+                try response.send(fileName: "./Tests/KituraTests/TestStaticFileServer/index.html")
+                try response.send(download: "./Tests/KituraTests/TestStaticFileServer/index.html")
+            } catch {}
+            next()
+        }
+
         router.error { request, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             do {
@@ -1207,7 +1239,7 @@ class TestResponse: KituraTest {
 
         router.error([DummyErrorMiddleware()])
 
-	return router
+        return router
     }
 
     class DummyErrorMiddleware: RouterMiddleware {

--- a/Tests/KituraTests/TestRouteRegex.swift
+++ b/Tests/KituraTests/TestRouteRegex.swift
@@ -62,14 +62,6 @@ class TestRouteRegex: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     func testBuildRegexFromPattern() {
         #if os(Linux)
             var regex: RegularExpression?

--- a/Tests/KituraTests/TestRouterHTTPVerbs_generated.swift
+++ b/Tests/KituraTests/TestRouterHTTPVerbs_generated.swift
@@ -48,8 +48,7 @@ class TestRouterHTTPVerbs_generated: KituraTest {
 
     // check that all verbs with BodyTestHandler parameter was added to elements array
     func testFirstTypeVerbsAdded() {
-        let router = Router()
-        performServerTest(router) { expectation in
+            let router = Router()
             var verbsArray: [String] = []
             verbsArray.append("ALL")
             router.all("/bodytest", handler: self.BodyTestHandler)
@@ -119,13 +118,10 @@ class TestRouterHTTPVerbs_generated: KituraTest {
                     return
                 }
             }
-            expectation.fulfill()
-        }
     }
 
     func testSecondTypeVerbsAdded() {
-        let router = Router()
-        performServerTest(router) { expectation in
+            let router = Router()
             var verbsArray: [String] = []
             verbsArray.append("ALL")
             router.all("/bodytest", handler: [self.BodyTestHandler, self.BodyTestHandler])
@@ -195,13 +191,10 @@ class TestRouterHTTPVerbs_generated: KituraTest {
                     return
                 }
             }
-            expectation.fulfill()
-        }
     }
 
     func testThirdTypeVerbsAdded() {
-        let router = Router()
-        performServerTest(router) { expectation in
+            let router = Router()
             var verbsArray: [String] = []
             let bodyParser = BodyParser()
             verbsArray.append("ALL")
@@ -272,13 +265,10 @@ class TestRouterHTTPVerbs_generated: KituraTest {
                     return
                 }
             }
-            expectation.fulfill()
-        }
     }
 
     func testFourthTypeVerbsAdded() {
-        let router = Router()
-        performServerTest(router) { expectation in
+            let router = Router()
             var verbsArray: [String] = []
             let bodyParser = BodyParser()
             verbsArray.append("ALL")
@@ -349,7 +339,5 @@ class TestRouterHTTPVerbs_generated: KituraTest {
                     return
                 }
             }
-            expectation.fulfill()
-        }
     }
 }

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -30,12 +30,8 @@ class TestServer: KituraTest {
     }
 
     override func setUp() {
-        doSetUp()
-        KituraTest.stopServer() // stop common server so we can run these tests
-    }
-
-    override func tearDown() {
-        doTearDown()
+        super.setUp()
+        stopServer() // stop common server so we can run these tests
     }
 
     private func setupServerAndExpectations(expectStart: Bool, expectStop: Bool, expectFail: Bool,

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -31,6 +31,7 @@ class TestServer: KituraTest {
 
     override func setUp() {
         doSetUp()
+        KituraTest.stopServer() // stop common server so we can run these tests
     }
 
     override func tearDown() {
@@ -103,7 +104,7 @@ class TestServer: KituraTest {
             Kitura.stop()
         }
 
-        waitExpectation(timeout: 10) { error in
+        waitForExpectations(timeout: 10) { error in
             XCTAssertNil(error)
         }
     }
@@ -116,7 +117,7 @@ class TestServer: KituraTest {
             Kitura.run()
         }
 
-        waitExpectation(timeout: 10) { error in
+        waitForExpectations(timeout: 10) { error in
             Kitura.stop()
             XCTAssertNil(error)
         }
@@ -131,7 +132,7 @@ class TestServer: KituraTest {
             Kitura.start()
         }
 
-        waitExpectation(timeout: 10) { error in
+        waitForExpectations(timeout: 10) { error in
             Kitura.stop()
             XCTAssertNil(error)
         }

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -32,11 +32,13 @@ class TestStaticFileServer: KituraTest {
     static var allTests: [(String, (TestStaticFileServer) -> () throws -> Void)] {
         return [
             ("testFileServer", testFileServer),
+            ("testFileServerSSL", testFileServerSSL),
             ("testGetWithWhiteSpaces", testGetWithWhiteSpaces),
             ("testGetWithSpecialCharacters", testGetWithSpecialCharacters),
             ("testGetWithSpecialCharactersEncoded", testGetWithSpecialCharactersEncoded),
             ("testGetKituraResource", testGetKituraResource),
-            ("testGetMissingKituraResource", testGetMissingKituraResource)
+            ("testGetMissingKituraResource", testGetMissingKituraResource),
+            ("testAbsolutePathFunction", testAbsolutePathFunction)
         ]
     }
 
@@ -51,7 +53,15 @@ class TestStaticFileServer: KituraTest {
     let router = TestStaticFileServer.setupRouter()
 
     func testFileServer() {
-    	performServerTest(router, asyncTasks: { expectation in
+        testFileServer(useSSL: false)
+    }
+
+    func testFileServerSSL() {
+        testFileServer(useSSL: true)
+    }
+
+    func testFileServer(useSSL: Bool) {
+        performServerTest(router, useSSL: useSSL, asyncTasks: { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -32,7 +32,6 @@ class TestStaticFileServer: KituraTest {
     static var allTests: [(String, (TestStaticFileServer) -> () throws -> Void)] {
         return [
             ("testFileServer", testFileServer),
-            ("testFileServerSSL", testFileServerSSL),
             ("testGetWithWhiteSpaces", testGetWithWhiteSpaces),
             ("testGetWithSpecialCharacters", testGetWithSpecialCharacters),
             ("testGetWithSpecialCharactersEncoded", testGetWithSpecialCharactersEncoded),
@@ -42,26 +41,10 @@ class TestStaticFileServer: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     let router = TestStaticFileServer.setupRouter()
 
     func testFileServer() {
-        testFileServer(useSSL: false)
-    }
-
-    func testFileServerSSL() {
-        testFileServer(useSSL: true)
-    }
-
-    func testFileServer(useSSL: Bool) {
-        performServerTest(router, useSSL: useSSL, asyncTasks: { expectation in
+        performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")

--- a/Tests/KituraTests/TestSubrouter.swift
+++ b/Tests/KituraTests/TestSubrouter.swift
@@ -39,14 +39,6 @@ class TestSubrouter: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     let router = TestSubrouter.setupRouter()
 
     func testSimpleSub() {

--- a/Tests/KituraTests/TestTemplateEngine.swift
+++ b/Tests/KituraTests/TestTemplateEngine.swift
@@ -44,14 +44,6 @@ class TestTemplateEngine: KituraTest {
         ]
     }
 
-    override func setUp() {
-        doSetUp()
-    }
-
-    override func tearDown() {
-        doTearDown()
-    }
-
     func testEmptyTemplateName() {
         let router = Router()
         router.setDefault(templateEngine: MockTemplateEngine())


### PR DESCRIPTION
## Description
- Add state guards for RouterResponse end() and send() functions
- Make most unit tests use SSLService as it surfaces socket read, write, close contention problems whereas Socket mostly ignores them
- We still need some fixes in SSLService before we can enable SSL tests. This just requires us to change the default for `sslOption` in KituraTest.performServerTest() from `SSLOption.httpOnly` to `SSLOption.both`

## Motivation and Context
#959
#962

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
