### PR TITLE
Allow non-array Codables in get without id

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -22,12 +22,12 @@ import KituraContracts
 // Codable router
 
 extension Router {
-    
+
     // MARK: Codable Routing
-    
+
     /**
      Setup a SimpleCodableClosure on the provided route which will be invoked when a request comes to the server.
-     
+
      ### Usage Example: ###
      ````
      //User is a struct object that conforms to Codable
@@ -47,7 +47,7 @@ extension Router {
 
     /**
      Setup a IdentifierSimpleCodableClosure on the provided route which will be invoked when a request comes to the server.
-     
+
      ### Usage Example: ###
      ````
      //User is a struct object that conforms to Codable
@@ -67,13 +67,13 @@ extension Router {
 
     /**
      Setup a NonCodableClosure on the provided route which will be invoked when a request comes to the server.
-     
+
      ### Usage Example: ###
      ````
      router.delete("/users") { (respondWith: (RequestError?) -> Void) in
-     
+
         ...
-     
+
         respondWith(nil)
      }
      ````
@@ -86,13 +86,13 @@ extension Router {
 
     /**
      Setup a IdentifierNonCodableClosure on the provided route which will be invoked when a request comes to the server.
-     
+
      ### Usage Example: ###
      ````
      router.delete("/users") { (id: Int, respondWith: (RequestError?) -> Void) in
-     
+
         ...
-     
+
         respondWith(nil)
      }
      ````
@@ -102,18 +102,18 @@ extension Router {
     public func delete<Id: Identifier>(_ route: String, handler: @escaping IdentifierNonCodableClosure<Id>) {
         deleteSafely(route, handler: handler)
     }
-    
+
     /**
      Setup a CodableClosure on the provided route which will be invoked when a POST request comes to the server.
      In this scenario, the ID (i.e. unique identifier) is a field in the Codable instance.
-          
+
      ### Usage Example: ###
      ````
      //User is a struct object that conforms to Codable
      router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
-     
+
         ...
-     
+
         respondWith(user, nil)
      }
      ````
@@ -123,19 +123,19 @@ extension Router {
     public func post<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
         postSafely(route, handler: handler)
     }
-    
+
     /**
      Setup a CodableIdentifierClosure on the provided route which will be invoked when a POST request comes to the server.
      In this scenario, the ID (i.e. unique identifier) for the Codable instance is a separate field (which is sent back to the client
      in the location HTTP header).
-          
+
      ### Usage Example: ###
      ````
      //User is a struct object that conforms to Codable
      router.post("/users") { (user: User, respondWith: (Int?, User?, RequestError?) -> Void) in
-          
+
         ...
-     
+
         respondWith(id, user, nil)
      }
      ````
@@ -148,14 +148,14 @@ extension Router {
 
     /**
      Setup a IdentifierCodableClosure on the provided route which will be invoked when a request comes to the server.
-     
+
      ### Usage Example: ###
      ````
      //User is a struct object that conforms to Codable
      router.put("/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
-     
+
         ...
-     
+
         respondWith(user, nil)
      }
      ````
@@ -168,15 +168,15 @@ extension Router {
 
     /**
      Setup a IdentifierCodableClosure on the provided route which will be invoked when a request comes to the server.
-     
+
      ### Usage Example: ###
      ````
      //User is a struct object that conforms to Codable
      //OptionalUser is a struct object that conforms to Codable where all properties are optional
      router.patch("/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
-     
+
         ...
-     
+
         respondWith(user, nil)
      }
      ````
@@ -233,7 +233,7 @@ extension Router {
             }
         }
     }
-    
+
     // POST
     fileprivate func postSafelyWithId<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
         post(route) { request, response, next in
@@ -251,7 +251,7 @@ extension Router {
             do {
                 // Process incoming data from client
                 let param = try request.read(as: I.self)
-                
+
                 // Define handler to process result from application
                 let resultHandler: IdentifierCodableResultClosure<Id, O> = { id, result, error in
                     do {
@@ -264,7 +264,7 @@ extension Router {
                                 response.status(.internalServerError)
                                 next()
                                 return
-                            }                            
+                            }
                             let encoded = try JSONEncoder().encode(result)
                             response.status(.created)
                             response.headers["Location"] = String(id.value)

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -26,22 +26,22 @@ extension Router {
     // MARK: Codable Routing
     
     /**
-     Setup a CodableArrayClosure on the provided route which will be invoked when a request comes to the server.
+     Setup a SimpleCodableClosure on the provided route which will be invoked when a request comes to the server.
      
      ### Usage Example: ###
      ````
      //User is a struct object that conforms to Codable
      router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void) in
-     
+
         ...
 
         respondWith(users, nil)
      }
      ````
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
-     - Parameter handler: A CodableArrayClosure that gets invoked when a request comes to the server.
+     - Parameter handler: A SimpleCodableClosure that gets invoked when a request comes to the server.
      */
-    public func get<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    public func get<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         getSafely(route, handler: handler)
     }
 
