### PR TITLE
#982 #962 Avoid forced unwrapping in tests and tests with/without SSL

### DIFF
--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -65,7 +65,7 @@ class KituraTest: XCTestCase {
         PrintLogger.use(colored: true)
     }
 
-    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.httpOnly,
+    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both,
                            line: Int = #line, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
         if sslOption != SSLOption.httpsOnly {
             self.port = KituraTest.httpPort

--- a/Tests/KituraTests/MiscellaneousTests.swift
+++ b/Tests/KituraTests/MiscellaneousTests.swift
@@ -40,11 +40,11 @@ class MiscellaneousTests: KituraTest {
         switch key {
         case "kitura":
             XCTAssertNotNil(value, "Value for the header kitura was nil")
-            XCTAssertEqual(value!, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(value!)")
+            XCTAssertEqual(value, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(value)")
             firstKeyWasKitura = true
         case "plover":
             XCTAssertNotNil(value, "Value for the header plover was nil")
-            XCTAssertEqual(value!, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(value!)")
+            XCTAssertEqual(value, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(value)")
             firstKeyWasKitura = false
         default:
             firstKeyWasKitura = false
@@ -59,11 +59,11 @@ class MiscellaneousTests: KituraTest {
         case "kitura":
             XCTAssertFalse(firstKeyWasKitura, "Second key was kitura, it should not have been")
             XCTAssertNotNil(value, "Value for the header kitura was nil")
-            XCTAssertEqual(value!, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(value!)")
+            XCTAssertEqual(value, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(value)")
         case "plover":
             XCTAssertTrue(firstKeyWasKitura, "The first key should have been kitura")
             XCTAssertNotNil(value, "Value for the header plover was nil")
-            XCTAssertEqual(value!, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(value!)")
+            XCTAssertEqual(value, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(value)")
         default:
             XCTFail("The header key was neither kitura nor plover, it was \(key)")
         }
@@ -75,30 +75,30 @@ class MiscellaneousTests: KituraTest {
         headers.setLocation("back")   // Without referrer set
         var location = headers["Location"]
         XCTAssertNotNil(location, "Location header wasn't set")
-        XCTAssertEqual(location!, "/", "Location header should have been /, it was \(location!)")
+        XCTAssertEqual(location, "/", "Location header should have been /, it was \(location)")
 
         let referrer = "http://plover.com/xyzzy"
         headers["referrer"] = referrer
         headers.setLocation("back")   // With referrer set
         location = headers["Location"]
-        XCTAssertEqual(location!, referrer, "Location header should have been \(referrer), it was \(location!)")
+        XCTAssertEqual(location, referrer, "Location header should have been \(referrer), it was \(location)")
 
         headers.setType("html", charset: "UTF-8")
         let contentType = headers["Content-Type"]
         XCTAssertNotNil(contentType, "Content-Type header wasn't set")
         let expectedContentType = "text/html; charset=UTF-8"
-        XCTAssertEqual(contentType!, expectedContentType, "Content-Type header should have been \(expectedContentType), it was \(contentType!)")
+        XCTAssertEqual(contentType, expectedContentType, "Content-Type header should have been \(expectedContentType), it was \(contentType)")
 
         var contentDispostion = headers["Content-Disposition"]
         XCTAssertNil(contentDispostion, "Content-Disposition shouldn't have been set yet")
 
         headers.addAttachment(for: "")
         contentDispostion = headers["Content-Disposition"]
-        XCTAssertNil(contentDispostion, "Content-Disposition shouldn't have been set. It's value is \(contentDispostion!)")
+        XCTAssertNil(contentDispostion, "Content-Disposition shouldn't have been set. It's value is \(contentDispostion)")
 
         headers.addAttachment()
         contentDispostion = headers["Content-Disposition"]
         XCTAssertNotNil(contentDispostion, "Content-Disposition should have been set.")
-        XCTAssertEqual(contentDispostion!, "attachment", "Content-Disposition should have the value attachment. It has the value \(contentDispostion!)")
+        XCTAssertEqual(contentDispostion, "attachment", "Content-Disposition should have the value attachment. It has the value \(contentDispostion)")
     }
 }

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -80,10 +80,10 @@ class TestCookies: KituraTest {
             }
 
             self.performRequest("get", path: "/1/cookiedump", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "cookiedump route did not match single path request")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "cookiedump route did not match single path request")
                 do {
                     var data = Data()
-                    try response!.readAllData(into: &data)
+                    try response?.readAllData(into: &data)
 
                     let responseBody = String(data: data as Data, encoding: .utf8)
                     if  let responseBody = responseBody {
@@ -103,43 +103,52 @@ class TestCookies: KituraTest {
     func testCookieFromServer() {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/1/sendcookie", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "/1/sendcookie route did not match single path request")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "/1/sendcookie route did not match single path request")
 
-                let (cookie1, cookie1Expire) = self.cookieFrom(response: response!, named: cookie1Name as String)
-                XCTAssert(cookie1 != nil, "Cookie \(cookie1Name) wasn't found in the response.")
-                XCTAssertEqual(cookie1!.value, cookie1Value as String, "Value of Cookie \(cookie1Name) is not \(cookie1Value), was \(cookie1!.value)")
-                XCTAssertEqual(cookie1!.path, "/", "Path of Cookie \(cookie1Name) is not (/), was \(cookie1!.path)")
-                XCTAssertEqual(cookie1!.domain, cookieHost as String, "Domain of Cookie \(cookie1Name) is not \(cookieHost), was \(cookie1!.domain)")
-                XCTAssertFalse(cookie1!.isSecure, "\(cookie1Name) was marked as secure. Should have not been marked so.")
-                XCTAssertNil(cookie1Expire, "\(cookie1Name) had an expiration date. It shouldn't have had one")
+                let (cookie1, cookie1Expire) = self.cookieFrom(response: response, named: cookie1Name as String)
+                XCTAssertNotNil(cookie1, "Cookie \(cookie1Name) wasn't found in the response.")
+                if let cookie1 = cookie1 {
+                    XCTAssertEqual(cookie1.value, cookie1Value as String, "Value of Cookie \(cookie1Name) is not \(cookie1Value), was \(cookie1.value)")
+                    XCTAssertEqual(cookie1.path, "/", "Path of Cookie \(cookie1Name) is not (/), was \(cookie1.path)")
+                    XCTAssertEqual(cookie1.domain, cookieHost as String, "Domain of Cookie \(cookie1Name) is not \(cookieHost), was \(cookie1.domain)")
+                    XCTAssertFalse(cookie1.isSecure, "\(cookie1Name) was marked as secure. Should have not been marked so.")
+                    XCTAssertNil(cookie1Expire, "\(cookie1Name) had an expiration date. It shouldn't have had one")
+                }
 
-                let (cookie2, cookie2Expire) = self.cookieFrom(response: response!, named: cookie2Name as String)
-                XCTAssert(cookie2 != nil, "Cookie \(cookie2Name) wasn't found in the response.")
-                XCTAssertEqual(cookie2!.value, cookie2Value as String, "Value of Cookie \(cookie2Name) is not \(cookie2Value), was \(cookie2!.value)")
-                XCTAssertEqual(cookie2!.path, "/", "Path of Cookie \(cookie2Name) is not (/), was \(cookie2!.path)")
-                XCTAssertEqual(cookie2!.domain, cookieHost as String, "Domain of Cookie \(cookie2Name) is not \(cookieHost), was \(cookie2!.domain)")
-                XCTAssertFalse(cookie2!.isSecure, "\(cookie2Name) was marked as secure. Should have not been marked so.")
-                XCTAssertNotNil(cookie2Expire, "\(cookie2Name) had no expiration date. It should have had one")
-                XCTAssertEqual(cookie2Expire!, SPIUtils.httpDate(cookie2ExpireExpected))
+                let (cookie2, cookie2Expire) = self.cookieFrom(response: response, named: cookie2Name as String)
+                XCTAssertNotNil(cookie2, "Cookie \(cookie2Name) wasn't found in the response.")
+                if let cookie2 = cookie2 {
+                    XCTAssertEqual(cookie2.value, cookie2Value as String, "Value of Cookie \(cookie2Name) is not \(cookie2Value), was \(cookie2.value)")
+                    XCTAssertEqual(cookie2.path, "/", "Path of Cookie \(cookie2Name) is not (/), was \(cookie2.path)")
+                    XCTAssertEqual(cookie2.domain, cookieHost as String, "Domain of Cookie \(cookie2Name) is not \(cookieHost), was \(cookie2.domain)")
+                    XCTAssertFalse(cookie2.isSecure, "\(cookie2Name) was marked as secure. Should have not been marked so.")
+                    XCTAssertNotNil(cookie2Expire, "\(cookie2Name) had no expiration date. It should have had one")
+                    XCTAssertEqual(cookie2Expire, SPIUtils.httpDate(cookie2ExpireExpected))
+                }
                 expectation.fulfill()
             })
         }, { expectation in
             self.performRequest("get", path: "/2/sendcookie", callback: { response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "/2/sendcookie route did not match single path request")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "/2/sendcookie route did not match single path request")
 
-                let (cookie, cookieExpire) = self.cookieFrom(response: response!, named: cookie3Name as String)
+                let (cookie, cookieExpire) = self.cookieFrom(response: response, named: cookie3Name as String)
                 XCTAssertNotNil(cookie, "Cookie \(cookie3Name) wasn't found in the response.")
-                XCTAssertEqual(cookie!.value, cookie3Value as String, "Value of Cookie \(cookie3Name) is not \(cookie3Value), was \(cookie!.value)")
-                XCTAssertEqual(cookie!.path, "/", "Path of Cookie \(cookie3Name) is not (/), was \(cookie!.path)")
-                XCTAssertEqual(cookie!.domain, cookieHost as String, "Domain of Cookie \(cookie3Name) is not \(cookieHost), was \(cookie!.domain)")
-                XCTAssertTrue(cookie!.isSecure, "\(cookie3Name) wasn't marked as secure. It should have been marked so.")
-                XCTAssertNil(cookieExpire, "\(cookie3Name) had an expiration date. It shouldn't have had one")
+                if let cookie = cookie {
+                    XCTAssertEqual(cookie.value, cookie3Value as String, "Value of Cookie \(cookie3Name) is not \(cookie3Value), was \(cookie.value)")
+                    XCTAssertEqual(cookie.path, "/", "Path of Cookie \(cookie3Name) is not (/), was \(cookie.path)")
+                    XCTAssertEqual(cookie.domain, cookieHost as String, "Domain of Cookie \(cookie3Name) is not \(cookieHost), was \(cookie.domain)")
+                    XCTAssertTrue(cookie.isSecure, "\(cookie3Name) wasn't marked as secure. It should have been marked so.")
+                    XCTAssertNil(cookieExpire, "\(cookie3Name) had an expiration date. It shouldn't have had one")
+                }
                 expectation.fulfill()
             })
         })
     }
 
-    func cookieFrom(response: ClientResponse, named: String) -> (HTTPCookie?, String?) {
+    func cookieFrom(response: ClientResponse?, named: String) -> (HTTPCookie?, String?) {
+        guard let response = response else {
+            return (nil, nil)
+        }
         var resultCookie: HTTPCookie? = nil
         var resultExpire: String?
         for (headerKey, headerValues) in response.headers {
@@ -190,10 +199,10 @@ class TestCookies: KituraTest {
     func testNoCookies() {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/1/cookiedump", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "cookiedump route did not match single path request")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "cookiedump route did not match single path request")
                 do {
                     var data = Data()
-                    try response!.readAllData(into: &data)
+                    try response?.readAllData(into: &data)
 
                     let responseBody = String(data: data as Data, encoding: .utf8)
                     if  let responseBody = responseBody {
@@ -208,10 +217,10 @@ class TestCookies: KituraTest {
             })
         }, { expectation in
             self.performRequest("get", path: "/1/cookiedump", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "cookiedump route did not match single path request")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "cookiedump route did not match single path request")
                 do {
                     var data = Data()
-                    try response!.readAllData(into: &data)
+                    try response?.readAllData(into: &data)
 
                     let responseBody = String(data: data as Data, encoding: .utf8)
                     if  let responseBody = responseBody {

--- a/Tests/KituraTests/TestErrors.swift
+++ b/Tests/KituraTests/TestErrors.swift
@@ -57,7 +57,7 @@ class TestErrors: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/notreal", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
                 expectation.fulfill()
             })
         }

--- a/Tests/KituraTests/TestMultiplicity.swift
+++ b/Tests/KituraTests/TestMultiplicity.swift
@@ -35,17 +35,17 @@ class TestMultiplicity: KituraTest {
     func testPlus() {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/1/plus", callback: {response in
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Plus route did not match single path request")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Plus route did not match single path request")
                 expectation.fulfill()
             })
         }, { expectation in
             self.performRequest("get", path: "/1/plus/plus", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Plus route did not match multiple path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Plus route did not match multiple path request")
                     expectation.fulfill()
                 })
         }, { expectation in
             self.performRequest("get", path: "/1", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.notFound, "Plus route did not miss empty path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "Plus route did not miss empty path request")
                     expectation.fulfill()
                 })
         })
@@ -54,17 +54,17 @@ class TestMultiplicity: KituraTest {
     func testStar() {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/2/star", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Star route did not match single path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Star route did not match single path request")
                   expectation.fulfill()
             })
         }, { expectation in
             self.performRequest("get", path: "/2/star/star", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Star route did not match multiple path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Star route did not match multiple path request")
                   expectation.fulfill()
                 })
         }, { expectation in
             self.performRequest("get", path: "/2", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Star route did not match empty path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Star route did not match empty path request")
                   expectation.fulfill()
                 })
         })
