### PR TITLE
Unify query string parsing for 'RouterRequest' and 'BodyParser'

### DIFF
--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -139,7 +139,7 @@ public class RouterRequest {
 
     /// List of query parameters.
     public lazy var queryParameters: [String:String] = { [unowned self] in
-        return self.urlURL.query?.asUrlEncoded ?? [:]
+        return self.urlURL.query?.urlDecodedFieldValuePairs ?? [:]
     }()
 
     /// User info.

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -139,26 +139,8 @@ public class RouterRequest {
 
     /// List of query parameters.
     public lazy var queryParameters: [String:String] = { [unowned self] in
-        var decodedParameters: [String:String] = [:]
-        if let query = self.urlURL.query {
-            for item in query.components(separatedBy: "&") {
-                guard let range = item.range(of: "=") else {
-                    decodedParameters[item] = nil
-                    break
-                }
-                let key = item.substring(to: range.lowerBound)
-                let value = item.substring(from: range.upperBound)
-                let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
-                if let decodedValue = valueReplacingPlus.removingPercentEncoding {
-                    decodedParameters[key] = decodedValue
-                } else {
-                    Log.warning("Unable to decode query parameter \(key)")
-                    decodedParameters[key] = valueReplacingPlus
-                }
-            }
-        }
-        return decodedParameters
-        }()
+        return self.urlURL.query?.asUrlEncoded ?? [:]
+    }()
 
     /// User info.
     public var userInfo: [String: Any] = [:]

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import LoggerAPI
+
+extension String {
+    
+    var asUrlEncoded: [String : String] {
+        var decodedParameters: [String:String] = [:]
+        
+        for item in self.components(separatedBy: "&") {
+            guard let range = item.range(of: "=") else {
+                continue
+            }
+            
+            let key = item.substring(to: range.lowerBound)
+            let value = item.substring(from: range.upperBound)
+            let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
+            if let decodedValue = valueReplacingPlus.removingPercentEncoding {
+                decodedParameters[key] = decodedValue
+            } else {
+                Log.warning("Unable to decode query parameter \(key)")
+                decodedParameters[key] = valueReplacingPlus
+            }
+        }
+        
+        return decodedParameters
+    }
+}

--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -20,11 +20,12 @@ import LoggerAPI
 extension String {
     
     /// Parses percent encoded string into query parameters
-    var asUrlEncoded: [String : String] {
+    var urlDecodedFieldValuePairs: [String : String] {
         var result: [String:String] = [:]
         
         for item in self.components(separatedBy: "&") {
             guard let range = item.range(of: "=") else {
+                result[item] = nil
                 continue
             }
             

--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -19,8 +19,9 @@ import LoggerAPI
 
 extension String {
     
+    /// Parses percent encoded string into query parameters
     var asUrlEncoded: [String : String] {
-        var decodedParameters: [String:String] = [:]
+        var result: [String:String] = [:]
         
         for item in self.components(separatedBy: "&") {
             guard let range = item.range(of: "=") else {
@@ -31,13 +32,13 @@ extension String {
             let value = item.substring(from: range.upperBound)
             let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
             if let decodedValue = valueReplacingPlus.removingPercentEncoding {
-                decodedParameters[key] = decodedValue
+                result[key] = decodedValue
             } else {
                 Log.warning("Unable to decode query parameter \(key)")
-                decodedParameters[key] = valueReplacingPlus
+                result[key] = valueReplacingPlus
             }
         }
         
-        return decodedParameters
+        return result
     }
 }

--- a/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
+++ b/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
@@ -22,7 +22,7 @@ class URLEncodedBodyParser: BodyParserProtocol {
             return nil
         }
         
-        let parsedBody = bodyAsString.asUrlEncoded
+        let parsedBody = bodyAsString.urlDecodedFieldValuePairs
         return parsedBody.count > 0 ? .urlEncoded(parsedBody) : nil
     }
 }

--- a/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
+++ b/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
@@ -18,25 +18,11 @@ import Foundation
 
 class URLEncodedBodyParser: BodyParserProtocol {
     func parse(_ data: Data) -> ParsedBody? {
-        var parsedBody = [String:String]()
-        var success = true
-        let bodyAsString = String(data: data as Data, encoding: .utf8)
-
-        if let bodyAsString = bodyAsString {
-            let bodyAsArray = bodyAsString.components(separatedBy: "&")
-
-            for element in bodyAsArray {
-                let elementPair = element.components(separatedBy: "=")
-                if elementPair.count == 2 {
-                    parsedBody[elementPair[0]] = elementPair[1]
-                } else {
-                    success = false
-                }
-            }
-            if success && parsedBody.count > 0 {
-                return .urlEncoded(parsedBody)
-            }
+        guard let bodyAsString = String(data: data, encoding: .utf8) else {
+            return nil
         }
-        return nil
+        
+        let parsedBody = bodyAsString.asUrlEncoded
+        return parsedBody.count > 0 ? .urlEncoded(parsedBody) : nil
     }
 }

--- a/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
+++ b/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrects `URLEncodedBodyParser` dictionary parsing and provides correct representation of query parameter values for `.urlEncoded(...)` body.
Implementing `String` extension `. asUrlEncoded` make a single entry point for `url-encoded` parameters parsing.

## How Has This Been Tested?
I didn't add any new tests. 
Existing test that uses `.queryParameters` and `.urlEncoded(...)` body should cover this changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.