### PR TITLE
Update isContentTypeJson method

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -507,7 +507,7 @@ extension Router {
         guard let contentType = request.headers["Content-Type"] else {
             return false
         }
-        return (contentType == "application/json")
+        return (contentType.hasPrefix("application/json"))
     }
 
     private func httpStatusCode(from error: RequestError) -> HTTPStatusCode {

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -110,7 +110,7 @@ class TestCodableRouter: KituraTest {
 
                 expectation.fulfill()
             }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json"
+                request.headers["Content-Type"] = "application/json; charset=utf-8"
                 request.write(from: userData)
             })
         }
@@ -161,7 +161,7 @@ class TestCodableRouter: KituraTest {
                 
                 expectation.fulfill()
             }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json"
+                request.headers["Content-Type"] = "application/json; charset=utf-8"
                 request.write(from: userData)
             })
         }
@@ -354,7 +354,7 @@ class TestCodableRouter: KituraTest {
 
                 expectation.fulfill()
             }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json"
+                request.headers["Content-Type"] = "application/json; charset=utf-8"
                 request.write(from: userData)
             })
         }
@@ -410,7 +410,7 @@ class TestCodableRouter: KituraTest {
 
                 expectation.fulfill()
             }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json"
+                request.headers["Content-Type"] = "application/json; charset=utf-8"
                 request.write(from: userData)
             })
         }
@@ -495,7 +495,7 @@ class TestCodableRouter: KituraTest {
 
                 expectation.fulfill()
             }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json"
+                request.headers["Content-Type"] = "application/json; charset=utf-8"
                 request.write(from: userData)
             })
         }
@@ -537,7 +537,7 @@ class TestCodableRouter: KituraTest {
 
                 expectation.fulfill()
             }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json"
+                request.headers["Content-Type"] = "application/json; charset=utf-8"
                 request.write(from: userData)
             })
         }
@@ -574,7 +574,7 @@ class TestCodableRouter: KituraTest {
 
                 expectation.fulfill()
             }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json"
+                request.headers["Content-Type"] = "application/json; charset=utf-8"
                 request.write(from: userData)
             })
         }


### PR DESCRIPTION
## Description
Changed `contentType == "application/json"` to `contentType.hasPrefix("application/json")`

## Motivation and Context
In Kitura the client requests have a `Content-Type` header, this can have a value like the following: `application/json; charset=utf-8`. The start of the value will always be `application/json` but can have extra information following this. We're currently testing that the value is equal to `application/json` when it'd be more accurate to check whether the start of the value is `application/json`. This can be achieved simply with the `hasPrefix()` call.
This change fixes #1171 

## How Has This Been Tested?
Updated the previous codable routing tests so they now set the content type to `application/json; charset=utf-8` rather than `application/json`. 
This will obviously fail without the change I've submitted but is a more accurate representation of a content type. 
With this change the tests will pass on both MacOS and Linux. 