@@ -52,9 +52,9 @@ extension Router {
      ````
      //User is a struct object that conforms to Codable
      router.get("/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
-     
+
         ...
-     
+
         respondWith(user, nil)
      }
      ````
@@ -385,11 +385,11 @@ extension Router {
     }
 
     // Get
-    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
             // Define result handler
-            let resultHandler: CodableArrayResultClosure<O> = { result, error in
+            let resultHandler: CodableResultClosure<O> = { result, error in
                 do {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -26,7 +26,7 @@ extension Router {
     // MARK: Codable Routing
 
     /**
-     Setup a SimpleCodableClosure on the provided route which will be invoked when a request comes to the server.
+     Setup a CodableArrayClosure on the provided route which will be invoked when a request comes to the server.
 
      ### Usage Example: ###
      ````
@@ -36,6 +36,26 @@ extension Router {
         ...
 
         respondWith(users, nil)
+     }
+     ````
+     - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
+     - Parameter handler: A CodableArrayClosure that gets invoked when a request comes to the server.
+     */
+    public func get<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+        getSafely(route, handler: handler)
+    }
+
+    /**
+     Setup a SimpleCodableClosure on the provided route which will be invoked when a request comes to the server.
+
+     ### Usage Example: ###
+     ````
+     //Status is a struct object that conforms to Codable
+     router.get("/status") { (respondWith: (Status?, RequestError?) -> Void) in
+
+        ...
+
+        respondWith(status, nil)
      }
      ````
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -407,7 +407,7 @@ extension Router {
     // Get single
     fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         get(route) { request, response, next in
-            Log.verbose("Received GET (plural) type-safe request")
+            Log.verbose("Received GET (single no-identifier) type-safe request")
             // Define result handler
             let resultHandler: CodableResultClosure<O> = { result, error in
                 do {
@@ -460,7 +460,7 @@ extension Router {
             return
         }
         get(join(path: route, with: ":id")) { request, response, next in
-            Log.verbose("Received GET (singular) type-safe request")
+            Log.verbose("Received GET (singular with identifier) type-safe request")
             do {
                 // Define result handler
                 let resultHandler: CodableResultClosure<O> = { result, error in


### PR DESCRIPTION
## Description
I have changed the old array-restricted `get` function to instead allow any `Codable` in the response callback. This means changing the `CodableArrayClosure` for the new `SimpleCodableClosure` which I plan to add to `KituraContracts` in PR https://github.com/IBM-Swift/KituraContracts/pull/4.

This closure type is looser than `CodableArrayClosure`. `CodableArrayClosure` is castable to `SimpleCodableClosure` so the change to the function is not breaking. We no longer need `CodableArrayClosure` but removing it from `KituraContracts` would be a breaking change, so I have left it there for now.

## Motivation and Context
Currently it is not possible to register a Codable `get` handler that doesn't want an id but does respond with a single Codable object (see https://github.com/IBM-Swift/Kitura/issues/1172).

For example, you cannot currently do the following:
```
app.router.get("/health") { (respondWith: (Health.Status?, RequestError?) -> Void in
    ...
}
```

This was simply an oversight, and we do allow both of these:
```
app.router.get("/health") { (id: Int, respondWith: (Health.Status?, RequestError?) -> Void in
    ...
}
```
and
```
app.router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void in
    ...
}
```

In fact, that last example could have been satisfied automatically if we had implemented the single Codable object.

## How Has This Been Tested?
Passes existing Kitura tests and I have added a new test so that both the `[Codable]` and the new single `Codable` work.

Also tested against an updated KituraKit in development mode (using `swift package edit`).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
