### PR TITLE
Make sure Response is closed at deinit in case router handlers do not call end() or next()

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -121,6 +121,16 @@ public class RouterResponse {
         statusCode = .unknown
     }
 
+    deinit {
+        if !state.invokedEnd {
+            do {
+                try end()
+            } catch {
+                Log.warning("Error in RouterResponse end(): \(error)")
+            }
+        }
+    }
+
     /// End the response.
     ///
     /// - Throws: Socket.Error if an error occurred while writing to a socket.

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -123,6 +123,10 @@ public class RouterResponse {
 
     deinit {
         if !state.invokedEnd {
+            if !state.invokedSend && statusCode == .unknown {
+                statusCode = .serviceUnavailable
+            }
+
             do {
                 try end()
             } catch {

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -32,6 +32,7 @@ class TestResponse: KituraTest {
     static var allTests: [(String, (TestResponse) -> () throws -> Void)] {
         return [
             ("testSimpleResponse", testSimpleResponse),
+            ("testResponseNoEndOrNext", testResponseNoEndOrNext),
             ("testPostRequest", testPostRequest),
             ("testPostRequestTheHardWay", testPostRequestTheHardWay),
             ("testPostJSONRequest", testPostRequest),
@@ -73,6 +74,22 @@ class TestResponse: KituraTest {
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n")
+                } catch {
+                    XCTFail("No response body")
+                }
+                expectation.fulfill()
+            })
+        }
+    }
+
+    func testResponseNoEndOrNext() {
+        performServerTest(router) { expectation in
+            self.performRequest("get", path:"/noEndOrNext", callback: {response in
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
+                do {
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>noEndOrNext</b></body></html>\n\n")
                 } catch {
                     XCTFail("No response body")
                 }
@@ -948,6 +965,11 @@ class TestResponse: KituraTest {
                 try response.send("<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n").end()
             } catch {}
             next()
+        }
+
+        router.get("/noEndOrNext") { _, response, next in
+            response.headers["Content-Type"] = "text/html; charset=utf-8"
+            response.send("<!DOCTYPE html><html><body><b>noEndOrNext</b></body></html>\n\n")
         }
 
         router.get("/zxcv/:p1") { request, response, next in

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -76,7 +76,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -92,7 +92,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>noEndOrNext</b></body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -106,9 +106,9 @@ class TestResponse: KituraTest {
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
                     let body = try response?.readString()
-                    XCTAssertNil(body)
+                    XCTAssertNil(body, "No body expected, but was received: '\(body!)'")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -125,7 +125,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -143,7 +143,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "Read 13 bytes")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -173,7 +173,7 @@ class TestResponse: KituraTest {
                    let returnedJSON = JSON.parse(string: body)
                    XCTAssertEqual(returnedJSON, jsonToTest)
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }, headers: ["Content-Type": "application/json"]) { req in
@@ -198,7 +198,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received text body: </b>plover\nxyzzy\n</body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -217,7 +217,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -234,7 +234,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -282,7 +282,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "text  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -309,7 +309,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "  text(\"text default\") file1 a.txt text(\"Content of a.txt.\") file2 a.html text(\"<!DOCTYPE html><title>Content of a.html.</title>\") ")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -339,7 +339,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "  text(\"text default\") ")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -360,7 +360,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "Cannot POST /multibodytest.")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             }) {req in
@@ -424,7 +424,7 @@ class TestResponse: KituraTest {
                         "<p>q=\(expectedReturnedQueryParameter)<p>" +
                         "<p>u1=Ploni Almoni</body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -469,7 +469,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertNotNil(body?.range(of: "ibm"), "response does not contain IBM")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -485,7 +485,7 @@ class TestResponse: KituraTest {
                     let errorDescription = "foo is nil"
                     XCTAssertEqual(body, "Caught the error: \(errorDescription)")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -501,7 +501,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "get 1\nget 2\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -513,7 +513,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "post received")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -681,7 +681,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body>Hi from Kitura!</body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
                 }, headers: ["Accept" : "text/html"])
@@ -696,7 +696,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "Hi from Kitura!")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
                 }, headers: ["Accept" : "text/plain"])
@@ -710,7 +710,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "default")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
                 }, headers: ["Accept" : "text/cmd"])
@@ -760,7 +760,7 @@ class TestResponse: KituraTest {
                     XCTAssertEqual(body, "/**/ testfn(\(expected))")
                     XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/javascript")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -796,7 +796,7 @@ class TestResponse: KituraTest {
                     XCTAssertEqual(body, "/**/ testfn(\(expected))")
                     XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/javascript")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -816,7 +816,7 @@ class TestResponse: KituraTest {
                     XCTAssertEqual(body, "/**/ testfn(\(expected))")
                     XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/javascript")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -880,7 +880,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Filtered</b></body></html>\n\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -897,7 +897,7 @@ class TestResponse: KituraTest {
                     _ = try response?.read(into: &body)
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received</b></body></html>\n\n".data(using: .utf8)!)
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -914,7 +914,7 @@ class TestResponse: KituraTest {
                     let json = JSON(data: body)
                     XCTAssertEqual(json["some"], "json")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -929,7 +929,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
 
                 expectation.fulfill()
@@ -947,7 +947,7 @@ class TestResponse: KituraTest {
                     let body = try response?.readString()
                     XCTAssertEqual(body?.lowercased(), "forbidden<!DOCTYPE html><html><body><b>forbidden</b></body></html>\n\n".lowercased())
                 } catch {
-                    XCTFail("No response body")
+                    XCTFail("Error reading body")
                 }
                 expectation.fulfill()
             })
@@ -984,7 +984,7 @@ class TestResponse: KituraTest {
             next()
         }
 
-        router.get("/noEndOrNext") { _, response, next in
+        router.get("/noEndOrNext") { _, response, _ in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             response.send("<!DOCTYPE html><html><body><b>noEndOrNext</b></body></html>\n\n")
         }

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -33,6 +33,7 @@ class TestResponse: KituraTest {
         return [
             ("testSimpleResponse", testSimpleResponse),
             ("testResponseNoEndOrNext", testResponseNoEndOrNext),
+            ("testEmptyHandler", testEmptyHandler),
             ("testPostRequest", testPostRequest),
             ("testPostRequestTheHardWay", testPostRequestTheHardWay),
             ("testPostJSONRequest", testPostRequest),
@@ -90,6 +91,22 @@ class TestResponse: KituraTest {
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>noEndOrNext</b></body></html>\n\n")
+                } catch {
+                    XCTFail("No response body")
+                }
+                expectation.fulfill()
+            })
+        }
+    }
+
+    func testEmptyHandler() {
+        performServerTest(router) { expectation in
+            self.performRequest("get", path:"/emptyHandler", callback: {response in
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.serviceUnavailable, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
+                do {
+                    let body = try response?.readString()
+                    XCTAssertNil(body)
                 } catch {
                     XCTFail("No response body")
                 }
@@ -970,6 +987,9 @@ class TestResponse: KituraTest {
         router.get("/noEndOrNext") { _, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             response.send("<!DOCTYPE html><html><body><b>noEndOrNext</b></body></html>\n\n")
+        }
+
+        router.get("/emptyHandler") { _, _, _ in
         }
 
         router.get("/zxcv/:p1") { request, response, next in


### PR DESCRIPTION
## Description
Kitura Router.handle() calls `response.end()` in case none of the handlers call it, but this is dependent on the route handlers calling next(). Check and ensure RouterResponse end() has been invoked in it's deinitialization so we always end the response when we are done with it.

## Motivation and Context
#1009 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