@@ -73,17 +73,17 @@ class TestMultiplicity: KituraTest {
     func testQuestion() {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/3/question", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Question route did not match single path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Question route did not match single path request")
                   expectation.fulfill()
                 })
         }, { expectation in
             self.performRequest("get", path: "/3/question/question", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.notFound, "Question route did not miss multiple path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "Question route did not miss multiple path request")
                   expectation.fulfill()
                 })
         }, { expectation in
             self.performRequest("get", path: "/3", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Question route did not match empty path request")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Question route did not match empty path request")
                   expectation.fulfill()
                 })
         })
@@ -92,17 +92,17 @@ class TestMultiplicity: KituraTest {
     func testCombined() {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/4/question/plus", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Complex route did not match dropped star ending")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Complex route did not match dropped star ending")
                   expectation.fulfill()
                 })
         }, { expectation in
             self.performRequest("get", path: "/4/plus/plus/star", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Complex route did not match dropped beginning with extra middle")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Complex route did not match dropped beginning with extra middle")
                   expectation.fulfill()
                 })
         }, { expectation in
             self.performRequest("get", path: "/4/question/plusssssss/plus/pluss/star/star", callback: {response in
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "Complex route did not match internal extra plus signs with multiple extras")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "Complex route did not match internal extra plus signs with multiple extras")
                   expectation.fulfill()
                 })
         })

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -48,7 +48,7 @@ class TestRequests: KituraTest {
         }
         router.get("/zxcv/ploni") { request, _, next in
             let parameter = request.parameters["p1"]
-            XCTAssertNil(parameter, "URL parameter p1 was not nil, it's value was \(parameter!)")
+            XCTAssertNil(parameter, "URL parameter p1 was not nil, it's value was \(parameter)")
             next()
         }
         router.all() { _, response, next in
@@ -171,23 +171,23 @@ class TestRequests: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "users/random/1000", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertNotNil(response!.headers["User"])
-                XCTAssertNotNil(response!.headers["User-Id"])
-                XCTAssertEqual(response!.headers["User"]!.first, "random")
-                XCTAssertEqual(response!.headers["User-Id"]!.first, "1000")
+                XCTAssertNotNil(response?.headers["User"])
+                XCTAssertNotNil(response?.headers["User-Id"])
+                XCTAssertEqual(response?.headers["User"]?.first, "random")
+                XCTAssertEqual(response?.headers["User-Id"]?.first, "1000")
                 expectation.fulfill()
             })
         }, { expectation in
             self.performRequest("get", path: "posts/random/11000", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertNil(response!.headers["User"])
-                XCTAssertNotNil(response!.headers["User-Id"])
-                XCTAssertEqual(response!.headers["User-Id"]!.first, "11000")
+                XCTAssertNil(response?.headers["User"])
+                XCTAssertNotNil(response?.headers["User-Id"])
+                XCTAssertEqual(response?.headers["User-Id"]?.first, "11000")
 
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
                     XCTAssertNotNil(body)
-                    XCTAssertEqual(body!, "success")
+                    XCTAssertEqual(body, "success")
                 } catch {
                     XCTFail()
                 }
@@ -216,20 +216,22 @@ class TestRequests: KituraTest {
         // default test
         router.get("users/:user/:id") { request, response, next in
             XCTAssertNotNil(request.parameters["id"])
-            response.status(.OK).send(data: "\(request.parameters["id"]!)".data(using: .utf8)!)
+            if let id = request.parameters["id"] {
+                response.status(.OK).send(data: "\(id)".data(using: .utf8)!)
+            }
             next()
         }
 
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "users/random/1000", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertNotNil(response!.headers["User-Id"])
-                XCTAssertEqual(response!.headers["User-Id"]!.first!, "1000")
+                XCTAssertNotNil(response?.headers["User-Id"])
+                XCTAssertEqual(response?.headers["User-Id"]?.first, "1000")
 
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
                     XCTAssertNotNil(body)
-                    XCTAssertEqual(body!, "1000")
+                    XCTAssertEqual(body, "1000")
                 } catch {
                     XCTFail()
                 }
@@ -239,11 +241,11 @@ class TestRequests: KituraTest {
         }, { expectation in
             self.performRequest("get", path: "users/random/dsa", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertNil(response!.headers["User-Id"])
-                XCTAssertEqual(response!.statusCode, .notAcceptable)
+                XCTAssertNil(response?.headers["User-Id"])
+                XCTAssertEqual(response?.statusCode, .notAcceptable)
 
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
                     XCTAssertNil(body)
                 } catch {
                     XCTFail()

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -67,12 +67,12 @@ class TestResponse: KituraTest {
     	performServerTest(router) { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
-                //XCTAssertEqual(response!.method, "GET", "The request wasn't recognized as a get")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
+                //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -85,11 +85,11 @@ class TestResponse: KituraTest {
     	performServerTest(router) { expectation in
             self.performRequest("post", path: "/bodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                //XCTAssertEqual(response!.method, "POST", "The request wasn't recognized as a post")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                //XCTAssertEqual(response?.method, "POST", "The request wasn't recognized as a post")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -106,8 +106,8 @@ class TestResponse: KituraTest {
             self.performRequest("post", path: "/bodytesthardway", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "Read 13 bytes")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "Read 13 bytes")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -158,11 +158,11 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/doublebodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                //XCTAssertEqual(response!.method, "POST", "The request wasn't recognized as a post")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                //XCTAssertEqual(response?.method, "POST", "The request wasn't recognized as a post")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -178,10 +178,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/bodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -195,10 +195,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/bodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -245,8 +245,8 @@ class TestResponse: KituraTest {
             self.performRequest("post", path: "/multibodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "text  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "text  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -272,8 +272,8 @@ class TestResponse: KituraTest {
             self.performRequest("post", path: "/multibodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -302,8 +302,8 @@ class TestResponse: KituraTest {
             self.performRequest("post", path: "/multibodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "  text(\"text default\") ")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "  text(\"text default\") ")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -323,8 +323,8 @@ class TestResponse: KituraTest {
             self.performRequest("post", path: "/multibodytest", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "Cannot POST /multibodytest.")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "Cannot POST /multibodytest.")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -432,8 +432,8 @@ class TestResponse: KituraTest {
             self.performRequest("get", path: "/redir", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertNotNil(body!.range(of: "ibm"), "response does not contain IBM")
+                    let body = try response?.readString()
+                    XCTAssertNotNil(body?.range(of: "ibm"), "response does not contain IBM")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -447,9 +447,9 @@ class TestResponse: KituraTest {
             self.performRequest("get", path: "/error", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
                     let errorDescription = "foo is nil"
-                    XCTAssertEqual(body!, "Caught the error: \(errorDescription)")
+                    XCTAssertEqual(body, "Caught the error: \(errorDescription)")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -462,10 +462,10 @@ class TestResponse: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/route", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "get 1\nget 2\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "get 1\nget 2\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -474,10 +474,10 @@ class TestResponse: KituraTest {
         }, { expectation in
             self.performRequest("post", path: "/route", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "post received")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "post received")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -491,30 +491,30 @@ class TestResponse: KituraTest {
         router.get("/headerTest") { _, response, next in
 
             response.headers.append("Content-Type", value: "text/html")
-            XCTAssertEqual(response.headers["Content-Type"]!, "text/html")
+            XCTAssertEqual(response.headers["Content-Type"], "text/html")
 
             response.headers.append("Content-Type", value: "text/plain; charset=utf-8")
-            XCTAssertEqual(response.headers["Content-Type"]!, "text/html")
+            XCTAssertEqual(response.headers["Content-Type"], "text/html")
 
             response.headers["Content-Type"] = nil
             XCTAssertNil(response.headers["Content-Type"])
 
             response.headers.append("Content-Type", value: "text/plain, image/png")
-            XCTAssertEqual(response.headers["Content-Type"]!, "text/plain, image/png")
+            XCTAssertEqual(response.headers["Content-Type"], "text/plain, image/png")
 
             response.headers.append("Content-Type", value: "text/html, image/jpeg")
-            XCTAssertEqual(response.headers["Content-Type"]!, "text/plain, image/png")
+            XCTAssertEqual(response.headers["Content-Type"], "text/plain, image/png")
 
             response.headers.append("Content-Type", value: "charset=UTF-8")
-            XCTAssertEqual(response.headers["Content-Type"]!, "text/plain, image/png")
+            XCTAssertEqual(response.headers["Content-Type"], "text/plain, image/png")
 
             response.headers["Content-Type"] = nil
 
             response.headers.append("Content-Type", value: "text/html")
-            XCTAssertEqual(response.headers["Content-Type"]!, "text/html")
+            XCTAssertEqual(response.headers["Content-Type"], "text/html")
 
             response.headers.append("Content-Type", value: "image/png, text/plain")
-            XCTAssertEqual(response.headers["Content-Type"]!, "text/html")
+            XCTAssertEqual(response.headers["Content-Type"], "text/html")
 
             do {
                 try response.status(HTTPStatusCode.OK).send("<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n").end()
@@ -641,11 +641,11 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/format", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertEqual(response!.headers["Content-Type"]!.first!, "text/html")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.headers["Content-Type"]?.first, "text/html")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body>Hi from Kitura!</body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body>Hi from Kitura!</body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -656,11 +656,11 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/format", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertEqual(response!.headers["Content-Type"]!.first!, "text/plain")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.headers["Content-Type"]?.first, "text/plain")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "Hi from Kitura!")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "Hi from Kitura!")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -671,10 +671,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/format", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "default")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "default")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -688,10 +688,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/single_link", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                let header = response!.headers["Link"]?.first
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                let header = response?.headers["Link"]?.first
                 XCTAssertNotNil(header, "Link header should not be nil")
-                XCTAssertEqual(header!, "<https://developer.ibm.com/swift>; rel=\"root\"")
+                XCTAssertEqual(header, "<https://developer.ibm.com/swift>; rel=\"root\"")
                 expectation.fulfill()
             })
         }
@@ -699,13 +699,13 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/multiple_links", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 let firstLink = "<https://developer.ibm.com/swift/products/ibm-swift-sandbox/>; rel=\"next\""
                 let secondLink = "<https://developer.ibm.com/swift/products/ibm-bluemix/>; rel=\"prev\""
-                let header = response!.headers["Link"]?.first
+                let header = response?.headers["Link"]?.first
                 XCTAssertNotNil(header, "Link header should not be nil")
-                XCTAssertNotNil(header!.range(of: firstLink), "link header should contain first link")
-                XCTAssertNotNil(header!.range(of: secondLink), "link header should contain second link")
+                XCTAssertNotNil(header?.range(of: firstLink), "link header should contain first link")
+                XCTAssertNotNil(header?.range(of: secondLink), "link header should contain second link")
                 expectation.fulfill()
             })
         }
@@ -715,16 +715,16 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp?callback=testfn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
 #if os(Linux)
                     let expected = "{\n  \"some\": \"json\"\n}"
 #else
                     let expected = "{\n  \"some\" : \"json\"\n}"
 #endif
-                    XCTAssertEqual(body!, "/**/ testfn(\(expected))")
-                    XCTAssertEqual(response!.headers["Content-Type"]!.first!, "application/javascript")
+                    XCTAssertEqual(body, "/**/ testfn(\(expected))")
+                    XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/javascript")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -735,7 +735,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp?callback=test+fn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response?.statusCode)")
                 expectation.fulfill()
             })
         }
@@ -743,7 +743,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response?.statusCode)")
                 expectation.fulfill()
             })
         }
