### PR TITLE
Swift 4 support and add travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,21 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=4.0-DEVELOPMENT-SNAPSHOT-2017-06-11-a
     - os: linux
       dist: trusty
       sudo: required
-      services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_VERSION=3.0.2
     - os: linux
       dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.0-DEVELOPMENT-SNAPSHOT-2017-06-11-a
+    - os: osx
+      osx_image: xcode8.3
       sudo: required
     - os: osx
       osx_image: xcode8.3
       sudo: required
+      env: SWIFT_SNAPSHOT=4.0-DEVELOPMENT-SNAPSHOT-2017-06-11-a
 
 script:
   - ./build.sh

--- a/Scripts/generate_router_verbs.sh
+++ b/Scripts/generate_router_verbs.sh
@@ -63,7 +63,7 @@ cat <<EOF >> ${OUTPUT_FILE}
     /// - Parameter handler: A comma delimited set of \`RouterHandler\`s that will be
     ///                     invoked when $DOC_TEXT_1 request$DOC_TEXT_2 comes to the server.
     @discardableResult
-    public func $VERB_LOW_CASE(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func $VERB_LOW_CASE(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.$VERB_LOW_CASE, pattern: path, handler: handler)
     }
 

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -43,7 +43,7 @@ public class Kitura {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config
-        httpServersAndPorts.append(server: server, port: port)
+        httpServersAndPorts.append((server: server, port: port))
         return server
     }
 
