### PR TITLE
Expose allowPortReuse as a configuration option

### DIFF
--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -38,16 +38,19 @@ public class Kitura {
     /// - Parameter with: The `ServerDelegate` to use.
     /// - Parameter withSSL: The `sslConfig` to use.
     /// - Parameter keepAlive: The maximum number of additional requests to permit per Keep-Alive connection. Defaults to `.unlimited`. If set to `.disabled`, Keep-Alive will be not be permitted.
+    /// - Parameter allowPortReuse: Determines whether the listener port may be shared with other Kitura instances (`SO_REUSEPORT`). Defaults to `false`. If the specified port is already in use by another listener that has not allowed sharing, the server will fail to start.
     /// - Returns: The created `HTTPServer`.
     @discardableResult
     public class func addHTTPServer(onPort port: Int,
                                     with delegate: ServerDelegate,
                                     withSSL sslConfig: SSLConfig?=nil,
-                                    keepAlive keepAliveState: KeepAliveState = .unlimited) -> HTTPServer {
+                                    keepAlive keepAliveState: KeepAliveState = .unlimited,
+                                    allowPortReuse: Bool = false) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config
         server.keepAliveState = keepAliveState
+        server.allowPortReuse = allowPortReuse
         httpServersAndPorts.append((server: server, port: port))
         return server
     }
@@ -59,11 +62,15 @@ public class Kitura {
     ///
     /// - Parameter onPort: The port to listen on.
     /// - Parameter with: The `ServerDelegate` to use.
+    /// - Parameter allowPortReuse: Determines whether the listener port may be shared with other Kitura instances (`SO_REUSEPORT`). Defaults to `false`. If the specified port is already in use by another listener that has not allowed sharing, the server will fail to start.
     /// - Returns: The created `FastCGIServer`.
     @discardableResult
-    public class func addFastCGIServer(onPort port: Int, with delegate: ServerDelegate) -> FastCGIServer {
+    public class func addFastCGIServer(onPort port: Int,
+                                       with delegate: ServerDelegate,
+                                       allowPortReuse: Bool = false) -> FastCGIServer {
         let server = FastCGI.createServer()
         server.delegate = delegate
+        server.allowPortReuse = allowPortReuse
         fastCGIServersAndPorts.append((server: server, port: port))
         return server
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Exposes the `allowPortReuse` option that was added to Kitura-net in IBM-Swift/Kitura-net#223 to allow Kitura users to opt in to sharing the listener port if this is appropriate for their use case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A change earlier in the year to BlueSocket meant that Kitura no longer failed to listen on a port that was already in use by another Kitura server, as sockets were initialized with the `SO_REUSEPORT` option.  Prior to this, Kitura would fail to listen on a port that was already in use by another instance.

IBM-Swift/Kitura-net#223 reverts the behaviour for listening ports to disallow sharing by default, and exposes a configuration option on `HTTPServer` and `FastCGIServer` to allow the sharing of the listener port to be enabled again.

This PR adds a new optional parameter `allowPortReuse: Bool` on `Kitura.addHTTPServer()` and `Kitura.addFastCGIServer()`, defaulting to `false`.

Note that this PR cannot be merged until the prerequisite Kitura-net PR has been merged and tagged.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the Kitura tests locally, using branch `portReuse` of Kitura-net, and they passed.

I verified that a second instance of an application listening on a fixed port fails to start, unless the option `allowPortReuse: true` is specified.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