@@ -751,16 +751,16 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp_cb?cb=testfn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
 #if os(Linux)
                     let expected = "{\n  \"some\": \"json\"\n}"
 #else
                     let expected = "{\n  \"some\" : \"json\"\n}"
 #endif
-                    XCTAssertEqual(body!, "/**/ testfn(\(expected))")
-                    XCTAssertEqual(response!.headers["Content-Type"]!.first!, "application/javascript")
+                    XCTAssertEqual(body, "/**/ testfn(\(expected))")
+                    XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/javascript")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -771,16 +771,16 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp_encoded?callback=testfn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
                     #if os(Linux)
                         let expected = "{\n  \"some\": \"json with bad js chars \\u2028 \\u2029\"\n}"
                     #else
                         let expected = "{\n  \"some\" : \"json with bad js chars \\u2028 \\u2029\"\n}"
                     #endif
-                    XCTAssertEqual(body!, "/**/ testfn(\(expected))")
-                    XCTAssertEqual(response!.headers["Content-Type"]!.first!, "application/javascript")
+                    XCTAssertEqual(body, "/**/ testfn(\(expected))")
+                    XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/javascript")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -793,10 +793,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/subdomains", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                let hostHeader = response!.headers["Host"]?.first
-                let domainHeader = response!.headers["Domain"]?.first
-                let subdomainsHeader = response!.headers["Subdomain"]?.first
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                let hostHeader = response?.headers["Host"]?.first
+                let domainHeader = response?.headers["Domain"]?.first
+                let subdomainsHeader = response?.headers["Subdomain"]?.first
 
                 XCTAssertEqual(hostHeader, "localhost", "Wrong http response host")
                 XCTAssertEqual(domainHeader, "localhost", "Wrong http response domain")
