### PR TITLE
Serve static content

### DIFF
--- a/Sources/Kitura/FileResourceServer.swift
+++ b/Sources/Kitura/FileResourceServer.swift
@@ -67,9 +67,9 @@ class FileResourceServer {
     }
 
     private func getResourcePathBasedOnCurrentDirectory(for resource: String, withFileManager fileManager: FileManager) -> String? {
-        do {
-            for suffix in ["/Packages", "/.build/checkouts"] {
-                let packagePath = fileManager.currentDirectoryPath + suffix
+        for suffix in ["/Packages", "/.build/checkouts"] {
+            let packagePath = fileManager.currentDirectoryPath + suffix
+            do {
                 let packages = try fileManager.contentsOfDirectory(atPath: packagePath)
                 for package in packages {
                     let potentialResource = "\(packagePath)/\(package)/Sources/Kitura/resources/\(resource)"
@@ -78,9 +78,9 @@ class FileResourceServer {
                         return potentialResource
                     }
                 }
+            } catch {
+              Log.error("No packages found in \(packagePath)")
             }
-        } catch {
-            return nil
         }
         return nil
     }


### PR DESCRIPTION
<!---  -->
Fixes Broken index.html in Bluemix
## Description
<!--- Describe your changes in detail -->
This change fixes a problem serving the static index.html file in applications running in Bluemix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the release of **Swift 3.1**, the `Packages` directory is no longer included, and for backwards compatibility it now checks in both `Packages` and `.build/checkouts` in order to locate the index file.  With the `.build` directory no longer being removed, the file should have been found, but error caused by the missing `Packages` folder terminated the loop before it would check the `.build` directory.  This logic has been reformatted to try to find the file inside the `for` loop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This changes were tested locally using `swift build` & `swift test`, and in Frankfurt Bluemix.  In order to test that my changes worked in Bluemix, I created a 1.7.3 tag (deleted after testing) and pointed to this fork for downloading Kitura in my Package.swift.  This was tested against a [development branch](https://github.com/IBM-Swift/swift-buildpack/tree/issue.cache) of the Swift buildpack , which no longer removes the `.build` directory.

![screen shot 2017-04-27 at 6 08 14 pm](https://cloud.githubusercontent.com/assets/18534315/25508780/11b54150-2b7a-11e7-8aa0-7e50cc558e53.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
