### PR TITLE
Expose document root dir used by StaticFileServer

### DIFF
--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016,2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -70,6 +70,8 @@ public class StaticFileServer: RouterMiddleware {
         }
     }
 
+    public let absoluteRootPath: String
+
     let fileServer: FileServer
 
     /// Initializes a `StaticFileServer` instance.
@@ -81,7 +83,7 @@ public class StaticFileServer: RouterMiddleware {
     /// the headers of the response.
     public init(path: String = "./public", options: Options = Options(),
                  customResponseHeadersSetter: ResponseHeadersSetter? = nil) {
-        let path = StaticFileServer.ResourcePathHandler.getAbsolutePath(for: path)
+        absoluteRootPath = StaticFileServer.ResourcePathHandler.getAbsolutePath(for: path)
 
         let cacheOptions = options.cacheOptions
         let cacheRelatedHeadersSetter =
@@ -92,7 +94,7 @@ public class StaticFileServer: RouterMiddleware {
         let responseHeadersSetter = CompositeRelatedHeadersSetter(setters: cacheRelatedHeadersSetter,
                                                                   customResponseHeadersSetter)
 
-        fileServer = FileServer(servingFilesPath: path, options: options,
+        fileServer = FileServer(servingFilesPath: absoluteRootPath, options: options,
                                 responseHeadersSetter: responseHeadersSetter)
     }
 

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016,2017
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -216,4 +216,8 @@ class TestStaticFileServer: KituraTest {
     func testAbsolutePathFunction() {
         XCTAssertEqual(StaticFileServer.ResourcePathHandler.getAbsolutePath(for: "/"), "/", "Absolute path did not resolve to system root")
     }
+
+    func testAbsoluteRootPath() {
+        XCTAssertEqual(StaticFileServer(path: "/").absoluteRootPath, "/", "Absolute root path did not resolve to system root")
+    }
 }


### PR DESCRIPTION
## Description
This change exposes the document root / base directory used by the StaticFileServer middleware.

## Motivation and Context
The absolute path used for the document root is based on the code in `StaticFileServer.ResourcePathHandler.getAbsolutePath()` and can vary depending on the environment.
In order to work out where the directory is a user would have to reimplement the logic of this non-public code which is inconvenient and brittle to changes in the internals of Kitura.

Instead this PR adds a new property to the StaticFileServer API to provide access to the computed directory.

## How Has This Been Tested?
Tested in an example application and with a simple test case added to `KituraTests/TestStaticFileServer.swift`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
