### PR TITLE
Set statusCode on invokedSend

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -26,12 +26,20 @@ import LoggerAPI
 public class RouterResponse {
 
     struct State {
+        weak var response: RouterResponse?
 
         /// Whether the response has ended
         var invokedEnd = false
 
         /// Whether data has been added to buffer
-        var invokedSend = false
+        var invokedSend = false {
+            didSet {
+                if invokedSend && response?.statusCode == .unknown {
+                    // change statusCode to .OK
+                    response?.statusCode = .OK
+                }
+            }
+        }
     }
 
     /// A set of functions called during the life cycle of a Request.
@@ -119,6 +127,7 @@ public class RouterResponse {
         self.request = request
         headers = Headers(headers: response.headers)
         statusCode = .unknown
+        state.response = self
     }
 
     deinit {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For #1057

## Description
<!--- Describe your changes in detail -->
Set `statusCode` to `OK` if:
1. `invokedSend` is set to `true`, AND
2. `statusCode` is currently `unknown`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See issue for motivation and context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new test case.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
