### PR TITLE
Changes Body Parser to hold [String: Any] json obejcts

### DIFF
--- a/Sources/Kitura/bodyParser/JSONBodyParser.swift
+++ b/Sources/Kitura/bodyParser/JSONBodyParser.swift
@@ -19,9 +19,9 @@ import Foundation
 #if swift(>=4.0)
 class JSONBodyParser: BodyParserProtocol {
     func parse(_ data: Data) -> ParsedBody? {
-      guard let jsonObj = try? JSONSerialization.jsonObject(with: data, options: []),
+        guard let jsonObj = try? JSONSerialization.jsonObject(with: data, options: []),
             let json = jsonObj as? [String: Any] else {
-          return nil
+            return nil
       }
       return .json(json)
     }

--- a/Sources/Kitura/bodyParser/JSONBodyParser.swift
+++ b/Sources/Kitura/bodyParser/JSONBodyParser.swift
@@ -19,7 +19,11 @@ import Foundation
 #if swift(>=4.0)
 class JSONBodyParser: BodyParserProtocol {
     func parse(_ data: Data) -> ParsedBody? {
-        return .json(data)
+      guard let jsonObj = try? JSONSerialization.jsonObject(with: data, options: []),
+            let json = jsonObj as? [String: Any] else {
+          return nil
+      }
+      return .json(json)
     }
 }
 

--- a/Sources/Kitura/bodyParser/ParsedBody.swift
+++ b/Sources/Kitura/bodyParser/ParsedBody.swift
@@ -47,13 +47,13 @@ public indirect enum ParsedBody {
 
     /// If the content type was "application/json" this associated value will
     /// contain the body of a JSON object.
-    case json(Data)
+    case json([String: Any])
     
     /// Extract a "JSON" body from the `ParsedBody` enum
     ///
     /// - Returns: The parsed body as a JSON object, or nil if the body wasn't in
     ///           JSON format.
-    public var asJSON: Data? {
+  public var asJSON: [String: Any]? {
         switch self {
         case .json(let body):
             return body

--- a/Sources/Kitura/bodyParser/ParsedBody.swift
+++ b/Sources/Kitura/bodyParser/ParsedBody.swift
@@ -53,7 +53,7 @@ public indirect enum ParsedBody {
     ///
     /// - Returns: The parsed body as a JSON object, or nil if the body wasn't in
     ///           JSON format.
-  public var asJSON: [String: Any]? {
+    public var asJSON: [String: Any]? {
         switch self {
         case .json(let body):
             return body

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -1368,7 +1368,7 @@ class TestResponse: KituraTest {
                 do {
                     response.headers["Content-Type"] = "application/json; charset=utf-8"
                     #if swift(>=4.0)
-                    try response.send(data: json).end()
+                    response.send(json: json)
                     #else
                     try response.send(data: json.rawData()).end()
                     #endif

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -1368,7 +1368,7 @@ class TestResponse: KituraTest {
                 do {
                     response.headers["Content-Type"] = "application/json; charset=utf-8"
                     #if swift(>=4.0)
-                    response.send(json: json)
+                    try response.send(json: json).end()
                     #else
                     try response.send(data: json.rawData()).end()
                     #endif


### PR DESCRIPTION
## Description
Previously body parser was retaining json objects as .json(Data). This PR changes the case to be .json([String: Any])/

## Motivation and Context
Body parser should hold/make available usable json objects rather than requiring users to convert the data themselves.

## How Has This Been Tested?
unit tests

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
