### PR TITLE
revert recent breaking changes to send

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -272,8 +272,10 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                         } else {
+                            let encoded = try JSONEncoder().encode(result)
                             response.status(.created)
-                            try response.send(result)
+                            response.headers.setType("json")
+                            response.send(data: encoded)
                         }
                     } catch {
                         // Http 500 error
@@ -325,9 +327,11 @@ extension Router {
                                 next()
                                 return
                             }
+                            let encoded = try JSONEncoder().encode(result)
                             response.status(.created)
                             response.headers["Location"] = String(id.value)
-                            try response.send(result)
+                            response.headers.setType("json")
+                            response.send(data: encoded)
                         }
                     } catch {
                         // Http 500 error
@@ -374,8 +378,10 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                         } else {
+                            let encoded = try JSONEncoder().encode(result)
                             response.status(.OK)
-                            try response.send(result)
+                            response.headers.setType("json")
+                            response.send(data: encoded)
                         }
                     } catch {
                         // Http 500 error
@@ -422,8 +428,10 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                         } else {
+                            let encoded = try JSONEncoder().encode(result)
                             response.status(.OK)
-                            try response.send(result)
+                            response.headers.setType("json")
+                            response.send(data: encoded)
                         }
                     } catch {
                         // Http 500 error
@@ -452,8 +460,10 @@ extension Router {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
                     } else {
+                        let encoded = try JSONEncoder().encode(result)
                         response.status(.OK)
-                        try response.send(result)
+                        response.headers.setType("json")
+                        response.send(data: encoded)
                     }
                 } catch {
                     // Http 500 error
@@ -476,8 +486,10 @@ extension Router {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
                     } else {
+                        let encoded = try JSONEncoder().encode(result)
                         response.status(.OK)
-                        try response.send(result)
+                        response.headers.setType("json")
+                        response.send(data: encoded)
                     }
                 } catch {
                     // Http 500 error
@@ -500,8 +512,10 @@ extension Router {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
                     } else {
+                        let encoded = try JSONEncoder().encode(result)
                         response.status(.OK)
-                        try response.send(result)
+                        response.headers.setType("json")
+                        response.send(data: encoded)
                     }
                 } catch {
                     // Http 500 error
@@ -536,8 +550,10 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                         } else {
+                            let encoded = try JSONEncoder().encode(result)
                             response.status(.OK)
-                            try response.send(result)
+                            response.headers.setType("json")
+                            response.send(data: encoded)
                         }
                     } catch {
                         // Http 500 error

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -265,18 +265,21 @@ public class RouterResponse {
     ///
     /// - Parameter json: The array to send in JSON format.
     /// - Returns: this RouterResponse.
-    /// - Throws: if the the object could not be encoded using the JSONSerializationType
     @discardableResult
-    public func send(json: [Any]) throws -> RouterResponse {
+    public func send(json: [Any]) -> RouterResponse {
         guard !state.invokedEnd else {
             Log.warning("RouterResponse send(json:) invoked after end() for \(self.request.urlURL)")
             return self
         }
 
-        let jsonData = try JSONSerializationType.data(withJSONObject: json, options:.prettyPrinted)
-        headers.setType("json")
-        send(data: jsonData)
-
+        do {
+            let jsonData = try JSONSerializationType.data(withJSONObject: json, options:.prettyPrinted)
+            headers.setType("json")
+            send(data: jsonData)
+        } catch {
+            Log.warning("Failed to convert JSON for sending: \(error.localizedDescription)")
+        }
+        
         return self
     }
 
@@ -284,17 +287,20 @@ public class RouterResponse {
     ///
     /// - Parameter json: The Dictionary to send in JSON format as a hash.
     /// - Returns: this RouterResponse.
-    /// - Throws: if the the object could not be encoded using the JSONSerializationType
     @discardableResult
-    public func send(json: [String: Any]) throws -> RouterResponse {
+    public func send(json: [String: Any]) -> RouterResponse {
         guard !state.invokedEnd else {
             Log.warning("RouterResponse send(json:) invoked after end() for \(self.request.urlURL)")
             return self
         }
 
-        let jsonData = try JSONSerializationType.data(withJSONObject: json, options:.prettyPrinted)
-        headers.setType("json")
-        send(data: jsonData)
+        do {
+            let jsonData = try JSONSerializationType.data(withJSONObject: json, options:.prettyPrinted)
+            headers.setType("json")
+            send(data: jsonData)
+        } catch {
+            Log.warning("Failed to convert JSON for sending: \(error.localizedDescription)")
+        }
 
         return self
     }
@@ -441,16 +447,18 @@ extension RouterResponse {
     ///
     /// - Parameter obj: the Codable object to send.
     /// - Returns: this RouterResponse.
-    /// - Throws: if the the object could not be encoded using the JSONEncoder
     @discardableResult
-    public func send<T : Encodable>(_ obj: T) throws -> RouterResponse {
+    public func send<T : Encodable>(_ obj: T) -> RouterResponse {
         guard !state.invokedEnd else {
             Log.warning("RouterResponse send(_ obj:) invoked after end() for \(self.request.urlURL)")
             return self
         }
-
-        headers.setType("json")
-        send(data: try encoder.encode(obj))
+        do {
+            headers.setType("json")
+            send(data: try encoder.encode(obj))
+        } catch {
+            Log.warning("Failed to encode Codable object for sending: \(error.localizedDescription)")
+        }
 
         return self
     }
@@ -459,10 +467,9 @@ extension RouterResponse {
     ///
     /// - Parameter json: the Encodable object to send.
     /// - Returns: this RouterResponse.
-    /// - Throws: if the the object could not be encoded using the JSONEncoder
     @discardableResult
-    public func send<T : Encodable>(json: T) throws -> RouterResponse {
-        return try send(json)
+    public func send<T : Encodable>(json: T) -> RouterResponse {
+        return send(json)
     }
 
     /// Send JSON with JSONP callback.

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -1449,9 +1449,9 @@ class TestResponse: KituraTest {
                 try response.send(status: HTTPStatusCode.forbidden).send(data: "<!DOCTYPE html><html><body><b>forbidden</b></body></html>\n\n".data(using: .utf8)!).end()
                 try response.send(status: HTTPStatusCode.OK).end()
                 response.send("string")
-                try response.send(json: json)
-                try response.send(json: ["some": "json"])
-                try response.send(json: ["some", 10, "json"])
+                response.send(json: json)
+                response.send(json: ["some": "json"])
+                response.send(json: ["some", 10, "json"])
                 try response.send(jsonp: json, callbackParameter: "cb").end()
 
                 let data = try TestResponse.encoder.encode(json)

--- a/Tests/KituraTests/TestSubrouter.swift
+++ b/Tests/KituraTests/TestSubrouter.swift
@@ -157,7 +157,7 @@ class TestSubrouter: KituraTest {
         }
 
         let handler: RouterHandler = { (req: RouterRequest, res: RouterResponse, next: () -> Void) throws in
-            try res.send(json: req.parameters)
+            res.send(json: req.parameters)
         }
 
         let router = Router()
@@ -168,7 +168,7 @@ class TestSubrouter: KituraTest {
         subsubRouter1.all("/subsub2/passthrough", handler: handler)
 
         router.route("/root2/:root2", mergeParameters: true).all { req, res, _ in
-            try res.send(json: req.parameters)
+            res.send(json: req.parameters)
         }
 
         performServerTest(router, asyncTasks: { expectation in


### PR DESCRIPTION
## Description
For issue 574 We are reverting the changes made in #1190 where the send methods were all set to throw. This was a breaking change and so will now be deferred until kitura 3.0.0.


## Motivation and Context
In PR #1190 for the Kitura evolution proposals, we had noticed an inconsistency in error handling. In order to begin bridging this problem, we aligned all the send methods by making them throw and then having to handle them accordingly (mostly in the CodableRouter). As these are breaking changes and we don't want to force our users to migrate to 3.0.0 without any enhanced functionality, we believe this should be deferred until the next major release.

## How Has This Been Tested?
Swift test has been run and all tests passed.

## Checklist:
- [x ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x ] If applicable, I have updated the documentation accordingly.
- [x ] If applicable, I have added tests to cover my changes.