@@ -808,10 +808,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/subdomains", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                let hostHeader = response!.headers["Host"]?.first
-                let domainHeader = response!.headers["Domain"]?.first
-                let subdomainsHeader = response!.headers["Subdomain"]?.first
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                let hostHeader = response?.headers["Host"]?.first
+                let domainHeader = response?.headers["Domain"]?.first
+                let subdomainsHeader = response?.headers["Subdomain"]?.first
 
                 XCTAssertEqual(hostHeader, "a.b.c.example.com", "Wrong http response host")
                 XCTAssertEqual(domainHeader, "example.com", "Wrong http response domain")
@@ -823,10 +823,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/subdomains", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                let hostHeader = response!.headers["Host"]?.first
-                let domainHeader = response!.headers["Domain"]?.first
-                let subdomainsHeader = response!.headers["Subdomain"]?.first
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                let hostHeader = response?.headers["Host"]?.first
+                let domainHeader = response?.headers["Domain"]?.first
+                let subdomainsHeader = response?.headers["Subdomain"]?.first
 
                 XCTAssertEqual(hostHeader, "a.b.c.d.example.co.uk", "Wrong http response host")
                 XCTAssertEqual(domainHeader, "example.co.uk", "Wrong http response domain")
@@ -840,11 +840,11 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/lifecycle", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertEqual(response!.headers["x-lifecycle"]?.first, "kitura", "Wrong lifecycle header")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.headers["x-lifecycle"]?.first, "kitura", "Wrong lifecycle header")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Filtered</b></body></html>\n\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Filtered</b></body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -857,10 +857,10 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/data", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
                     var body = Data()
