### PR TITLE
Add a check for Kitura being under .build/checkouts

### DIFF
--- a/Sources/Kitura/FileResourceServer.swift
+++ b/Sources/Kitura/FileResourceServer.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,13 +68,15 @@ class FileResourceServer {
 
     private func getResourcePathBasedOnCurrentDirectory(for resource: String, withFileManager fileManager: FileManager) -> String? {
         do {
-            let packagePath = fileManager.currentDirectoryPath + "/Packages"
-            let packages = try fileManager.contentsOfDirectory(atPath: packagePath)
-            for package in packages {
-                let potentialResource = "\(packagePath)/\(package)/Sources/Kitura/resources/\(resource)"
-                let resourceExists = fileManager.fileExists(atPath: potentialResource)
-                if resourceExists {
-                    return potentialResource
+            for suffix in ["/Packages", "/.build/checkouts"] {
+                let packagePath = fileManager.currentDirectoryPath + suffix
+                let packages = try fileManager.contentsOfDirectory(atPath: packagePath)
+                for package in packages {
+                    let potentialResource = "\(packagePath)/\(package)/Sources/Kitura/resources/\(resource)"
+                    let resourceExists = fileManager.fileExists(atPath: potentialResource)
+                    if resourceExists {
+                        return potentialResource
+                    }
                 }
             }
         } catch {

--- a/Sources/Kitura/staticFileServer/ResourcePathHandler.swift
+++ b/Sources/Kitura/staticFileServer/ResourcePathHandler.swift
@@ -1,5 +1,6 @@
+
 /*
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016, 2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,11 +77,20 @@ extension StaticFileServer {
 
         static private func removePackagesDirectory(pathComponents: [String]) -> [String] {
             var pathComponents = pathComponents
-            let numberOfComponentsFromKituraPackageToDependentRepository = 2
+            let numberOfComponentsFromKituraPackageToDependentRepository = 3
             let packagesComponentIndex = pathComponents.endIndex - numberOfComponentsFromKituraPackageToDependentRepository
             if pathComponents.count > numberOfComponentsFromKituraPackageToDependentRepository &&
-                 pathComponents[packagesComponentIndex] == "Packages" {
+                pathComponents[packagesComponentIndex] == ".build"  &&
+                pathComponents[packagesComponentIndex+1] == "checkouts" {
                 pathComponents.removeLast(numberOfComponentsFromKituraPackageToDependentRepository)
+            }
+            else {
+                let numberOfComponentsFromEditableKituraPackageToDependentRepository = 2
+                let editablePackagesComponentIndex = pathComponents.endIndex - numberOfComponentsFromEditableKituraPackageToDependentRepository
+                if pathComponents.count > numberOfComponentsFromEditableKituraPackageToDependentRepository &&
+                    pathComponents[editablePackagesComponentIndex] == "Packages" {
+                    pathComponents.removeLast(numberOfComponentsFromEditableKituraPackageToDependentRepository)
+                }
             }
             return pathComponents
         }


### PR DESCRIPTION
## Description
Two changes have been made:

  1. In the code for the StaticServer middleware add a check for the Kitura repository being under .build/checkouts in addition to possibly being under Packages. These checks are done to find the root of the original repository, when the current directory at execution time is something different.

  2. In the code that serves the "landing page", there is code that searches for the resources dircetory which is primarily used when running on Bluemix. In this code a check was added to include looking for the Kitura resources directory under .build/checkouts as well as Packages.

## Motivation and Context
Swift 3.1 by default checks out dependent repositories under ./.build/checkouts. However if one does a `swift package edit .....` on a dependent repository, that repository would be under Packages.

## How Has This Been Tested?
The unit tests of both Kitura and Kitura-Sample have been both run.

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
