### PR TITLE
Add and use simple path join function

### DIFF
--- a/Sources/Kitura/TypeRouter.swift
+++ b/Sources/Kitura/TypeRouter.swift
@@ -75,14 +75,14 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        patch("\(route)/:id") { request, response, next in
+        patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard self.isContentTypeJson(request) else {
                 response.status(.unsupportedMediaType)
                 next()
                 return
             }
-            
+
             do {
                 // Process incoming data from client
                 let id = request.parameters["id"] ?? ""
@@ -174,7 +174,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        put("\(route)/:id") { request, response, next in
+        put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
              guard self.isContentTypeJson(request) else {
                 response.status(.unsupportedMediaType)
@@ -248,7 +248,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        get("\(route)/:id") { request, response, next in
+        get(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request")
             do {
                 // Define result handler
@@ -303,7 +303,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        delete("\(route)/:id") { request, response, next in
+        delete(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received DELETE (singular) type-safe request")
             let resultHandler: ResultClosure = { error in
                 if let err = error {
@@ -336,7 +336,7 @@ extension Router {
         }
         return false
     }
-    
+
     private func isContentTypeJson(_ request: RouterRequest) -> Bool {
         guard let contentType = request.headers["Content-Type"] else {
             return false
@@ -347,6 +347,12 @@ extension Router {
     private func httpStatusCode(from error: ProcessHandlerError) -> HTTPStatusCode {
         let status: HTTPStatusCode = HTTPStatusCode(rawValue: error.rawValue) ?? .unknown
         return status
+    }
+
+    func join(path base: String, with component: String) -> String {
+        let strippedBase = base.hasSuffix("/") ? String(base.dropLast()) : base
+        let strippedComponent = component.hasPrefix("/") ? String(component.dropFirst()) : component
+        return "\(strippedBase)/\(strippedComponent)"
     }
 }
 

--- a/Tests/KituraTests/TestBasicTypeRouter.swift
+++ b/Tests/KituraTests/TestBasicTypeRouter.swift
@@ -35,6 +35,8 @@ class TestBasicTypeRouter: KituraTest {
             ("testBasicSingleDelete", testBasicSingleDelete),
             ("testBasicPut", testBasicPut),
             ("testBasicPatch", testBasicPatch),
+            ("testJoinPath", testJoinPath),
+            ("testRouteWithTrailingSlash", testRouteWithTrailingSlash),
             ("testRouteParameters", testRouteParameters),
             ("testCodablePutBodyParsing", testCodablePutBodyParsing),
             ("testCodablePatchBodyParsing", testCodablePatchBodyParsing),
@@ -371,7 +373,34 @@ class TestBasicTypeRouter: KituraTest {
             })
         }
     }
-    
+
+    func testJoinPath() {
+        let router = Router()
+        XCTAssertEqual(router.join(path: "a", with: "b"), "a/b")
+        XCTAssertEqual(router.join(path: "a/", with: "/b"), "a/b")
+        XCTAssertEqual(router.join(path: "a", with: "/b"), "a/b")
+        XCTAssertEqual(router.join(path: "a/", with: "b"), "a/b")
+    }
+
+    func testRouteWithTrailingSlash() {
+        router.get("/users/") { (id: Int, respondWith: (User?, ProcessHandlerError?) -> Void) in
+            // Returning an error that's not .notFound so we know this route has been hit
+            respondWith(nil, .conflict)
+        }
+        performServerTest(router, timeout: 30) { expectation in
+            self.performRequest("get", path: "/users/1", callback: { response in
+                guard let response = response else {
+                    XCTFail("ERROR!!! ClientRequest response object was nil")
+                    return
+                }
+
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.conflict, "Expected the '/users' route to be executed even though we passed '/users/'")
+
+                expectation.fulfill()
+            })
+        }
+    }
+
     func testRouteParameters() {
         //Add this erroneous route which should not be hit by the test, should log an error but we can't test the log so we checkout for a 404 not found.
         router.get("/users/:id") { (id: Int, respondWith: (User?, ProcessHandlerError?) -> Void) in
@@ -381,7 +410,6 @@ class TestBasicTypeRouter: KituraTest {
         }
         
         performServerTest(router, timeout: 30) { expectation in
-            
             self.performRequest("get", path: "/users/1", callback: { response in
                 guard let response = response else {
                     XCTFail("ERROR!!! ClientRequest response object was nil")


### PR DESCRIPTION
Most basic trimming of internal slashes. Doesn't deal with multiple leading/trailing slashes on path components.