### PR TITLE
Enable one test for range requests

### DIFF
--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -40,6 +40,7 @@ class TestStaticFileServer: KituraTest {
             ("testAbsoluteRootPath", testAbsoluteRootPath),
             ("testRangeRequests", testRangeRequests),
             ("testRangeRequestIsIgnoredOnOptionOff", testRangeRequestIsIgnoredOnOptionOff),
+            ("testRangeRequestIsIgnoredOnNonGetMethod", testRangeRequestIsIgnoredOnNonGetMethod),
             ("testDataIsNotCorrupted", testDataIsNotCorrupted),
             ("testRangeRequestsWithMultipleRanges", testRangeRequestsWithMultipleRanges)
         ]
@@ -263,9 +264,7 @@ class TestStaticFileServer: KituraTest {
         }
     }
 
-    /// Enable this test when ClientRequests work fine with HEAD method.
-    /// See: [Fix parsing of responses to HEAD requests with non-zero Content-Length](https://github.com/IBM-Swift/Kitura-net/pull/225)
-    func disabled_testRangeRequestIsIgnoredOnNonGetMethod() {
+    func testRangeRequestIsIgnoredOnNonGetMethod() {
         performServerTest(router) { expectation in
             self.performRequest("head", path: "/qwer/index.html", callback: { response in
                 XCTAssertNotNil(response)


### PR DESCRIPTION
## Description
Enable test that was disabled at development time of range requests #1161 

## Motivation and Context
Ensure range requests are always GET
Improve code coverage

## How Has This Been Tested?
Enabling the test :)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
