### PR TITLE
Fix compile error on Swift 4.0.0

### DIFF
--- a/Sources/Kitura/staticFileServer/CacheRelatedHeadersSetter.swift
+++ b/Sources/Kitura/staticFileServer/CacheRelatedHeadersSetter.swift
@@ -70,8 +70,13 @@ extension StaticFileServer {
                 let size = fileAttributes[FileAttributeKey.size] as? NSNumber else {
                 return nil
             }
+            #if !os(Linux) || swift(>=4.0.2)
+                // https://bugs.swift.org/browse/SR-5850
+                let sizeHex = String(Int(truncating: size), radix: 16, uppercase: false)
+            #else
+                let sizeHex = String(Int(size), radix: 16, uppercase: false)
+            #endif
 
-            let sizeHex = String(Int(truncating: size), radix: 16, uppercase: false)
             let timeHex = String(Int(date.timeIntervalSince1970), radix: 16, uppercase: false)
             let etag = "W/\"\(sizeHex)-\(timeHex)\""
             return etag


### PR DESCRIPTION
Refix the changes in 2.1.2 as they break on Swift 4.0.0.

## Description
`2.1.2` fixes some compile warnings on Linux on Swift 4.0.2/4.0.3 but breaks builds on Swift 4.0.0 (as it takes advantage of a fix in corelibs-foundation that is not present in Swift 4.0.0).

This PR refixes the changes so that the original conditional compile is retained but if further conditional on the Swift version. That is, the old and Linux-specific code path is compiled in on Linux and Swift 4.0.0 but not on macOS (as before) nor on Linux for Swift 4.0.2+.

## Motivation and Context
This change prevents compile errors on Swift 4 in a patch update. Should resolve https://github.com/IBM-Swift/Kitura/issues/1200.

If we want to drop support for Swift 4.0.0 in an upcoming release, we should tag it to reflect the breaking change (at which point we can clean up the code and remove the conditional compilation).

## How Has This Been Tested?
Using `swift test`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
