### PR TITLE
IBM-Swift/Kitura#1016 Add unregister Bool parameter to Kitura.stop()

### DIFF
--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -98,22 +98,25 @@ public class Kitura {
     ///
     /// Make all registered servers stop listening on their port.
     ///
-    /// - note: All of the registered servers are unregistered after they are stopped.
-    public class func stop() {
+    /// - Parameter unregister: If servers should be unregistered after stopped (default true).
+    public class func stop(unregister: Bool = true) {
         for (server, port) in httpServersAndPorts {
             Log.verbose("Stopping HTTP Server on port \(port)...")
             server.stop()
         }
-        httpServersAndPorts.removeAll()
+
         for (server, port) in fastCGIServersAndPorts {
             Log.verbose("Stopping FastCGI Server on port \(port)...")
             server.stop()
         }
-        fastCGIServersAndPorts.removeAll()
+
+        if unregister {
+            httpServersAndPorts.removeAll()
+            fastCGIServersAndPorts.removeAll()
+        }
     }
 
     typealias Port = Int
-    private static var httpServersAndPorts = [(server: HTTPServer, port: Port)]()
-    private static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port)]()
-
+    internal private(set) static var httpServersAndPorts = [(server: HTTPServer, port: Port)]()
+    internal private(set) static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port)]()
 }

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -147,8 +147,12 @@ class KituraTest: XCTestCase {
         KituraTest.httpsServer = nil
     }
 
-    func performRequest(_ method: String, path: String, callback: @escaping ClientRequest.Callback,
-                        headers: [String: String]? = nil, requestModifier: ((ClientRequest) -> Void)? = nil) {
+    func performRequest(_ method: String, path: String, port: Int? = nil, useSSL: Bool? = nil,
+                        callback: @escaping ClientRequest.Callback, headers: [String: String]? = nil,
+                        requestModifier: ((ClientRequest) -> Void)? = nil) {
+
+        let port = Int16(port ?? self.port)
+        let useSSL = useSSL ?? self.useSSL
 
         var allHeaders = [String: String]()
         if  let headers = headers {
@@ -160,11 +164,11 @@ class KituraTest: XCTestCase {
             allHeaders["Content-Type"] = "text/plain"
         }
 
-        let schema = self.useSSL ? "https" : "http"
+        let schema = useSSL ? "https" : "http"
         var options: [ClientRequest.Options] =
-                [.method(method), .schema(schema), .hostname("localhost"), .port(Int16(self.port)), .path(path),
+                [.method(method), .schema(schema), .hostname("localhost"), .port(port), .path(path),
                  .headers(allHeaders)]
-        if self.useSSL {
+        if useSSL {
             options.append(.disableSSLVerification)
         }
 

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -18,7 +18,7 @@ import XCTest
 import Dispatch
 
 import KituraNet
-import Kitura
+@testable import Kitura
 
 class TestServer: KituraTest {
 
@@ -26,7 +26,8 @@ class TestServer: KituraTest {
         return [
             ("testServerStartStop", testServerStartStop),
             ("testServerRun", testServerRun),
-            ("testServerFail", testServerFail)
+            ("testServerFail", testServerFail),
+            ("testServerRestart", testServerRestart)
         ]
     }
 
@@ -148,5 +149,58 @@ class TestServer: KituraTest {
         } catch {
             XCTFail("Unexpected error starting server: \(error)")
         }
+    }
+
+    func testServerRestart() {
+        let port = httpPort
+        let path = "/testServerRestart"
+        let body = "Server is running."
+
+        let router = Router()
+        router.get(path) { _, response, next in
+            response.send(body)
+            next()
+        }
+        Kitura.addHTTPServer(onPort: port, with: router)
+
+        let server = Kitura.httpServersAndPorts[0].server
+        server.sslConfig = KituraTest.sslConfig.config
+
+        let stopped = DispatchSemaphore(value: 0)
+        server.stopped {
+            stopped.signal()
+        }
+
+        testResponse(port: port, path: path, expectedBody: nil, expectedStatus: nil)
+
+        Kitura.start()
+        testResponse(port: port, path: path, expectedBody: body)
+        Kitura.stop(unregister: false)
+        stopped.wait()
+
+        testResponse(port: port, path: path, expectedBody: nil, expectedStatus: nil)
+
+        Kitura.start()
+        testResponse(port: port, path: path, expectedBody: body)
+        Kitura.stop(unregister: true)
+        stopped.wait()
+
+        Kitura.start() // should be no servers to start as we just unregistered them
+        testResponse(port: port, path: path, expectedBody: nil, expectedStatus: nil)
+        Kitura.stop()
+    }
+
+    private func testResponse(port: Int, method: String = "get", path: String, expectedBody: String?, expectedStatus: HTTPStatusCode? = HTTPStatusCode.OK) {
+
+        performRequest(method, path: path, port: port, useSSL: true, callback: { response in
+            let status = response?.statusCode
+            XCTAssertEqual(status, expectedStatus, "status was \(status), expected \(expectedStatus)")
+            do {
+                let body = try response?.readString()
+                XCTAssertEqual(body, expectedBody, "body was '\(body)', expected '\(expectedBody)'")
+            } catch {
+                XCTFail("Error reading body: \(error)")
+            }
+        })
     }
 }


### PR DESCRIPTION
I can push the API doc changes once this is ready to merge.

## Description
- Add unregister Bool parameter to Kitura.stop() that defaults to true to maintain current behavior.
- Add relevant tests.

## Motivation and Context
#1016

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
