### PR TITLE
Fixing bug for multiple parameter handlers

### DIFF
--- a/Sources/Kitura/RouterParameterWalker.swift
+++ b/Sources/Kitura/RouterParameterWalker.swift
@@ -50,7 +50,7 @@ class RouterParameterWalker {
         }
 
         var parameters = filtered
-        let (key, value) = parameters.remove(at: parameters.startIndex)
+        let (key, value) = parameters[0]
 
         if !request.handledNamedParameters.contains(key),
             (self.parameterHandlers[key]?.count ?? 0) > 0,
@@ -66,6 +66,7 @@ class RouterParameterWalker {
         } else {
             request.handledNamedParameters.insert(key)
             self.parameterHandlers[key] = nil
+            parameters.remove(at: parameters.startIndex)
             self.handle(filtered: parameters, request: request, response: response, with: callback)
         }
     }

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -264,8 +264,8 @@ class TestRequests: KituraTest {
 
         router.get("/item/:id") { request, response, next in
             response.status(.OK)
-            XCTAssertEqual(request.userInfo["handler1"] as? Bool ?? false, true)
-            XCTAssertEqual(request.userInfo["handler2"] as? Bool ?? false, true)
+            XCTAssertTrue(request.userInfo["handler1"] as? Bool ?? false)
+            XCTAssertTrue(request.userInfo["handler2"] as? Bool ?? false)
             next()
         }
 
@@ -301,15 +301,19 @@ class TestRequests: KituraTest {
 
         router.get("/item/:id") { request, response, next in
             response.status(.OK)
-            XCTAssertEqual(request.userInfo["handler1"] as? Bool ?? false, true)
-            XCTAssertEqual(request.userInfo["handler2"] as? Bool ?? false, true)
+            XCTAssertTrue(request.userInfo["handler1"] as? Bool ?? false)
+            XCTAssertTrue(request.userInfo["handler2"] as? Bool ?? false)
+            XCTAssertNil(request.userInfo["handler3"])
+            XCTAssertNil(request.userInfo["handler4"])
             next()
         }
 
         router.get("/user/:name") { request, response, next in
             response.status(.OK)
-            XCTAssertEqual(request.userInfo["handler3"] as? Bool ?? false, true)
-            XCTAssertEqual(request.userInfo["handler4"] as? Bool ?? false, true)
+            XCTAssertTrue(request.userInfo["handler3"] as? Bool ?? false)
+            XCTAssertTrue(request.userInfo["handler4"] as? Bool ?? false)
+            XCTAssertNil(request.userInfo["handler1"])
+            XCTAssertNil(request.userInfo["handler2"])
             next()
         }
 

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -249,6 +249,33 @@ class TestRequests: KituraTest {
         })
     }
 
+    func testMultipleParameterHandlers() {
+        let router = Router()
+
+        router.parameter(["id"], handlers: [
+            { request, response, value, next in
+                request.userInfo["handler1"] = true
+                next()
+            },
+            { request, response, value, next in
+                request.userInfo["handler2"] = true
+                next()
+        }])
+
+        router.get("/item/:id") { request, response, next in
+            response.status(.OK)
+            XCTAssertEqual(request.userInfo["handler1"] as? Bool ?? false, true)
+            XCTAssertEqual(request.userInfo["handler2"] as? Bool ?? false, true)
+            next()
+        }
+
+        performServerTest(router) { expectation in
+            self.performRequest("get", path: "item/1000", callback: { response in
+                expectation.fulfill()
+            })
+        }
+    }
+
     func testParameterExit() {
         let router = Router()
 

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -249,7 +249,7 @@ class TestRequests: KituraTest {
         })
     }
 
-    func testMultipleParameterHandlers() {
+    func testOneParameterMultipleHandlers() {
         let router = Router()
 
         router.parameter(["id"], handlers: [
@@ -274,6 +274,54 @@ class TestRequests: KituraTest {
                 expectation.fulfill()
             })
         }
+    }
+
+    func testMultipleParametersMultipleHandlers() {
+        let router = Router()
+
+        router.parameter(["id"], handlers: [
+            { request, response, value, next in
+                request.userInfo["handler1"] = true
+                next()
+            },
+            { request, response, value, next in
+                request.userInfo["handler2"] = true
+                next()
+            }])
+
+        router.parameter(["name"], handlers: [
+            { request, response, value, next in
+                request.userInfo["handler3"] = true
+                next()
+            },
+            { request, response, value, next in
+                request.userInfo["handler4"] = true
+                next()
+            }])
+
+        router.get("/item/:id") { request, response, next in
+            response.status(.OK)
+            XCTAssertEqual(request.userInfo["handler1"] as? Bool ?? false, true)
+            XCTAssertEqual(request.userInfo["handler2"] as? Bool ?? false, true)
+            next()
+        }
+
+        router.get("/user/:name") { request, response, next in
+            response.status(.OK)
+            XCTAssertEqual(request.userInfo["handler3"] as? Bool ?? false, true)
+            XCTAssertEqual(request.userInfo["handler4"] as? Bool ?? false, true)
+            next()
+        }
+
+        performServerTest(router, asyncTasks: { expectation in
+            self.performRequest("get", path: "item/1000", callback: { response in
+                expectation.fulfill()
+            })
+        } , { expectation in
+            self.performRequest("get", path: "user/bob", callback: { response in
+                expectation.fulfill()
+            })
+        })
     }
 
     func testParameterExit() {


### PR DESCRIPTION
## Description
Changing to parameter is removed from list in `RouterParameterWalker.swift` only after all handlers have been dealt with. Previous code was prematurely removing the parameter instead of just reading it, so only the first parameter handler was ever being handled.

## Motivation and Context
Fixes bug in #1209. 

## How Has This Been Tested?
Implemented two new tests as code path wasn't currently being tested. All existing tests still pass.

