### PR TITLE
Change codable deletes to return noContent

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -501,7 +501,7 @@ extension Router {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
                 } else {
-                    response.status(.OK)
+                    response.status(.noContent)
                 }
                 next()
             }
@@ -521,7 +521,7 @@ extension Router {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
                 } else {
-                    response.status(.OK)
+                    response.status(.noContent)
                 }
                 next()
             }

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -311,7 +311,7 @@ class TestCodableRouter: KituraTest {
                     return
                 }
 
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.noContent, "HTTP Status code was \(String(describing: response.statusCode))")
                 var data = Data()
                 guard let length = try? response.readAllData(into: &data) else {
                     XCTFail("Error reading response length!")
@@ -343,7 +343,7 @@ class TestCodableRouter: KituraTest {
                     return
                 }
 
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
+                XCTAssertEqual(response.statusCode, HTTPStatusCode.noContent, "HTTP Status code was \(String(describing: response.statusCode))")
                 var data = Data()
                 guard let length = try? response.readAllData(into: &data) else {
                     XCTFail("Error reading response length!")


### PR DESCRIPTION
## Description
Currently a successfully return from a DELETE action in Codable Routing results in 200 OK. Best practices for REST are that this should return `204 No Content'.

## Motivation and Context
Fixes: https://github.com/IBM-Swift/Kitura/issues/1192

## How Has This Been Tested?
Updated tests to now check for no content rather than OK
