### PR TITLE
Test large gets and posts on SSL and non-SSL

### DIFF
--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -69,22 +69,22 @@ class KituraTest: XCTestCase {
         KituraTest.initOnce
     }
 
-    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both,
+    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
                            line: Int = #line, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
         if sslOption != SSLOption.httpsOnly {
             self.port = KituraTest.httpPort
             self.useSSL = false
-            doPerformServerTest(router: router, line: line, asyncTasks: asyncTasks)
+            doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
         }
 
         if sslOption != SSLOption.httpOnly {
             self.port = KituraTest.httpsPort
             self.useSSL = true
-            doPerformServerTest(router: router, line: line, asyncTasks: asyncTasks)
+            doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
         }
     }
 
-    func doPerformServerTest(router: ServerDelegate, line: Int, asyncTasks: [(XCTestExpectation) -> Void]) {
+    func doPerformServerTest(router: ServerDelegate, timeout: TimeInterval, line: Int, asyncTasks: [(XCTestExpectation) -> Void]) {
 
         guard startServer(router: router) else {
             XCTFail("Error starting server on port \(port). useSSL:\(useSSL)")
@@ -100,7 +100,7 @@ class KituraTest: XCTestCase {
         }
 
         // wait for timeout or for all created expectations to be fulfilled
-        waitForExpectations(timeout: 10) { error in
+        waitForExpectations(timeout: timeout) { error in
             XCTAssertNil(error)
         }
     }

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -86,7 +86,7 @@ class TestResponse: KituraTest {
     }
 
     func testLargeGet() {
-        performServerTest(router) { expectation in
+        performServerTest(router, timeout: 30) { expectation in
             let uint8 = UInt8.max
             let count = 1024 * 1024
 
@@ -109,7 +109,7 @@ class TestResponse: KituraTest {
     }
 
     func testLargePost() {
-        performServerTest(router) { expectation in
+        performServerTest(router, timeout: 30) { expectation in
             let count = 1024 * 1024
             let postData = Data(repeating: UInt8.max, count: count)
 

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -32,6 +32,8 @@ class TestResponse: KituraTest {
     static var allTests: [(String, (TestResponse) -> () throws -> Void)] {
         return [
             ("testSimpleResponse", testSimpleResponse),
+            ("testLargeGet", testLargeGet),
+            ("testLargePost", testLargePost),
             ("testResponseNoEndOrNext", testResponseNoEndOrNext),
             ("testEmptyHandler", testEmptyHandler),
             ("testPostRequest", testPostRequest),
@@ -79,6 +81,54 @@ class TestResponse: KituraTest {
                     XCTFail("Error reading body")
                 }
                 expectation.fulfill()
+            })
+        }
+    }
+
+    func testLargeGet() {
+        performServerTest(router) { expectation in
+            let uint8 = UInt8.max
+            let count = 1024 * 1024
+
+            self.performRequest("get", path:"/largeGet?uint8=\(uint8)&count=\(count)", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
+
+                do {
+                    var data = Data(capacity: count/32)
+                    let length = try response?.readAllData(into: &data)
+                    XCTAssertEqual(length, count, "Expected \(count) bytes, received \(String(describing: length)).")
+                    XCTAssertEqual(data, Data(repeating: uint8, count: count), "Received data different from expected data")
+                } catch {
+                    XCTFail("Error reading body")
+                }
+
+                expectation.fulfill()
+            })
+        }
+    }
+
+    func testLargePost() {
+        performServerTest(router) { expectation in
+            let count = 1024 * 1024
+            let postData = Data(repeating: UInt8.max, count: count)
+
+            self.performRequest("post", path: "/largePost", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
+
+                do {
+                    var data = Data(capacity: count/32)
+                    let length = try response?.readAllData(into: &data)
+                    XCTAssertEqual(length, count, "Expected \(count) bytes, received \(String(describing: length)).")
+                    XCTAssertEqual(data, postData, "Received data different from posted data")
+                } catch {
+                    XCTFail("Error reading body")
+                }
+
+                expectation.fulfill()
+            }, requestModifier: { request in
+                request.write(from: postData)
             })
         }
     }
@@ -1016,6 +1066,29 @@ class TestResponse: KituraTest {
                 XCTFail("Error sending response. Error=\(error.localizedDescription)")
             }
             next()
+        }
+
+        router.get("/largeGet") { request, response, _ in
+            do {
+                let uint8 = UInt8(request.queryParameters["uint8"] ?? "NA")
+                let count = Int(request.queryParameters["count"] ?? "NA")
+                if let uint8 = uint8, let count = count {
+                    response.send(data: Data(repeating: uint8, count: count))
+                }
+                try response.end()
+            } catch {
+                XCTFail("Error sending response. Error=\(error.localizedDescription)")
+            }
+        }
+
+        router.post("/largePost") { request, response, _ in
+            do {
+                var data = Data()
+                let count = try request.read(into: &data)
+                try response.send(data: data).end()
+            } catch {
+                XCTFail("Error sending response. Error=\(error.localizedDescription)")
+            }
         }
 
         router.get("/noEndOrNext") { _, response, _ in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Large gets and posts on SSL were failing due to various bugs in SSLService and Socket which have now been fixed. These tests add coverage for those issues.

## Motivation and Context
IBM-Swift/BlueSSLService#20
IBM-Swift/BlueSSLService#21
IBM-Swift/BlueSSLService#22

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
