### PR TITLE
Allow max Keep-Alive requests to be configurable

### DIFF
--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -37,12 +37,17 @@ public class Kitura {
     /// - Parameter onPort: The port to listen on.
     /// - Parameter with: The `ServerDelegate` to use.
     /// - Parameter withSSL: The `sslConfig` to use.
+    /// - Parameter maxKeepAliveRequests: The number of additional requests that may be made per connection. A value of zero disables Keep-Alive. A negative value indicates that unlimited requests, and is the default.
     /// - Returns: The created `HTTPServer`.
     @discardableResult
-    public class func addHTTPServer(onPort port: Int, with delegate: ServerDelegate, withSSL sslConfig: SSLConfig?=nil) -> HTTPServer {
+    public class func addHTTPServer(onPort port: Int,
+                                    with delegate: ServerDelegate,
+                                    withSSL sslConfig: SSLConfig?=nil,
+                                    maxKeepAliveRequests maxRequests: Int = -1) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config
+        server.maxRequests = maxRequests
         httpServersAndPorts.append(server: server, port: port)
         return server
     }

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -43,7 +43,7 @@ public class Kitura {
     public class func addHTTPServer(onPort port: Int,
                                     with delegate: ServerDelegate,
                                     withSSL sslConfig: SSLConfig?=nil,
-                                    keepAlive keepAliveState: HTTPServerResponse.KeepAliveState = .unlimited) -> HTTPServer {
+                                    keepAlive keepAliveState: KeepAliveState = .unlimited) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -37,13 +37,13 @@ public class Kitura {
     /// - Parameter onPort: The port to listen on.
     /// - Parameter with: The `ServerDelegate` to use.
     /// - Parameter withSSL: The `sslConfig` to use.
-    /// - Parameter maxKeepAliveRequests: The number of additional requests that may be made per connection. A value of zero disables Keep-Alive. A negative value indicates that unlimited requests, and is the default.
+    /// - Parameter keepAlive: The maximum number of additional requests to permit per Keep-Alive connection. Defaults to `.unlimited`. If set to `.disabled`, Keep-Alive will be not be permitted.
     /// - Returns: The created `HTTPServer`.
     @discardableResult
     public class func addHTTPServer(onPort port: Int,
                                     with delegate: ServerDelegate,
                                     withSSL sslConfig: SSLConfig?=nil,
-                                    keepalive keepAliveState: HTTPServerResponse.KeepAliveState = .unlimited) -> HTTPServer {
+                                    keepAlive keepAliveState: HTTPServerResponse.KeepAliveState = .unlimited) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -43,11 +43,11 @@ public class Kitura {
     public class func addHTTPServer(onPort port: Int,
                                     with delegate: ServerDelegate,
                                     withSSL sslConfig: SSLConfig?=nil,
-                                    maxKeepAliveRequests maxRequests: Int = -1) -> HTTPServer {
+                                    keepalive keepAliveState: HTTPServerResponse.KeepAliveState = .unlimited) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config
-        server.maxRequests = maxRequests
+        server.keepAliveState = keepAliveState
         httpServersAndPorts.append(server: server, port: port)
         return server
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enables the maximum number of subsequent Keep-Alive requests to be specified when creating an HTTP server.  A value of zero disables Keep-Alive.  A negative value allows unlimited requests, and is the default.

Resolves #1125 

Note that IBM-Swift/Kitura-net#216 is a prerequisite to this one and describes the motivation and context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See IBM-Swift/Kitura-net#216

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.