### PR TITLE
Conditional Swift 3.1 support

### DIFF
--- a/Sources/Kitura/JSONPError.swift
+++ b/Sources/Kitura/JSONPError.swift
@@ -31,7 +31,7 @@ extension JSONPError: CustomStringConvertible {
     public var description: String {
         switch self {
         case .invalidCallbackName(let name):
-            return "Invalid callback name \(name)"
+            return "Invalid callback name \(String(describing: name))"
         }
     }
 }

--- a/Sources/Kitura/RouteRegex.swift
+++ b/Sources/Kitura/RouteRegex.swift
@@ -21,7 +21,11 @@ import Foundation
 // MARK RouteRegex
 
 #if os(Linux)
-    typealias RegularExpressionType = RegularExpression
+    #if swift(>=3.1)
+        typealias RegularExpressionType = NSRegularExpression
+    #else
+        typealias RegularExpressionType = RegularExpression
+    #endif
 #else
     typealias RegularExpressionType = NSRegularExpression
 #endif

--- a/Sources/Kitura/RouterElement.swift
+++ b/Sources/Kitura/RouterElement.swift
@@ -30,7 +30,11 @@ class RouterElement {
 
     /// The regular expression
     #if os(Linux)
-        private var regex: RegularExpression?
+        #if swift(>=3.1)
+            private var regex: NSRegularExpression?
+        #else
+            private var regex: RegularExpression?
+        #endif
     #else
         private var regex: NSRegularExpression?
     #endif

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -138,7 +138,6 @@ public class RouterResponse {
     /// End the response.
     ///
     /// - Throws: Socket.Error if an error occurred while writing to a socket.
-    @discardableResult
     public func end() throws {
         guard !state.invokedEnd else {
             Log.warning("RouterResponse end() invoked more than once for \(self.request.urlURL)")

--- a/Tests/KituraTests/MiscellaneousTests.swift
+++ b/Tests/KituraTests/MiscellaneousTests.swift
@@ -40,11 +40,11 @@ class MiscellaneousTests: KituraTest {
         switch key {
         case "kitura":
             XCTAssertNotNil(value, "Value for the header kitura was nil")
-            XCTAssertEqual(value, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(value)")
+            XCTAssertEqual(value, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(String(describing: value))")
             firstKeyWasKitura = true
         case "plover":
             XCTAssertNotNil(value, "Value for the header plover was nil")
-            XCTAssertEqual(value, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(value)")
+            XCTAssertEqual(value, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(String(describing: value))")
             firstKeyWasKitura = false
         default:
             firstKeyWasKitura = false
@@ -59,11 +59,11 @@ class MiscellaneousTests: KituraTest {
         case "kitura":
             XCTAssertFalse(firstKeyWasKitura, "Second key was kitura, it should not have been")
             XCTAssertNotNil(value, "Value for the header kitura was nil")
-            XCTAssertEqual(value, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(value)")
+            XCTAssertEqual(value, "The greatest", "The value for the kitura header wasn't \"The greatest\". It was \(String(describing: value))")
         case "plover":
             XCTAssertTrue(firstKeyWasKitura, "The first key should have been kitura")
             XCTAssertNotNil(value, "Value for the header plover was nil")
-            XCTAssertEqual(value, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(value)")
+            XCTAssertEqual(value, "xyzzy", "The value for the plover header wasn't \"xyzzy\". It was \(String(describing: value))")
         default:
             XCTFail("The header key was neither kitura nor plover, it was \(key)")
         }
@@ -75,30 +75,30 @@ class MiscellaneousTests: KituraTest {
         headers.setLocation("back")   // Without referrer set
         var location = headers["Location"]
         XCTAssertNotNil(location, "Location header wasn't set")
-        XCTAssertEqual(location, "/", "Location header should have been /, it was \(location)")
+        XCTAssertEqual(location, "/", "Location header should have been /, it was \(String(describing: location))")
 
         let referrer = "http://plover.com/xyzzy"
         headers["referrer"] = referrer
         headers.setLocation("back")   // With referrer set
         location = headers["Location"]
-        XCTAssertEqual(location, referrer, "Location header should have been \(referrer), it was \(location)")
+        XCTAssertEqual(location, referrer, "Location header should have been \(referrer), it was \(String(describing: location))")
 
         headers.setType("html", charset: "UTF-8")
         let contentType = headers["Content-Type"]
         XCTAssertNotNil(contentType, "Content-Type header wasn't set")
         let expectedContentType = "text/html; charset=UTF-8"
-        XCTAssertEqual(contentType, expectedContentType, "Content-Type header should have been \(expectedContentType), it was \(contentType)")
+        XCTAssertEqual(contentType, expectedContentType, "Content-Type header should have been \(expectedContentType), it was \(String(describing: contentType))")
 
         var contentDispostion = headers["Content-Disposition"]
         XCTAssertNil(contentDispostion, "Content-Disposition shouldn't have been set yet")
 
         headers.addAttachment(for: "")
         contentDispostion = headers["Content-Disposition"]
-        XCTAssertNil(contentDispostion, "Content-Disposition shouldn't have been set. It's value is \(contentDispostion)")
+        XCTAssertNil(contentDispostion, "Content-Disposition shouldn't have been set. It's value is \(String(describing: contentDispostion))")
 
         headers.addAttachment()
         contentDispostion = headers["Content-Disposition"]
         XCTAssertNotNil(contentDispostion, "Content-Disposition should have been set.")
-        XCTAssertEqual(contentDispostion, "attachment", "Content-Disposition should have the value attachment. It has the value \(contentDispostion)")
+        XCTAssertEqual(contentDispostion, "attachment", "Content-Disposition should have the value attachment. It has the value \(String(describing: contentDispostion))")
     }
 }

--- a/Tests/KituraTests/TestErrors.swift
+++ b/Tests/KituraTests/TestErrors.swift
@@ -43,7 +43,7 @@ class TestErrors: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("invalid", path: "/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
             })
         }, { expectation in
@@ -57,7 +57,7 @@ class TestErrors: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/notreal", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
             })
         }

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -48,7 +48,7 @@ class TestRequests: KituraTest {
         }
         router.get("/zxcv/ploni") { request, _, next in
             let parameter = request.parameters["p1"]
-            XCTAssertNil(parameter, "URL parameter p1 was not nil, it's value was \(parameter)")
+            XCTAssertNil(parameter, "URL parameter p1 was not nil, it's value was \(String(describing: parameter))")
             next()
         }
         router.all() { _, response, next in

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -69,7 +69,7 @@ class TestResponse: KituraTest {
     	performServerTest(router) { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
@@ -86,7 +86,7 @@ class TestResponse: KituraTest {
     func testResponseNoEndOrNext() {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/noEndOrNext", callback: {response in
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
                     let body = try response?.readString()
@@ -102,7 +102,7 @@ class TestResponse: KituraTest {
     func testEmptyHandler() {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/emptyHandler", callback: {response in
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.serviceUnavailable, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.serviceUnavailable, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
                     let body = try response?.readString()
@@ -496,7 +496,7 @@ class TestResponse: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/route", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "get 1\nget 2\n")
@@ -508,7 +508,7 @@ class TestResponse: KituraTest {
         }, { expectation in
             self.performRequest("post", path: "/route", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "post received")
@@ -675,7 +675,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/format", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertEqual(response?.headers["Content-Type"]?.first, "text/html")
                 do {
                     let body = try response?.readString()
@@ -690,7 +690,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/format", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertEqual(response?.headers["Content-Type"]?.first, "text/plain")
                 do {
                     let body = try response?.readString()
@@ -705,7 +705,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/format", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "default")
@@ -722,7 +722,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/single_link", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 let header = response?.headers["Link"]?.first
                 XCTAssertNotNil(header, "Link header should not be nil")
                 XCTAssertEqual(header, "<https://developer.ibm.com/swift>; rel=\"root\"")
@@ -733,7 +733,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/multiple_links", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 let firstLink = "<https://developer.ibm.com/swift/products/ibm-swift-sandbox/>; rel=\"next\""
                 let secondLink = "<https://developer.ibm.com/swift/products/ibm-bluemix/>; rel=\"prev\""
                 let header = response?.headers["Link"]?.first
@@ -749,7 +749,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp?callback=testfn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
 #if os(Linux)
@@ -769,7 +769,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp?callback=test+fn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
             })
         }
@@ -777,7 +777,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(String(describing: response?.statusCode))")
                 expectation.fulfill()
             })
         }
@@ -785,7 +785,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp_cb?cb=testfn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
 #if os(Linux)
@@ -805,7 +805,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/jsonp_encoded?callback=testfn", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     #if os(Linux)
@@ -827,7 +827,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/subdomains", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 let hostHeader = response?.headers["Host"]?.first
                 let domainHeader = response?.headers["Domain"]?.first
                 let subdomainsHeader = response?.headers["Subdomain"]?.first
@@ -842,7 +842,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/subdomains", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 let hostHeader = response?.headers["Host"]?.first
                 let domainHeader = response?.headers["Domain"]?.first
                 let subdomainsHeader = response?.headers["Subdomain"]?.first
@@ -857,7 +857,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/subdomains", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 let hostHeader = response?.headers["Host"]?.first
                 let domainHeader = response?.headers["Domain"]?.first
                 let subdomainsHeader = response?.headers["Subdomain"]?.first
@@ -874,7 +874,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/lifecycle", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertEqual(response?.headers["x-lifecycle"]?.first, "kitura", "Wrong lifecycle header")
                 do {
                     let body = try response?.readString()
@@ -891,7 +891,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/data", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     var body = Data()
                     _ = try response?.read(into: &body)
@@ -906,7 +906,7 @@ class TestResponse: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path: "/json", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/json", "Wrong Content-Type header")
                 do {
                     var body = Data()
@@ -922,7 +922,7 @@ class TestResponse: KituraTest {
         { expectation in
             self.performRequest("get", path: "/jsonDictionary", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/json", "Wrong Content-Type header")
                 do {
                     var body = Data()
@@ -938,7 +938,7 @@ class TestResponse: KituraTest {
         { expectation in
             self.performRequest("get", path: "/jsonArray", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertEqual(response?.headers["Content-Type"]?.first, "application/json", "Wrong Content-Type header")
                 do {
                     var body = Data()
@@ -955,7 +955,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/download", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertEqual(response?.headers["Content-Type"]?.first, "text/html", "Wrong Content-Type header")
                 do {
                     let body = try response?.readString()
@@ -974,7 +974,7 @@ class TestResponse: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path: "/send_after_end", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.forbidden, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.forbidden, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body?.lowercased(), "forbidden<!DOCTYPE html><html><body><b>forbidden</b></body></html>\n\n".lowercased())
@@ -1103,7 +1103,7 @@ class TestResponse: KituraTest {
                 _ = response.send("length: \(length)")
                 next()
             } else {
-                response.error = Error.failedToParseRequestBody(body: "\(request.body)")
+                response.error = Error.failedToParseRequestBody(body: "\(String(describing: request.body))")
             }
 
             next()
@@ -1131,7 +1131,7 @@ class TestResponse: KituraTest {
                 return
             }
             guard let parts = body.asMultiPart else {
-                response.error = Error.failedToParseRequestBody(body: "\(request.body)")
+                response.error = Error.failedToParseRequestBody(body: "\(String(describing: request.body))")
                 next ()
                 return
             }

--- a/Tests/KituraTests/TestRouteRegex.swift
+++ b/Tests/KituraTests/TestRouteRegex.swift
@@ -64,7 +64,11 @@ class TestRouteRegex: KituraTest {
 
     func testBuildRegexFromPattern() {
         #if os(Linux)
-            var regex: RegularExpression?
+            #if swift(>=3.1)
+                var regex: NSRegularExpression?
+            #else
+                var regex: RegularExpression?
+            #endif
         #else
             var regex: NSRegularExpression?
         #endif

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -189,10 +189,10 @@ class TestServer: KituraTest {
 
         performRequest(method, path: path, port: port, useSSL: true, callback: { response in
             let status = response?.statusCode
-            XCTAssertEqual(status, expectedStatus, "status was \(status), expected \(expectedStatus)")
+            XCTAssertEqual(status, expectedStatus, "status was \(String(describing: status)), expected \(String(describing: expectedStatus))")
             do {
                 let body = try response?.readString()
-                XCTAssertEqual(body, expectedBody, "body was '\(body)', expected '\(expectedBody)'")
+                XCTAssertEqual(body, expectedBody, "body was '\(String(describing: body))', expected '\(String(describing: expectedBody))'")
             } catch {
                 XCTFail("Error reading body: \(error)")
             }

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -47,7 +47,7 @@ class TestStaticFileServer: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
@@ -64,7 +64,7 @@ class TestStaticFileServer: KituraTest {
         }, { expectation in
             self.performRequest("get", path:"/qwer/index.html", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
@@ -76,7 +76,7 @@ class TestStaticFileServer: KituraTest {
         }, { expectation in
             self.performRequest("get", path:"/qwer/index", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 do {
                     let body = try response?.readString()
                     XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
@@ -88,7 +88,7 @@ class TestStaticFileServer: KituraTest {
             }, { expectation in
                 self.performRequest("get", path:"/zxcv/index.html", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                     do {
                         let body = try response?.readString()
                         XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")
@@ -104,31 +104,31 @@ class TestStaticFileServer: KituraTest {
             }, { expectation in
                 self.performRequest("get", path:"/zxcv", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(String(describing: response?.statusCode))")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("get", path:"/zxcv/index", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(String(describing: response?.statusCode))")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("get", path:"/asdf", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(String(describing: response?.statusCode))")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("put", path:"/asdf", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(response?.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(String(describing:response?.statusCode))")
                     expectation.fulfill()
                 })
             }, { expectation in
                 self.performRequest("get", path:"/asdf/", callback: {response in
                     XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                    XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                     do {
                         let body = try response?.readString()
                         XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Index</b></body></html>\n")

--- a/Tests/KituraTests/TestSubrouter.swift
+++ b/Tests/KituraTests/TestSubrouter.swift
@@ -45,7 +45,7 @@ class TestSubrouter: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/sub", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
@@ -76,7 +76,7 @@ class TestSubrouter: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/extern", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
@@ -105,7 +105,7 @@ class TestSubrouter: KituraTest {
         performServerTest(router, asyncTasks: { expectation in
             self.performRequest("get", path:"/sub/sub2", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {
@@ -134,7 +134,7 @@ class TestSubrouter: KituraTest {
         performServerTest(router) { expectation in
             self.performRequest("get", path:"/middle/sub1", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(response?.statusCode)")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 //XCTAssertEqual(response?.method, "GET", "The request wasn't recognized as a get")
                 do {


### PR DESCRIPTION
This will let this code compile and run (without warnings) on both swift 3.0.2 and 3.1 (March 15h snapshot).

We can remove this once we start requiring Swift 3.1, but this makes it easier for us to take our time to cut the latest tag once Xcode 8.3 is released.

We can take this or ignore it, but it might make our lives easier.