@@ -59,7 +59,7 @@ public class Kitura {
     public class func addFastCGIServer(onPort port: Int, with delegate: ServerDelegate) -> FastCGIServer {
         let server = FastCGI.createServer()
         server.delegate = delegate
-        fastCGIServersAndPorts.append(server: server, port: port)
+        fastCGIServersAndPorts.append((server: server, port: port))
         return server
     }
 

--- a/Sources/Kitura/RouteRegex.swift
+++ b/Sources/Kitura/RouteRegex.swift
@@ -155,7 +155,7 @@ public class RouteRegex {
         return (matched, prefix, matchExp, plusQuestStar)
     }
 
-    #if os(Linux)
+    #if os(Linux) && swift(>=3.1.1) && !swift(>=3.1)
     typealias TextCheckingResultType = TextCheckingResult
     #else
     typealias TextCheckingResultType = NSTextCheckingResult

--- a/Sources/Kitura/RouteRegex.swift
+++ b/Sources/Kitura/RouteRegex.swift
@@ -53,11 +53,11 @@ public class RouteRegex {
         guard let pattern = fromPattern else {
             return (nil, false, nil)
         }
-        
+
         // Check and see if the pattern is a simple string (no captures and not a regular expression)
         if pattern.rangeOfCharacter(from: complexRouteCharacters) == nil {
             return (nil, true, nil)
-        } 
+        }
 
         var regexStr = "^"
         var keys = [String]()
@@ -88,80 +88,78 @@ public class RouteRegex {
 
     func handlePath(_ path: String, regexStr: String, keys: [String], nonKeyIndex: Int) ->
         (regexStr: String, keys: [String], nonKeyIndex: Int) {
-        var nonKeyIndex = nonKeyIndex
-        var keys = keys
-        var regexStr = regexStr
+            var nonKeyIndex = nonKeyIndex
+            var keys = keys
+            var regexStr = regexStr
 
-        // If there was a leading slash, there will be an empty component in the split
-        if  path.isEmpty {
+            // If there was a leading slash, there will be an empty component in the split
+            if  path.isEmpty {
+                return (regexStr, keys, nonKeyIndex)
+            }
+
+            let (matched, prefix, matchExp, plusQuestStar) =
+                matchRangesInPath(path, nonKeyIndex: &nonKeyIndex, keys: &keys)
+
+            let toAppend: String
+            if  matched { // A path element with no capture
+                toAppend = getStringToAppendToRegex(plusQuestStar: plusQuestStar,
+                                                    prefix: prefix, matchExp: matchExp)
+            } else {
+                toAppend = "/\(path)"  // A path element with no capture
+            }
+            regexStr.append(toAppend)
+
             return (regexStr, keys, nonKeyIndex)
-        }
-
-        let (matched, prefix, matchExp, plusQuestStar) =
-            matchRangesInPath(path, nonKeyIndex: &nonKeyIndex, keys: &keys)
-
-        let toAppend: String
-        if  matched { // A path element with no capture
-            toAppend = getStringToAppendToRegex(plusQuestStar: plusQuestStar,
-                                                prefix: prefix, matchExp: matchExp)
-        } else {
-            toAppend = "/\(path)"  // A path element with no capture
-        }
-        regexStr.append(toAppend)
-
-        return (regexStr, keys, nonKeyIndex)
     }
 
     func matchRangesInPath(_ path: String, nonKeyIndex: inout Int, keys: inout [String]) ->
         (match: Bool, prefix: String, matchExp: String, plusQuestStar: String) {
-        var matched = false
-        var prefix = ""
-        var matchExp = "[^/]+?"
-        var plusQuestStar = ""
+            var matched = false
+            var prefix = ""
+            var matchExp = "[^/]+?"
+            var plusQuestStar = ""
 
-        if  path == "*" {
-            // Handle a path element of * specially
-            return (true, prefix, ".*", plusQuestStar)
-        }
+            if  path == "*" {
+                // Handle a path element of * specially
+                return (true, prefix, ".*", plusQuestStar)
+            }
 
             let range = NSRange(location: 0, length: path.characters.count)
             let nsPath = NSString(string: path)           // Needed for substring
 
-        if let keyMatch = keyRegex.firstMatch(in: path, options: [], range: range) {
-            // We found a path element with a named/key capture
-            extract(fromPath: nsPath, with: keyMatch, at: 1, to: &prefix)
-            extract(fromPath: nsPath, with: keyMatch, at: 3, to: &matchExp)
-            extract(fromPath: nsPath, with: keyMatch, at: 4, to: &plusQuestStar)
+            if let keyMatch = keyRegex.firstMatch(in: path, options: [], range: range) {
+                // We found a path element with a named/key capture
+                extract(fromPath: nsPath, with: keyMatch, at: 1, to: &prefix)
+                extract(fromPath: nsPath, with: keyMatch, at: 3, to: &matchExp)
+                extract(fromPath: nsPath, with: keyMatch, at: 4, to: &plusQuestStar)
 
-            #if os(Linux)
-                let keyMatchRange = keyMatch.range(at: 2)
-            #else
-                let keyMatchRange = keyMatch.rangeAt(2)
-            #endif
+                #if os(Linux)
+                    let keyMatchRange = keyMatch.range(at: 2)
+                #else
+                    let keyMatchRange = keyMatch.rangeAt(2)
+                #endif
 
-            keys.append(nsPath.substring(with: keyMatchRange))
-            matched = true
-        } else if let nonKeyMatch = nonKeyRegex.firstMatch(in: path, options: [], range: range) {
-            // We found a path element with an unnamed capture
-            extract(fromPath: nsPath, with: nonKeyMatch, at: 1, to: &prefix)
-            extract(fromPath: nsPath, with: nonKeyMatch, at: 2, to: &matchExp)
-            extract(fromPath: nsPath, with: nonKeyMatch, at: 3, to: &plusQuestStar)
+                keys.append(nsPath.substring(with: keyMatchRange))
+                matched = true
+            } else if let nonKeyMatch = nonKeyRegex.firstMatch(in: path, options: [], range: range) {
+                // We found a path element with an unnamed capture
+                extract(fromPath: nsPath, with: nonKeyMatch, at: 1, to: &prefix)
+                extract(fromPath: nsPath, with: nonKeyMatch, at: 2, to: &matchExp)
+                extract(fromPath: nsPath, with: nonKeyMatch, at: 3, to: &plusQuestStar)
 
-            keys.append(String(nonKeyIndex))
-            nonKeyIndex+=1
-            matched = true
-        }
+                keys.append(String(nonKeyIndex))
+                nonKeyIndex+=1
+                matched = true
+            }
 
-        return (matched, prefix, matchExp, plusQuestStar)
+            return (matched, prefix, matchExp, plusQuestStar)
     }
 
-    #if os(Linux) && swift(>=3.1.1) && !swift(>=3.1)
-    typealias TextCheckingResultType = TextCheckingResult
-    #else
-    typealias TextCheckingResultType = NSTextCheckingResult
+    #if os(Linux) && !swift(>=3.2)
+        typealias NSTextCheckingResult = TextCheckingResult
     #endif
 
-    func extract(fromPath path: NSString, with match: TextCheckingResultType, at index: Int,
+    func extract(fromPath path: NSString, with match: NSTextCheckingResult, at index: Int,
                  to string: inout String) {
         #if os(Linux)
             let range = match.range(at: index)

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -199,7 +199,7 @@ public class Router {
     ///                     invoked when request parses a parameter with specified name.
     /// - Returns: Current router instance
     @discardableResult
-    public func parameter(_ name: String, handler: @escaping RouterParameterHandler...) -> Router {
+    public func parameter(_ name: String, handler: RouterParameterHandler...) -> Router {
         return self.parameter([name], handlers: handler)
     }
 
@@ -211,7 +211,7 @@ public class Router {
     ///                     invoked when request parses a parameter with specified name.
     /// - Returns: Current router instance
     @discardableResult
-    public func parameter(_ names: [String], handler: @escaping RouterParameterHandler...) -> Router {
+    public func parameter(_ names: [String], handler: RouterParameterHandler...) -> Router {
         return self.parameter(names, handlers: handler)
     }
 

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -115,6 +115,8 @@ public class Router {
         for fileExtension in fileExtensions {
             templateEngines[fileExtension] = templateEngine
         }
+        let absoluteViewsPath = StaticFileServer.ResourcePathHandler.getAbsolutePath(for: viewsPath)
+        templateEngine.setRootPaths(rootPaths: [absoluteViewsPath])
     }
 
     /// Render a template using a context
@@ -163,7 +165,8 @@ public class Router {
         }
 
         let absoluteFilePath = StaticFileServer.ResourcePathHandler.getAbsolutePath(for: filePath)
-        return try templateEngine.render(filePath: absoluteFilePath, context: context)
+        return try templateEngine.render(filePath: absoluteFilePath, context: context, options: options,
+                                         templateName: template)
     }
 
     // MARK: Sub router

--- a/Sources/Kitura/RouterElement.swift
+++ b/Sources/Kitura/RouterElement.swift
@@ -182,7 +182,7 @@ class RouterElement {
         looper.next()
     }
 
-    #if os(Linux)
+    #if os(Linux) && !swift(>=3.1)
         typealias TextCheckingResultType = TextCheckingResult
     #else
         typealias TextCheckingResultType = NSTextCheckingResult

--- a/Sources/Kitura/RouterElement.swift
+++ b/Sources/Kitura/RouterElement.swift
@@ -182,17 +182,15 @@ class RouterElement {
         looper.next()
     }
 
-    #if os(Linux) && !swift(>=3.1)
-        typealias TextCheckingResultType = TextCheckingResult
-    #else
-        typealias TextCheckingResultType = NSTextCheckingResult
+    #if os(Linux) && !swift(>=3.2)
+        typealias NSTextCheckingResult = TextCheckingResult
     #endif
 
     /// Update the request parameters
     ///
     /// - Parameter match: the regular expression result
     /// - Parameter request:
-    private func setParameters(forRequest request: RouterRequest, fromUrlPath urlPath: NSString, match: TextCheckingResultType) {
+    private func setParameters(forRequest request: RouterRequest, fromUrlPath urlPath: NSString, match: NSTextCheckingResult) {
         var parameters = mergeParameters ? request.parameters : [:]
 
         if let keys = keys {

--- a/Sources/Kitura/RouterHTTPVerbs+Error.swift
+++ b/Sources/Kitura/RouterHTTPVerbs+Error.swift
@@ -25,7 +25,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler` that will be
     ///                     invoked if an error ocurrs.
     @discardableResult
-    public func error(_ handler: @escaping RouterHandler...) -> Router {
+    public func error(_ handler: RouterHandler...) -> Router {
         return routingHelper(.error, pattern: nil, handler: handler)
     }
 

--- a/Sources/Kitura/RouterHTTPVerbs_generated.swift
+++ b/Sources/Kitura/RouterHTTPVerbs_generated.swift
@@ -28,7 +28,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when any request comes to the server.
     @discardableResult
-    public func all(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func all(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.all, pattern: path, handler: handler)
     }
 
@@ -85,7 +85,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP GET requests comes to the server.
     @discardableResult
-    public func get(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func get(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.get, pattern: path, handler: handler)
     }
 
@@ -142,7 +142,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP HEAD requests comes to the server.
     @discardableResult
-    public func head(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func head(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.head, pattern: path, handler: handler)
     }
 
@@ -199,7 +199,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP POST requests comes to the server.
     @discardableResult
-    public func post(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func post(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.post, pattern: path, handler: handler)
     }
 
@@ -256,7 +256,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP PUT requests comes to the server.
     @discardableResult
-    public func put(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func put(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.put, pattern: path, handler: handler)
     }
 
@@ -313,7 +313,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP DELETE requests comes to the server.
     @discardableResult
-    public func delete(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func delete(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.delete, pattern: path, handler: handler)
     }
 
@@ -370,7 +370,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP OPTIONS requests comes to the server.
     @discardableResult
-    public func options(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func options(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.options, pattern: path, handler: handler)
     }
 
@@ -427,7 +427,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP TRACE requests comes to the server.
     @discardableResult
-    public func trace(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func trace(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.trace, pattern: path, handler: handler)
     }
 
@@ -484,7 +484,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP COPY requests comes to the server.
     @discardableResult
-    public func copy(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func copy(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.copy, pattern: path, handler: handler)
     }
 
@@ -541,7 +541,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP LOCK requests comes to the server.
     @discardableResult
-    public func lock(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func lock(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.lock, pattern: path, handler: handler)
     }
 
@@ -598,7 +598,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP MKCOL requests comes to the server.
     @discardableResult
-    public func mkCol(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func mkCol(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.mkCol, pattern: path, handler: handler)
     }
 
@@ -655,7 +655,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP MOVE requests comes to the server.
     @discardableResult
-    public func move(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func move(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.move, pattern: path, handler: handler)
     }
 
@@ -712,7 +712,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP PURGE requests comes to the server.
     @discardableResult
-    public func purge(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func purge(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.purge, pattern: path, handler: handler)
     }
 
@@ -769,7 +769,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP PROPFIND requests comes to the server.
     @discardableResult
-    public func propFind(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func propFind(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.propFind, pattern: path, handler: handler)
     }
 
@@ -826,7 +826,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP PROPPATCH requests comes to the server.
     @discardableResult
-    public func propPatch(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func propPatch(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.propPatch, pattern: path, handler: handler)
     }
 
@@ -883,7 +883,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP UNLOCK requests comes to the server.
     @discardableResult
-    public func unlock(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func unlock(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.unlock, pattern: path, handler: handler)
     }
 
@@ -940,7 +940,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP REPORT requests comes to the server.
     @discardableResult
-    public func report(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func report(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.report, pattern: path, handler: handler)
     }
 
@@ -997,7 +997,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP MKACTIVITY requests comes to the server.
     @discardableResult
-    public func mkActivity(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func mkActivity(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.mkActivity, pattern: path, handler: handler)
     }
 
@@ -1054,7 +1054,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP CHECKOUT requests comes to the server.
     @discardableResult
-    public func checkout(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func checkout(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.checkout, pattern: path, handler: handler)
     }
 
@@ -1111,7 +1111,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP MERGE requests comes to the server.
     @discardableResult
-    public func merge(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func merge(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.merge, pattern: path, handler: handler)
     }
 
@@ -1168,7 +1168,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP MSEARCH requests comes to the server.
     @discardableResult
-    public func mSearch(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func mSearch(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.mSearch, pattern: path, handler: handler)
     }
 
@@ -1225,7 +1225,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP NOTIFY requests comes to the server.
     @discardableResult
-    public func notify(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func notify(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.notify, pattern: path, handler: handler)
     }
 
@@ -1282,7 +1282,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP SUBSCRIBE requests comes to the server.
     @discardableResult
-    public func subscribe(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func subscribe(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.subscribe, pattern: path, handler: handler)
     }
 
@@ -1339,7 +1339,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP UNSUBSCRIBE requests comes to the server.
     @discardableResult
-    public func unsubscribe(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func unsubscribe(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.unsubscribe, pattern: path, handler: handler)
     }
 
@@ -1396,7 +1396,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP PATCH requests comes to the server.
     @discardableResult
-    public func patch(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func patch(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.patch, pattern: path, handler: handler)
     }
 
@@ -1453,7 +1453,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP SEARCH requests comes to the server.
     @discardableResult
-    public func search(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func search(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.search, pattern: path, handler: handler)
     }
 
@@ -1510,7 +1510,7 @@ extension Router {
     /// - Parameter handler: A comma delimited set of `RouterHandler`s that will be
     ///                     invoked when HTTP CONNECT requests comes to the server.
     @discardableResult
-    public func connect(_ path: String?=nil, handler: @escaping RouterHandler...) -> Router {
+    public func connect(_ path: String?=nil, handler: RouterHandler...) -> Router {
         return routingHelper(.connect, pattern: path, handler: handler)
     }
 

--- a/Sources/Kitura/RouterParameterWalker.swift
+++ b/Sources/Kitura/RouterParameterWalker.swift
@@ -44,10 +44,6 @@ class RouterParameterWalker {
             }
         }
 
-//        let filtered = request.parameters.filter { (key, _) in
-//            self.parameterHandlers.keys.contains(key) && !request.handledNamedParameters.contains(key)
-//        }
-
         self.handle(filtered: filtered, request: request, response: response, with: callback)
     }
 

--- a/Sources/Kitura/RouterParameterWalker.swift
+++ b/Sources/Kitura/RouterParameterWalker.swift
@@ -36,7 +36,18 @@ class RouterParameterWalker {
             return
         }
 
-        let filtered = request.parameters.filter { (key, _) in self.parameterHandlers.keys.contains(key) && !request.handledNamedParameters.contains(key) }
+        var filtered = [(String, String)]()
+
+        for parameter in request.parameters {
+            if self.parameterHandlers.keys.contains(parameter.key) && !request.handledNamedParameters.contains(parameter.key) {
+                filtered.append((parameter.key, parameter.value))
+            }
+        }
+
+//        let filtered = request.parameters.filter { (key, _) in
+//            self.parameterHandlers.keys.contains(key) && !request.handledNamedParameters.contains(key)
+//        }
+
         self.handle(filtered: filtered, request: request, response: response, with: callback)
     }
 

--- a/Sources/Kitura/staticFileServer/CacheRelatedHeadersSetter.swift
+++ b/Sources/Kitura/staticFileServer/CacheRelatedHeadersSetter.swift
@@ -60,7 +60,7 @@ extension StaticFileServer {
                 let size = fileAttributes[FileAttributeKey.size] as? NSNumber
 
                 if let date = date, let size = size {
-                    let sizeHex = String(Int(size), radix: 16, uppercase: false)
+                    let sizeHex = String(size.intValue, radix: 16, uppercase: false)
                     let timeHex = String(Int(date.timeIntervalSince1970), radix: 16, uppercase: false)
                     let etag = "W/\"\(sizeHex)-\(timeHex)\""
                     response.headers["Etag"] = etag

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -70,7 +70,7 @@ class KituraTest: XCTestCase {
     }
 
     func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
-                           line: Int = #line, asyncTasks: @escaping (XCTestExpectation) -> Void...) {
+                           line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
         if sslOption != SSLOption.httpsOnly {
             self.port = KituraTest.httpPort
             self.useSSL = false

--- a/Tests/KituraTests/TestTemplateEngine.swift
+++ b/Tests/KituraTests/TestTemplateEngine.swift
@@ -38,7 +38,6 @@ class TestTemplateEngine: KituraTest {
             ("testRender", testRender),
             ("testRenderWithServer", testRenderWithServer),
             ("testRenderWithOptionsWithServer", testRenderWithOptionsWithServer),
-            ("testRenderWithServerAndSubRouter", testRenderWithServerAndSubRouter),
             ("testRenderWithExtensionAndWithoutDefaultTemplateEngine",
              testRenderWithExtensionAndWithoutDefaultTemplateEngine),
             ("testAddWithFileExtensions", testAddWithFileExtensions),
@@ -77,7 +76,7 @@ class TestTemplateEngine: KituraTest {
         let router = Router()
 
         do {
-            let _ = try router.render(template: "test", context: [:])
+            _ = try router.render(template: "test", context: [:])
         } catch TemplatingError.noDefaultTemplateEngineAndNoExtensionSpecified {
             //Expect this error to be thrown
         } catch {
@@ -107,19 +106,6 @@ class TestTemplateEngine: KituraTest {
         let router = Router()
         setupRouterForRendering(router, options: MockRenderingOptions())
         performRenderServerTest(withRouter: router, onPath: "/render")
-    }
-
-    func testRenderWithServerAndSubRouter() {
-        //TODO enable this test once https://github.com/IBM-Swift/Kitura/issues/1070 is resolved
-        /*
-
-        let subRouter = Router()
-        setupRouterForRendering(subRouter)
-
-        let router = Router()
-        router.all("/sub", middleware: subRouter)
-        performRenderServerTest(withRouter: router, onPath: "/sub/render")
-        */
     }
 
     private func setupRouterForRendering(_ router: Router, options: RenderingOptions? = nil) {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,13 +18,16 @@ import XCTest
 import Glibc
 @testable import KituraTests
 
+srand(UInt32(time(nil)))
+
 // http://stackoverflow.com/questions/24026510/how-do-i-shuffle-an-array-in-swift
+
+#if !swift(>=3.2)
 extension MutableCollection where Indices.Iterator.Element == Index {
     mutating func shuffle() {
         let c = count
         guard c > 1 else { return }
-        
-        srand(UInt32(time(nil)))
+
         for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
             let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
             guard d != 0 else { continue }
@@ -33,6 +36,21 @@ extension MutableCollection where Indices.Iterator.Element == Index {
         }
     }
 }
+#else
+extension MutableCollection {
+    mutating func shuffle() {
+        let c = count
+        guard c > 1 else { return }
+
+        for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
+            let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
+            guard d != 0 else { continue }
+            let i = index(firstUnshuffled, offsetBy: d)
+            self.swapAt(firstUnshuffled, i)
+        }
+    }
+}
+#endif
 
 extension Sequence {
     func shuffled() -> [Iterator.Element] {
@@ -56,4 +74,4 @@ XCTMain([
     testCase(TestSubrouter.allTests.shuffled()),
     testCase(TestStaticFileServer.allTests.shuffled()),
     testCase(TestTemplateEngine.allTests.shuffled())
-].shuffled())
+    ].shuffled())

--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,8 @@ set -o verbose
 
 if [ -n "${DOCKER_IMAGE}" ]; then
     docker pull ${DOCKER_IMAGE}
-    docker run --env SWIFT_VERSION -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
+    docker run --env SWIFT_SNAPSHOT -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
 else
-    test -n "${SWIFT_VERSION}" && echo "${SWIFT_VERSION}" > .swift-version || echo "SWIFT_VERSION not set, using $(cat .swift-version)"
     git clone https://github.com/IBM-Swift/Package-Builder.git
     ./Package-Builder/build-package.sh -projectDir $(pwd)
 fi


### PR DESCRIPTION
The removal of `@escaping` on the parameter closures was required for Swift 4 because these were variadic closures, which are already escaping. The 3.1 compiler ignored this/was a bug.
https://bugs.swift.org/browse/SR-2444
https://lists.swift.org/pipermail/swift-users/Week-of-Mon-20160905/003185.html

In `RouterParameterWalker.swift`, the removal of `.filter` over the request parameters was required for Swift 4 because `filter`ing over a dictionary now correctly returns a dictionary in Swift 4. A `for` loop is used instead in order to build the required `[(String, String)]`.
https://stackoverflow.com/questions/32604897/swift-filter-dictionary