### PR TITLE
Added array support to query params.

### DIFF
--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -33,7 +33,11 @@ extension String {
 
             let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
             if let decodedValue = valueReplacingPlus.removingPercentEncoding {
-                result[key] = decodedValue
+                if let value = result[key] {
+                    result[key] = "\(value),\(decodedValue)"
+                } else {
+                    result[key] = decodedValue
+                }
             } else {
                 Log.warning("Unable to decode query parameter \(key)")
                 result[key] = valueReplacingPlus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Kitura currently does not have array support for query parameters (something that I have always seen in every web framework that I have used in the past).

## Motivation and Context
Developers wanting to map multiple values to a single key as a query parameter in the URL will now be able to do so. This change brings functionality that is commonly found these days in most web frameworks.

## How Has This Been Tested?
A new test function named `testQueryParameters` was added to `TestRequests.swift`. Test cases were executed on macOS and Ubuntu 14.04. Travis CI build is in progress for this PR.

## Checklist:
- [x] I have added tests to cover my changes.