-                    _ = try response!.read(into: &body)
+                    _ = try response?.read(into: &body)
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n".data(using: .utf8)!)
                 } catch {
                     XCTFail("No response body")
@@ -872,11 +872,11 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/json", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertEqual(response!.headers["Content-Type"]?.first, "application/json", "Wrong Content-Type header")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/json", "Wrong Content-Type header")
                 do {
                     var body = Data()
-                    _ = try response!.read(into: &body)
+                    _ = try response?.read(into: &body)
                     let json = JSON(data: body)
                     XCTAssertEqual(json["some"], "json")
                 } catch {
@@ -889,11 +889,11 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/download", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertEqual(response!.headers["Content-Type"]?.first, "text/html", "Wrong Content-Type header")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.headers["Content-Type"]?.first, "text/html", "Wrong Content-Type header")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -908,9 +908,9 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/send_after_end", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.forbidden, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.forbidden, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
+                    let body = try response?.readString()
                     XCTAssertEqual(body?.lowercased(), "forbidden<!DOCTYPE html><html><body><b>forbidden</b></body></html>\n\n".lowercased())
                 } catch {
                     XCTFail("No response body")

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -47,27 +47,27 @@ class TestStaticFileServer: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
                 } catch {
                     XCTFail("No response body")
                 }
 
-                XCTAssertEqual(response!.headers["x-custom-header"]!.first!, "Kitura")
-                XCTAssertNotNil(response!.headers["Last-Modified"])
-                XCTAssertNotNil(response!.headers["Etag"])
-                XCTAssertEqual(response!.headers["Cache-Control"]!.first!, "max-age=2")
+                XCTAssertEqual(response?.headers["x-custom-header"]?.first, "Kitura")
+                XCTAssertNotNil(response?.headers["Last-Modified"])
+                XCTAssertNotNil(response?.headers["Etag"])
+                XCTAssertEqual(response?.headers["Cache-Control"]?.first, "max-age=2")
                 expectation.fulfill()
             })
         }, { expectation in
             self.performRequest("get", path:"/qwer/index.html", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -76,10 +76,10 @@ class TestStaticFileServer: KituraTest {
         }, { expectation in
             self.performRequest("get", path:"/qwer/index", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -88,57 +88,57 @@ class TestStaticFileServer: KituraTest {
             }, { expectation in
                 self.performRequest("get", path:"/zxcv/index.html", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                     do {
-                        let body = try response!.readString()
-                        XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
+                        let body = try response?.readString()
+                        XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
                     } catch {
                         XCTFail("No response body")
                     }
-                    XCTAssertNil(response!.headers["x-custom-header"])
-                    XCTAssertNil(response!.headers["Last-Modified"])
-                    XCTAssertNil(response!.headers["Etag"])
-                    XCTAssertEqual(response!.headers["Cache-Control"]!.first!, "max-age=0")
+                    XCTAssertNil(response?.headers["x-custom-header"])
+                    XCTAssertNil(response?.headers["Last-Modified"])
+                    XCTAssertNil(response?.headers["Etag"])
+                    XCTAssertEqual(response?.headers["Cache-Control"]?.first, "max-age=0")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("get", path:"/zxcv", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response!.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("get", path:"/zxcv/index", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response!.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("get", path:"/asdf", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response!.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("put", path:"/asdf", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response!.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("get", path:"/asdf/", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
                     do {
-                        let body = try response!.readString()
-                        XCTAssertEqual(body!, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
+                        let body = try response?.readString()
+                        XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
                     } catch {
                         XCTFail("No response body")
                     }
-                    XCTAssertNil(response!.headers["x-custom-header"])
-                    XCTAssertNotNil(response!.headers["Last-Modified"])
-                    XCTAssertNotNil(response!.headers["Etag"])
-                    XCTAssertEqual(response!.headers["Cache-Control"]!.first!, "max-age=0")
+                    XCTAssertNil(response?.headers["x-custom-header"])
+                    XCTAssertNotNil(response?.headers["Last-Modified"])
+                    XCTAssertNotNil(response?.headers["Etag"])
+                    XCTAssertEqual(response?.headers["Cache-Control"]?.first, "max-age=0")
                     expectation.fulfill()
                 })
         })

--- a/Tests/KituraTests/TestSubrouter.swift
+++ b/Tests/KituraTests/TestSubrouter.swift
@@ -45,12 +45,12 @@ class TestSubrouter: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/sub", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
-                //XCTAssertEqual(response!.method, "GET", "The request wasn't recognized as a get")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
+                //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "hello from the sub")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "hello from the sub")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -60,8 +60,8 @@ class TestSubrouter: KituraTest {
         	self.performRequest("get", path:"/sub/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "sub1")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "sub1")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -76,12 +76,12 @@ class TestSubrouter: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/extern", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
-                //XCTAssertEqual(response!.method, "GET", "The request wasn't recognized as a get")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
+                //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "hello from the sub")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "hello from the sub")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -91,8 +91,8 @@ class TestSubrouter: KituraTest {
             self.performRequest("get", path:"/extern/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "sub1")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "sub1")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -105,12 +105,12 @@ class TestSubrouter: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/sub/sub2", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
-                //XCTAssertEqual(response!.method, "GET", "The request wasn't recognized as a get")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
+                //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "hello from the sub sub")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "hello from the sub sub")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -120,8 +120,8 @@ class TestSubrouter: KituraTest {
             self.performRequest("get", path:"/sub/sub2/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "subsub1")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "subsub1")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -134,12 +134,12 @@ class TestSubrouter: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/middle/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response!.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response!.statusCode)")
-                XCTAssertNotNil(response!.headers["Date"], "There was No Date header in the response")
-                //XCTAssertEqual(response!.method, "GET", "The request wasn't recognized as a get")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
+                //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
-                    let body = try response!.readString()
-                    XCTAssertEqual(body!, "first middle\nsub1last middle\n")
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "first middle\nsub1last middle\n")
                 } catch {
                     XCTFail("No response body")
                 }


### PR DESCRIPTION
## Description
There is a lot of forced unwrapping (mostly response related references) in tests which causes a crash when the test fails and the reference is nil. This causes test execution to terminate and subsequent tests to not be run.

We should be able to fix most of the issues by either just removing the forced unwrapping or replacing it with optional chaining, but may require some additional logic in a few cases.

Also, run all tests with SSL as well now that SSLService has added guards against the race conditions that were crashing SSL tests.

## Motivation and Context
#982
#962
#983 
#959

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
