### PR TITLE
Add RequestError body codable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .upToNextMinor(from: "2.0.0")),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.0")),
-        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", .branch("add_requesterror_body"))
+        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", .upToNextMinor(from: "0.0.19")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .upToNextMinor(from: "2.0.0")),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", .upToNextMinor(from: "1.7.0")),
-        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", .upToNextMinor(from: "0.0.17"))
+        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", .branch("add_requesterror_body"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -273,6 +273,7 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                             if let bodyData = err.bodyData {
+                                response.headers.setType("json")
                                 response.send(data: try bodyData(.json))
                             }
                         } else {
@@ -326,6 +327,7 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                             if let bodyData = err.bodyData {
+                                response.headers.setType("json")
                                 response.send(data: try bodyData(.json))
                             }
                         } else {
@@ -387,6 +389,7 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                             if let bodyData = err.bodyData {
+                                response.headers.setType("json")
                                 response.send(data: try bodyData(.json))
                             }
                         } else {
@@ -441,6 +444,7 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                             if let bodyData = err.bodyData {
+                                response.headers.setType("json")
                                 response.send(data: try bodyData(.json))
                             }
                         } else {
@@ -476,6 +480,7 @@ extension Router {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
                         if let bodyData = err.bodyData {
+                            response.headers.setType("json")
                             response.send(data: try bodyData(.json))
                         }
                     } else {
@@ -505,6 +510,7 @@ extension Router {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
                         if let bodyData = err.bodyData {
+                            response.headers.setType("json")
                             response.send(data: try bodyData(.json))
                         }
                     } else {
@@ -572,6 +578,7 @@ extension Router {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
                             if let bodyData = err.bodyData {
+                                response.headers.setType("json")
                                 response.send(data: try bodyData(.json))
                             }
                         } else {
@@ -609,6 +616,7 @@ extension Router {
                     response.status(status)
                     if let bodyData = err.bodyData {
                         do {
+                            response.headers.setType("json")
                             response.send(data: try bodyData(.json))
                         } catch {
                             response.status(.internalServerError)
@@ -636,6 +644,7 @@ extension Router {
                     response.status(status)
                     if let bodyData = err.bodyData {
                         do {
+                            response.headers.setType("json")
                             response.send(data: try bodyData(.json))
                         } catch {
                             response.status(.internalServerError)

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -271,6 +271,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
+                            if let bodyDataGenerator = err.bodyDataGenerator {
+                                response.send(data: try bodyDataGenerator(.json))
+                            }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
                             response.status(.created)
@@ -320,6 +323,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
+                            if let bodyDataGenerator = err.bodyDataGenerator {
+                                response.send(data: try bodyDataGenerator(.json))
+                            }
                         } else {
                             guard let id = id else {
                                 Log.error("No id (unique identifier) value provided.")
@@ -377,6 +383,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
+                            if let bodyDataGenerator = err.bodyDataGenerator {
+                                response.send(data: try bodyDataGenerator(.json))
+                            }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
                             response.status(.OK)
@@ -427,6 +436,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
+                            if let bodyDataGenerator = err.bodyDataGenerator {
+                                response.send(data: try bodyDataGenerator(.json))
+                            }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
                             response.status(.OK)
@@ -459,6 +471,9 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
+                        if let bodyDataGenerator = err.bodyDataGenerator {
+                            response.send(data: try bodyDataGenerator(.json))
+                        }
                     } else {
                         let encoded = try JSONEncoder().encode(result)
                         response.status(.OK)
@@ -485,6 +500,9 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
+                        if let bodyDataGenerator = err.bodyDataGenerator {
+                            response.send(data: try bodyDataGenerator(.json))
+                        }
                     } else {
                         let encoded = try JSONEncoder().encode(result)
                         response.status(.OK)
@@ -549,6 +567,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
+                            if let bodyDataGenerator = err.bodyDataGenerator {
+                                response.send(data: try bodyDataGenerator(.json))
+                            }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
                             response.status(.OK)
@@ -582,6 +603,13 @@ extension Router {
                 if let err = error {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
+                    if let bodyDataGenerator = err.bodyDataGenerator {
+                        do {
+                            response.send(data: try bodyDataGenerator(.json))
+                        } catch {
+                            response.status(.internalServerError)
+                        }
+                    }
                 } else {
                     response.status(.noContent)
                 }
@@ -602,6 +630,13 @@ extension Router {
                 if let err = error {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
+                    if let bodyDataGenerator = err.bodyDataGenerator {
+                        do {
+                            response.send(data: try bodyDataGenerator(.json))
+                        } catch {
+                            response.status(.internalServerError)
+                        }
+                    }
                 } else {
                     response.status(.noContent)
                 }

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -259,6 +259,7 @@ extension Router {
             guard !request.hasBodyParserBeenUsed else {
                 Log.error("No data in request. Codable routes do not allow the use of a BodyParser.")
                 response.status(.internalServerError)
+                next()
                 return
             }
             do {
@@ -271,8 +272,8 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyDataGenerator = err.bodyDataGenerator {
-                                response.send(data: try bodyDataGenerator(.json))
+                            if let bodyData = err.bodyData {
+                                response.send(data: try bodyData(.json))
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -311,6 +312,7 @@ extension Router {
             guard !request.hasBodyParserBeenUsed else {
                 Log.error("No data in request. Codable routes do not allow the use of a BodyParser.")
                 response.status(.internalServerError)
+                next()
                 return
             }
             do {
@@ -323,8 +325,8 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyDataGenerator = err.bodyDataGenerator {
-                                response.send(data: try bodyDataGenerator(.json))
+                            if let bodyData = err.bodyData {
+                                response.send(data: try bodyData(.json))
                             }
                         } else {
                             guard let id = id else {
@@ -370,6 +372,7 @@ extension Router {
             guard !request.hasBodyParserBeenUsed else {
                 Log.error("No data in request. Codable routes do not allow the use of a BodyParser.")
                 response.status(.internalServerError)
+                next()
                 return
             }
             do {
@@ -383,8 +386,8 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyDataGenerator = err.bodyDataGenerator {
-                                response.send(data: try bodyDataGenerator(.json))
+                            if let bodyData = err.bodyData {
+                                response.send(data: try bodyData(.json))
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -422,6 +425,7 @@ extension Router {
             guard !request.hasBodyParserBeenUsed else {
                 Log.error("No data in request. Codable routes do not allow the use of a BodyParser.")
                 response.status(.internalServerError)
+                next()
                 return
             }
             do {
@@ -436,8 +440,8 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyDataGenerator = err.bodyDataGenerator {
-                                response.send(data: try bodyDataGenerator(.json))
+                            if let bodyData = err.bodyData {
+                                response.send(data: try bodyData(.json))
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -471,8 +475,8 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
-                        if let bodyDataGenerator = err.bodyDataGenerator {
-                            response.send(data: try bodyDataGenerator(.json))
+                        if let bodyData = err.bodyData {
+                            response.send(data: try bodyData(.json))
                         }
                     } else {
                         let encoded = try JSONEncoder().encode(result)
@@ -500,8 +504,8 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
-                        if let bodyDataGenerator = err.bodyDataGenerator {
-                            response.send(data: try bodyDataGenerator(.json))
+                        if let bodyData = err.bodyData {
+                            response.send(data: try bodyData(.json))
                         }
                     } else {
                         let encoded = try JSONEncoder().encode(result)
@@ -567,8 +571,8 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyDataGenerator = err.bodyDataGenerator {
-                                response.send(data: try bodyDataGenerator(.json))
+                            if let bodyData = err.bodyData {
+                                response.send(data: try bodyData(.json))
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -603,9 +607,9 @@ extension Router {
                 if let err = error {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
-                    if let bodyDataGenerator = err.bodyDataGenerator {
+                    if let bodyData = err.bodyData {
                         do {
-                            response.send(data: try bodyDataGenerator(.json))
+                            response.send(data: try bodyData(.json))
                         } catch {
                             response.status(.internalServerError)
                         }
@@ -630,9 +634,9 @@ extension Router {
                 if let err = error {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
-                    if let bodyDataGenerator = err.bodyDataGenerator {
+                    if let bodyData = err.bodyData {
                         do {
-                            response.send(data: try bodyDataGenerator(.json))
+                            response.send(data: try bodyData(.json))
                         } catch {
                             response.status(.internalServerError)
                         }

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -616,8 +616,8 @@ extension Router {
                     response.status(status)
                     do {
                         if let bodyData = try err.encodeBody(.json) {
-                                response.headers.setType("json")
-                                response.send(data: bodyData)
+                            response.headers.setType("json")
+                            response.send(data: bodyData)
                         }
                     } catch {
                         response.status(.internalServerError)

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -272,7 +272,7 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = try err.bodyData(.json) {
+                            if let bodyData = try err.encodeBody(.json) {
                                 response.headers.setType("json")
                                 response.send(data: bodyData)
                             }
@@ -326,7 +326,7 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = try err.bodyData(.json) {
+                            if let bodyData = try err.encodeBody(.json) {
                                 response.headers.setType("json")
                                 response.send(data: bodyData)
                             }
@@ -388,7 +388,7 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = try err.bodyData(.json) {
+                            if let bodyData = try err.encodeBody(.json) {
                                 response.headers.setType("json")
                                 response.send(data: bodyData)
                             }
@@ -443,7 +443,7 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = try err.bodyData(.json) {
+                            if let bodyData = try err.encodeBody(.json) {
                                 response.headers.setType("json")
                                 response.send(data: bodyData)
                             }
@@ -479,7 +479,7 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
-                        if let bodyData = try err.bodyData(.json) {
+                        if let bodyData = try err.encodeBody(.json) {
                             response.headers.setType("json")
                             response.send(data: bodyData)
                         }
@@ -509,7 +509,7 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
-                        if let bodyData = try err.bodyData(.json) {
+                        if let bodyData = try err.encodeBody(.json) {
                             response.headers.setType("json")
                             response.send(data: bodyData)
                         }
@@ -577,7 +577,7 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = try err.bodyData(.json) {
+                            if let bodyData = try err.encodeBody(.json) {
                                 response.headers.setType("json")
                                 response.send(data: bodyData)
                             }
@@ -615,7 +615,7 @@ extension Router {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
                     do {
-                        if let bodyData = try err.bodyData(.json) {
+                        if let bodyData = try err.encodeBody(.json) {
                                 response.headers.setType("json")
                                 response.send(data: bodyData)
                         }
@@ -643,7 +643,7 @@ extension Router {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
                     do {
-                        if let bodyData = try err.bodyData(.json) {
+                        if let bodyData = try err.encodeBody(.json) {
                             response.headers.setType("json")
                             response.send(data: bodyData)
                         }

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -272,9 +272,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = err.bodyData {
+                            if let bodyData = try err.bodyData(.json) {
                                 response.headers.setType("json")
-                                response.send(data: try bodyData(.json))
+                                response.send(data: bodyData)
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -326,9 +326,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = err.bodyData {
+                            if let bodyData = try err.bodyData(.json) {
                                 response.headers.setType("json")
-                                response.send(data: try bodyData(.json))
+                                response.send(data: bodyData)
                             }
                         } else {
                             guard let id = id else {
@@ -388,9 +388,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = err.bodyData {
+                            if let bodyData = try err.bodyData(.json) {
                                 response.headers.setType("json")
-                                response.send(data: try bodyData(.json))
+                                response.send(data: bodyData)
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -443,9 +443,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = err.bodyData {
+                            if let bodyData = try err.bodyData(.json) {
                                 response.headers.setType("json")
-                                response.send(data: try bodyData(.json))
+                                response.send(data: bodyData)
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -479,9 +479,9 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
-                        if let bodyData = err.bodyData {
+                        if let bodyData = try err.bodyData(.json) {
                             response.headers.setType("json")
-                            response.send(data: try bodyData(.json))
+                            response.send(data: bodyData)
                         }
                     } else {
                         let encoded = try JSONEncoder().encode(result)
@@ -509,9 +509,9 @@ extension Router {
                     if let err = error {
                         let status = self.httpStatusCode(from: err)
                         response.status(status)
-                        if let bodyData = err.bodyData {
+                        if let bodyData = try err.bodyData(.json) {
                             response.headers.setType("json")
-                            response.send(data: try bodyData(.json))
+                            response.send(data: bodyData)
                         }
                     } else {
                         let encoded = try JSONEncoder().encode(result)
@@ -577,9 +577,9 @@ extension Router {
                         if let err = error {
                             let status = self.httpStatusCode(from: err)
                             response.status(status)
-                            if let bodyData = err.bodyData {
+                            if let bodyData = try err.bodyData(.json) {
                                 response.headers.setType("json")
-                                response.send(data: try bodyData(.json))
+                                response.send(data: bodyData)
                             }
                         } else {
                             let encoded = try JSONEncoder().encode(result)
@@ -614,13 +614,13 @@ extension Router {
                 if let err = error {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
-                    if let bodyData = err.bodyData {
-                        do {
-                            response.headers.setType("json")
-                            response.send(data: try bodyData(.json))
-                        } catch {
-                            response.status(.internalServerError)
+                    do {
+                        if let bodyData = try err.bodyData(.json) {
+                                response.headers.setType("json")
+                                response.send(data: bodyData)
                         }
+                    } catch {
+                        response.status(.internalServerError)
                     }
                 } else {
                     response.status(.noContent)
@@ -642,13 +642,13 @@ extension Router {
                 if let err = error {
                     let status = self.httpStatusCode(from: err)
                     response.status(status)
-                    if let bodyData = err.bodyData {
-                        do {
+                    do {
+                        if let bodyData = try err.bodyData(.json) {
                             response.headers.setType("json")
-                            response.send(data: try bodyData(.json))
-                        } catch {
-                            response.status(.internalServerError)
+                            response.send(data: bodyData)
                         }
+                    } catch {
+                        response.status(.internalServerError)
                     }
                 } else {
                     response.status(.noContent)

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -63,8 +63,18 @@ class KituraTest: XCTestCase {
         KituraTest.initOnce
     }
 
+    func buildServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
+                           line: Int = #line) -> RequestTestBuilder {
+        return ServerTestBuilder(test: self, router: router, sslOption: sslOption, timeout: timeout, line: line)
+    }
+
     func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
                            line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
+        performServerTest(router, sslOption: sslOption, timeout: timeout, line: line, asyncTasks: asyncTasks)
+    }
+
+    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
+                           line: Int = #line, asyncTasks: [(XCTestExpectation) -> Void]) {
         if sslOption != SSLOption.httpsOnly {
             self.port = KituraTest.httpPort
             self.useSSL = false

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -1,0 +1,241 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import Kitura
+
+@testable import KituraNet
+
+import Foundation
+import Dispatch
+
+// This file defines a builder API on top of KituraTest as syntactic sugar
+// for writing more concise tests.
+//
+// For example, from inside a subclass of KituraTest, you can write:
+// func testSomething() {
+//     buildServerTest(someRouter, timeout: 30)
+//         .request("get", path: "/route")
+//         .hasStatus(.OK)
+//         .hasData(someCodable)
+//         .run()
+// }
+// This will create a test server connected to someRouter, send a single
+// GET request to "/route", and test the response HTTP status code is 200 (OK)
+// and the response data can be decoded and equal to someCodable.
+
+// These protocols prevent adding assertions before adding at least
+// one request
+protocol RequestTestBuilder {
+    func request(_ method: String, path: String) -> AssertionTestBuilder
+    func request<T: Encodable>(_ method: String, path: String, data: T) -> AssertionTestBuilder
+    func run()
+}
+
+protocol AssertionTestBuilder: RequestTestBuilder {
+    func has(callback: @escaping (ClientResponse) -> Void) -> Self
+    func hasStatus(_ statusCode: HTTPStatusCode) -> Self
+    func hasContentType(withPrefix contentTypePrefix: String) -> Self
+    func hasHeader(_ name: String, only expectedValue: String) -> Self
+    func hasNoData() -> Self
+    func hasData(_ expected: String) -> Self
+    func hasData<T: Decodable & Equatable>(_ expected: [T]) -> Self
+    func hasData<T: Decodable & Equatable>(_ expected: T) -> Self
+}
+
+// A builder object for constructing tests made up of one or more
+// requests on which multiple assertions can be applied
+class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
+    // An object to keep track of a request and store up a list of
+    // assertions to be applied when the request is complete
+    private class Request {
+        let test: KituraTest
+        let invoker: (@escaping (ClientResponse?) -> Void) throws -> Void
+        fileprivate var assertions: [(ClientResponse) -> Void] = []
+
+        init(_ test: KituraTest, _ method: String, _ path: String) {
+            self.test = test
+            self.invoker = { callback in
+                test.performRequest(method, path: path, callback: callback)
+            }
+        }
+
+        init<T: Encodable>(_ test: KituraTest, _ method: String, _ path: String, _ data: T) {
+            self.test = test
+            self.invoker = { callback in
+                let data = try JSONEncoder().encode(data)
+                test.performRequest(method, path: path, callback: callback, requestModifier: { request in
+                    request.headers["Content-Type"] = "application/json; charset=utf-8"
+                    request.write(from: data)
+                })
+            }
+        }
+    }
+    let test: KituraTest
+    let router: ServerDelegate
+    let sslOption: SSLOption
+    let timeout: TimeInterval
+    let line: Int
+    private var requests: [Request] = []
+    private var currentRequest: Request? { return requests.last }
+
+    public init(test: KituraTest, router: ServerDelegate, sslOption: SSLOption, timeout: TimeInterval, line: Int) {
+        self.test = test
+        self.router = router
+        self.sslOption = sslOption
+        self.timeout = timeout
+        self.line = line
+    }
+
+    public func request(_ method: String, path: String) -> AssertionTestBuilder {
+        requests.append(Request(test, method, path))
+        return self
+    }
+
+    public func request<T: Encodable>(_ method: String, path: String, data: T) -> AssertionTestBuilder {
+        requests.append(Request(test, method, path, data))
+        return self
+    }
+
+    public func has(callback: @escaping (ClientResponse) -> Void) -> Self {
+        currentRequest?.assertions.append(callback)
+        return self
+    }
+
+    public func hasStatus(_ statusCode: HTTPStatusCode) -> Self {
+        return has { XCTAssertEqual($0.statusCode, statusCode) }
+    }
+
+    public func hasContentType(withPrefix contentTypePrefix: String) -> Self {
+        return hasHeader("Content-Type", withPrefix: contentTypePrefix)
+    }
+
+    public func hasHeader(_ name: String, withPrefix expectedPrefix: String) -> Self {
+        return has { response in
+            guard let header = response.headers[name] else {
+                XCTFail("Expected response header \(name) missing")
+                return
+            }
+            guard header.count == 1 else {
+                XCTFail("Header \(name) does not contain expected number of values:\nexpected: 1\nactual: \(header.count)")
+                return
+            }
+            let matches = header.filter { $0.hasPrefix(expectedPrefix) }
+            XCTAssert(matches.count > 0, "No values for header \(name) found with expected prefix:\nexpected prefix \(expectedPrefix)\nactual values: \(String(describing: matches))")
+        }
+    }
+
+    public func hasHeader(_ name: String, only expectedValue: String) -> Self {
+        return has { response in
+            guard let header = response.headers[name] else {
+                XCTFail("Expected response header \(name) missing")
+                return
+            }
+            guard header.count == 1, let actualValue = header.first else {
+                XCTFail("Header \(name) does not contain expected number of values:\nexpected: 1\nactual: \(header.count)")
+                return
+            }
+            XCTAssertEqual(actualValue, expectedValue, "Header \(name) does not contain expected value:\nexpected: \(expectedValue)\nactual: \(actualValue)")
+        }
+    }
+
+    private func readDataOrFail(from response: ClientResponse, allowEmpty: Bool = false) -> (length: Int, data: Data)? {
+        var data = Data()
+        guard let length = try? response.readAllData(into: &data) else {
+            XCTFail("Failed to read response data")
+            return nil
+        }
+        guard allowEmpty || length > 0 else {
+            XCTFail("Expected some data but got none")
+            return nil
+        }
+        return (length, data)
+    }
+
+    public func hasNoData() -> Self {
+        return has { response in
+            guard let (length, _) = self.readDataOrFail(from: response, allowEmpty: true) else { return }
+            XCTAssertEqual(length, 0, "Response data does not match expected length:\nexpected: 0\nactual: \(length)")
+        }
+    }
+
+    public func hasData(_ expected: Data) -> Self {
+        return has { response in
+            guard let (_, data) = self.readDataOrFail(from: response) else { return }
+            XCTAssertEqual(data, expected, "Response data does not match expected")
+        }
+    }
+
+    public func hasData(_ expected: String) -> Self {
+        return has { response in
+            guard let (_, data) = self.readDataOrFail(from: response) else { return }
+            guard let actual = String(data: data, encoding: .utf8) else {
+                XCTFail("Failed to decode response data into UTF8 String")
+                return
+            }
+            XCTAssertEqual(expected, actual, "Response data does not match expected value:\nexpected: \(expected)\nactual: \(actual)")
+        }
+    }
+
+    public func hasData<T: Decodable & Equatable>(_ expected: [T]) -> Self {
+        return has { response in
+            guard let (_, data) = self.readDataOrFail(from: response) else { return }
+            do {
+                let actual = try JSONDecoder().decode([T].self, from: data)
+                XCTAssertEqual(expected, actual, "Response data does not match expected value:\nexpected: \(expected)\nactual: \(actual)")
+            } catch {
+                XCTFail("Failed to decode response data into type \([T].self): \(error)")
+            }
+        }
+    }
+
+    public func hasData<T: Decodable & Equatable>(_ expected: T) -> Self {
+        return has { response in
+            guard let (_, data) = self.readDataOrFail(from: response) else { return }
+            do {
+                let actual = try JSONDecoder().decode(T.self, from: data)
+                XCTAssertEqual(expected, actual, "Response data does not match expected value:\nexpected: \(expected)\nactual: \(actual)")
+            } catch {
+                XCTFail("Failed to decode response data into type \(T.self): \(error)")
+            }
+        }
+    }
+
+    public func run() {
+        // Construct a list of async tasks that will perform each
+        // request in turn and test their associated assertions
+        let tasks = requests.map { request in
+            return { (expectation: XCTestExpectation) in
+                do {
+                    try request.invoker() { response in
+                        guard let response = response else {
+                            XCTFail("Expected response object")
+                            return
+                        }
+                        for assertion in request.assertions {
+                            assertion(response)
+                        }
+                        expectation.fulfill()
+                    }
+                } catch {
+                    XCTFail("Failed to build request: \(error)")
+                    expectation.fulfill()
+                }
+            }
+        }
+        test.performServerTest(router, sslOption: sslOption, timeout: timeout, line: line, asyncTasks: tasks)
+    }
+}

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -223,6 +223,7 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
                     try request.invoker() { response in
                         guard let response = response else {
                             XCTFail("Expected response object")
+                            expectation.fulfill()
                             return
                         }
                         for assertion in request.assertions {

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -51,6 +51,7 @@ protocol AssertionTestBuilder: RequestTestBuilder {
     func hasContentType(withPrefix contentTypePrefix: String) -> Self
     func hasHeader(_ name: String, only expectedValue: String) -> Self
     func hasNoData() -> Self
+    func hasData() -> Self
     func hasData(_ expected: String) -> Self
     func hasData<T: Decodable & Equatable>(_ expected: [T]) -> Self
     func hasData<T: Decodable & Equatable>(_ expected: T) -> Self
@@ -169,6 +170,12 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
         return has { response in
             guard let (length, _) = self.readDataOrFail(from: response, allowEmpty: true) else { return }
             XCTAssertEqual(length, 0, "Response data does not match expected length:\nexpected: 0\nactual: \(length)")
+        }
+    }
+
+    public func hasData() -> Self {
+        return has { response in
+            _ = self.readDataOrFail(from: response)
         }
     }
 

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -26,19 +26,17 @@ class TestCodableRouter: KituraTest {
         return [
             ("testBasicPost", testBasicPost),
             ("testBasicPostIdentifier", testBasicPostIdentifier),
-            ("testBasicGet", testBasicGet),
+            ("testBasicGetSingleton", testBasicGetSingleton),
             ("testBasicGetArray", testBasicGetArray),
-            ("testBasicSingleGet", testBasicSingleGet),
+            ("testBasicGetSingle", testBasicGetSingle),
             ("testBasicDelete", testBasicDelete),
-            ("testBasicSingleDelete", testBasicSingleDelete),
+            ("testBasicDeleteSingle", testBasicDeleteSingle),
             ("testBasicPut", testBasicPut),
             ("testBasicPatch", testBasicPatch),
             ("testJoinPath", testJoinPath),
             ("testRouteWithTrailingSlash", testRouteWithTrailingSlash),
             ("testRouteParameters", testRouteParameters),
-            ("testCodablePutBodyParsing", testCodablePutBodyParsing),
-            ("testCodablePatchBodyParsing", testCodablePatchBodyParsing),
-            ("testCodablePostBodyParsing", testCodablePostBodyParsing),
+            ("testCodableRoutesWithBodyParsingFail", testCodableRoutesWithBodyParsingFail),
             ("testCodableGetQueryParameters", testCodableGetQueryParameters),
             ("testCodableDeleteQueryParameters", testCodableDeleteQueryParameters)
         ]
@@ -54,7 +52,19 @@ class TestCodableRouter: KituraTest {
         userStore = [1: User(id: 1, name: "Mike"), 2: User(id: 2, name: "Chris"), 3: User(id: 3, name: "Ricardo")]
     }
 
-    struct User: Codable {
+    struct Conflict: Codable, Equatable {
+        let field: String
+
+        init(on field: String) {
+            self.field = field
+        }
+
+        static func ==(lhs: Conflict, rhs: Conflict) -> Bool {
+            return lhs.field == rhs.field
+        }
+    }
+
+    struct User: Codable, Equatable {
         let id: Int
         let name: String
 
@@ -62,9 +72,13 @@ class TestCodableRouter: KituraTest {
             self.id = id
             self.name = name
         }
+
+        static func ==(lhs: User, rhs: User) -> Bool {
+            return lhs.id == rhs.id && lhs.name == rhs.name
+        }
     }
 
-    struct OptionalUser: Codable {
+    struct OptionalUser: Codable, Equatable {
         let id: Int?
         let name: String?
 
@@ -72,12 +86,20 @@ class TestCodableRouter: KituraTest {
             self.id = id
             self.name = name
         }
+
+        static func ==(lhs: OptionalUser, rhs: OptionalUser) -> Bool {
+            return lhs.id == rhs.id && lhs.name == rhs.name
+        }
     }
 
-    struct Status: Codable {
+    struct Status: Codable, Equatable {
         let description: String
         init(_ desc: String) {
             description = desc
+        }
+
+        static func ==(lhs: Status, rhs: Status) -> Bool {
+            return lhs.description == rhs.description
         }
     }
 
@@ -113,182 +135,134 @@ class TestCodableRouter: KituraTest {
     func testBasicPost() {
         router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
             print("POST on /users for user \(user)")
-            self.userStore[user.id] = user
             respondWith(user, nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-            let expectedUser = User(id: 4, name: "David")
-            guard let userData = try? JSONEncoder().encode(expectedUser) else {
-                XCTFail("Could not generate user data from string!")
-                return
-            }
-
-            self.performRequest("post", path: "/users", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.created, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-                    guard let user = try? JSONDecoder().decode(User.self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to User, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-
-                // Validate the data we got back from the server
-                XCTAssertEqual(user.name, expectedUser.name)
-                XCTAssertEqual(user.id, expectedUser.id)
-
-                expectation.fulfill()
-            }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json; charset=utf-8"
-                request.write(from: userData)
-            })
+        router.post("/error/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
+            print("POST on /error/users for user \(user)")
+            respondWith(nil, .conflict)
         }
+        router.post("/bodyerror/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
+            print("POST on /bodyerror/users for user \(user)")
+            respondWith(user, RequestError(.conflict, body: Conflict(on: "id")))
+        }
+
+        let user = User(id: 4, name: "David")
+        buildServerTest(router, timeout: 30)
+            .request("post", path: "/users", data: user)
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(user)
+
+            .request("post", path: "/error/users", data: user)
+            .hasStatus(.conflict)
+
+            .request("post", path: "/bodyerror/users", data: user)
+            .hasStatus(.conflict)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Conflict(on: "id"))
+
+            .run()
     }
 
     func testBasicPostIdentifier() {
         router.post("/users") { (user: User, respondWith: (Int?, User?, RequestError?) -> Void) in
             print("POST on /users for user \(user)")
-            self.userStore[user.id] = user
             respondWith(user.id, user, nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-            let expectedUser = User(id: 4, name: "David")
-            guard let userData = try? JSONEncoder().encode(expectedUser) else {
-                XCTFail("Could not generate user data from string!")
-                return
-            }
-
-            self.performRequest("post", path: "/users", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.created, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-                guard let user = try? JSONDecoder().decode(User.self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to User, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-
-                guard let location = response.headers["Location"] else {
-                    XCTFail("Could not find Location header. Expected Location header to be set to the created User id.")
-                    return
-                }
-                XCTAssertEqual(location[0], String(expectedUser.id))
-
-                // Validate the data we got back from the server
-                XCTAssertEqual(user.name, expectedUser.name)
-                XCTAssertEqual(user.id, expectedUser.id)
-
-                expectation.fulfill()
-            }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json; charset=utf-8"
-                request.write(from: userData)
-            })
+        router.post("/error/users") { (user: User, respondWith: (Int?, User?, RequestError?) -> Void) in
+            print("POST on /error/users for user \(user)")
+            respondWith(nil, nil, .conflict)
         }
+        router.post("/bodyerror/users") { (user: User, respondWith: (Int?, User?, RequestError?) -> Void) in
+            print("POST on /bodyerror/users for user \(user)")
+            respondWith(nil, nil, RequestError(.conflict, body: Conflict(on: "id")))
+        }
+
+        let user = User(id: 4, name: "David")
+        buildServerTest(router, timeout: 30)
+            .request("post", path: "/users", data: user)
+            .hasStatus(.created)
+            .hasHeader("Location", only: String(user.id))
+            .hasContentType(withPrefix: "application/json")
+            .hasData(user)
+
+            .request("post", path: "/error/users", data: user)
+            .hasStatus(.conflict)
+
+            .request("post", path: "/bodyerror/users", data: user)
+            .hasStatus(.conflict)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Conflict(on: "id"))
+
+            .run()
     }
 
-    func testBasicGet() {
+    func testBasicGetSingleton() {
         router.get("/status") { (respondWith: (Status?, RequestError?) -> Void) in
             print("GET on /status")
-
             respondWith(Status("GOOD"), nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-            let expectedStatus = Status("GOOD")
-
-            self.performRequest("get", path: "/status", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-                guard let status = try? JSONDecoder().decode(Status.self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to a Status object, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-                // Validate the data we got back from the server
-                XCTAssertEqual(status.description, expectedStatus.description)
-
-                expectation.fulfill()
-            })
+        router.get("/error/status") { (respondWith: (Status?, RequestError?) -> Void) in
+            print("GET on /status")
+            respondWith(nil, .serviceUnavailable)
         }
+        router.get("/bodyerror/status") { (respondWith: (Status?, RequestError?) -> Void) in
+            print("GET on /status")
+            respondWith(nil, RequestError(.serviceUnavailable, body: Status("BAD")))
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/status")
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("GOOD"))
+
+            .request("get", path: "/error/status")
+            .hasStatus(.serviceUnavailable)
+
+            .request("get", path: "/bodyerror/status")
+            .hasStatus(.serviceUnavailable)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("BAD"))
+
+            .run()
     }
 
     func testBasicGetArray() {
         router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void) in
             print("GET on /users")
-
             respondWith(self.userStore.map({ $0.value }), nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-            let expectedUsers = self.userStore.map({ $0.value }) // TODO: Write these out explicitly?
-
-            self.performRequest("get", path: "/users", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-                guard let users = try? JSONDecoder().decode([User].self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to array of Users, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-
-                // Validate the data we got back from the server
-                for (index, user) in users.enumerated() {
-                    XCTAssertEqual(user.id, expectedUsers[index].id)
-                    XCTAssertEqual(user.name, expectedUsers[index].name)
-                }
-
-                expectation.fulfill()
-            })
+        router.get("/error/users") { (respondWith: ([User]?, RequestError?) -> Void) in
+            print("GET on /error/users")
+            respondWith(nil, .serviceUnavailable)
         }
+        router.get("/bodyerror/users") { (respondWith: ([User]?, RequestError?) -> Void) in
+            print("GET on /bodyerror/users")
+            respondWith(nil, RequestError(.serviceUnavailable, body: Status("BAD")))
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/users")
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(self.userStore.map({ $0.value }))
+
+            .request("get", path: "/error/users")
+            .hasStatus(.serviceUnavailable)
+            .hasNoData()
+
+            .request("get", path: "/bodyerror/users")
+            .hasStatus(.serviceUnavailable)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("BAD"))
+
+            .run()
     }
 
-    func testBasicSingleGet() {
+    func testBasicGetSingle() {
         router.get("/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
-            print("GET on /users")
+            print("GET on /users/\(id)")
             guard let user = self.userStore[id] else {
                 XCTFail("ERROR!!! Couldn't find user with id \(id)")
                 respondWith(nil, .notFound)
@@ -296,154 +270,146 @@ class TestCodableRouter: KituraTest {
             }
             respondWith(user, nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-            guard let expectedUser = self.userStore[1] else {
-                XCTFail("ERROR!!! Couldn't find user with id 1")
-                return
-            }
-
-            self.performRequest("get", path: "/users/1", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-                guard let user = try? JSONDecoder().decode(User.self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to array of Users, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-
-                // Validate the data we got back from the server
-                XCTAssertEqual(user.id, expectedUser.id)
-                XCTAssertEqual(user.name, expectedUser.name)
-
-                expectation.fulfill()
-            })
+        router.get("/error/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
+            print("GET on /error/users/\(id)")
+            respondWith(nil, .serviceUnavailable)
         }
+        router.get("/bodyerror/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
+            print("GET on /bodyerror/users/\(id)")
+            respondWith(nil, RequestError(.serviceUnavailable, body: Status("BAD: \(id)")))
+        }
+
+        guard let user = self.userStore[1] else {
+            XCTFail("ERROR!!! Couldn't find user with id 1")
+            return
+        }
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/users/1")
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(user)
+
+            .request("get", path: "/error/users/1")
+            .hasStatus(.serviceUnavailable)
+            .hasNoData()
+
+            .request("get", path: "/bodyerror/users/1")
+            .hasStatus(.serviceUnavailable)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("BAD: 1"))
+
+            .run()
     }
 
     func testBasicDelete() {
-
         router.delete("/users") { (respondWith: (RequestError?) -> Void) in
+            print("DELETE on /users")
             self.userStore.removeAll()
             respondWith(nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-
-            self.performRequest("delete", path: "/users", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.noContent, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length == 0, "Expected zero bytes, received \(String(describing: length)) bytes.")
-
-                expectation.fulfill()
-            })
+        router.delete("/error/users") { (respondWith: (RequestError?) -> Void) in
+            print("DELETE on /error/users")
+            respondWith(.serviceUnavailable)
         }
+        router.delete("/bodyerror/users") { (respondWith: (RequestError?) -> Void) in
+            print("DELETE on /bodyerror/users")
+            respondWith(RequestError(.serviceUnavailable, body: Status("BAD")))
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("delete", path: "/users")
+            .hasStatus(.noContent)
+            .hasNoData()
+            .has { _ in XCTAssertEqual(self.userStore.count, 0) }
+
+            .request("delete", path: "/error/users")
+            .hasStatus(.serviceUnavailable)
+            .hasNoData()
+
+            .request("delete", path: "/bodyerror/users")
+            .hasStatus(.serviceUnavailable)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("BAD"))
+
+            .run()
     }
 
-    func testBasicSingleDelete() {
-
+    func testBasicDeleteSingle() {
         router.delete("/users") { (id: Int, respondWith: (RequestError?) -> Void) in
+            print("DELETE on /users/\(id)")
             guard let _ = self.userStore.removeValue(forKey: id) else {
                 respondWith(.notFound)
                 return
             }
             respondWith(nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-
-            self.performRequest("delete", path: "/users/1", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.noContent, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length == 0, "Expected zero bytes, received \(String(describing: length)) bytes.")
-
-                expectation.fulfill()
-            })
+        router.delete("/error/users") { (id: Int, respondWith: (RequestError?) -> Void) in
+            print("DELETE on /error/users/\(id)")
+            respondWith(.serviceUnavailable)
         }
+        router.delete("/bodyerror/users") { (id: Int, respondWith: (RequestError?) -> Void) in
+            print("DELETE on /bodyerror/users/\(id)")
+            respondWith(RequestError(.serviceUnavailable, body: Status("BAD: \(id)")))
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("delete", path: "/users/1")
+            .hasStatus(.noContent)
+            .hasNoData()
+            .has { _ in XCTAssertNil(self.userStore[1]) }
+
+            .request("delete", path: "/error/users/1")
+            .hasStatus(.serviceUnavailable)
+            .hasNoData()
+
+            .request("delete", path: "/bodyerror/users/1")
+            .hasStatus(.serviceUnavailable)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("BAD: 1"))
+
+            .run()
     }
 
     func testBasicPut() {
-
         router.put("/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
+            print("PUT on /users/\(id)")
             self.userStore[id] = user
             respondWith(user, nil)
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-            // Let's create a User instance
-            let expectedUser = User(id: 1, name: "David")
-            // Create JSON representation of User instance
-            guard let userData = try? JSONEncoder().encode(expectedUser) else {
-                XCTFail("Could not generate user data from string!")
-                return
-            }
-
-            self.performRequest("put", path: "/users/1", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-                guard let user = try? JSONDecoder().decode(User.self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to User, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-
-                // Validate the data we got back from the server
-                XCTAssertEqual(user.name, expectedUser.name)
-                XCTAssertEqual(user.id, expectedUser.id)
-
-                expectation.fulfill()
-            }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json; charset=utf-8"
-                request.write(from: userData)
-            })
+        router.put("/error/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
+            print("PUT on /error/users/\(id)")
+            respondWith(nil, .serviceUnavailable)
         }
+        router.put("/bodyerror/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
+            print("PUT on /bodyerror/users/\(id)")
+            respondWith(nil, RequestError(.serviceUnavailable, body: Status("BAD: \(id)")))
+        }
+
+        XCTAssertEqual(self.userStore[1]?.name, "Mike")
+
+        let user = User(id: 1, name: "David")
+        buildServerTest(router, timeout: 30)
+            .request("put", path: "/users/1", data: user)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(user)
+            .has { _ in XCTAssertEqual(self.userStore[1]?.name, "David") }
+
+            .request("put", path: "/error/users/1", data: user)
+            .hasStatus(.serviceUnavailable)
+            .hasNoData()
+
+            .request("put", path: "/bodyerror/users/1", data: user)
+            .hasStatus(.serviceUnavailable)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("BAD: 1"))
+
+            .run()
     }
 
     func testBasicPatch() {
-
         router.patch("/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
+            print("PATCH on /users/\(id)")
             guard let existingUser = self.userStore[id] else {
                 respondWith(nil, .notFound)
                 return
@@ -456,46 +422,35 @@ class TestCodableRouter: KituraTest {
                 respondWith(existingUser, nil)
             }
         }
-
-        performServerTest(router, timeout: 30) { expectation in
-            // Let's create a User instance
-            let patchUser = User(id: 2, name: "David")
-            // Create JSON representation of User instance
-            guard let userData = try? JSONEncoder().encode(patchUser) else {
-                XCTFail("Could not generate user data from string!")
-                return
-            }
-
-            self.performRequest("patch", path: "/users/2", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
-
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-                guard let user = try? JSONDecoder().decode(User.self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to User, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-
-                // Validate the data we got back from the server
-                XCTAssertEqual(user.name, patchUser.name)
-                XCTAssertEqual(user.id, 2)
-
-                expectation.fulfill()
-            }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json; charset=utf-8"
-                request.write(from: userData)
-            })
+        router.patch("/error/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
+            print("PATCH on /error/users/\(id)")
+            respondWith(nil, .serviceUnavailable)
         }
+        router.patch("/bodyerror/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
+            print("PATCH on /bodyerror/users/\(id)")
+            respondWith(nil, RequestError(.serviceUnavailable, body: Status("BAD: \(id)")))
+        }
+
+        XCTAssertEqual(self.userStore[2]?.name, "Chris")
+
+        let user = User(id: 2, name: "David")
+        buildServerTest(router, timeout: 30)
+            .request("patch", path: "/users/2", data: user)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(user)
+            .has { _ in XCTAssertEqual(self.userStore[2]?.name, "David") }
+
+            .request("patch", path: "/error/users/2", data: user)
+            .hasStatus(.serviceUnavailable)
+            .hasNoData()
+
+            .request("patch", path: "/bodyerror/users/2", data: user)
+            .hasStatus(.serviceUnavailable)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(Status("BAD: 2"))
+
+            .run()
     }
 
     func testJoinPath() {
@@ -506,164 +461,55 @@ class TestCodableRouter: KituraTest {
         XCTAssertEqual(router.join(path: "a/", with: "b"), "a/b")
     }
 
+    // Test adding a trailing slash to your route when it has an implicit id parameter
     func testRouteWithTrailingSlash() {
-        router.get("/users/") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
-            // Returning an error that's not .notFound so we know this route has been hit
-            respondWith(nil, .conflict)
-        }
-        performServerTest(router, timeout: 30) { expectation in
-            self.performRequest("get", path: "/users/1", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
+        let status = Status("Slashes work as expected")
+        router.get("/status/") { (id: Int, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, nil) }
+        router.put("/status/") { (id: Int, status: Status, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, nil) }
+        router.patch("/status/") { (id: Int, status: Status, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, nil) }
+        router.delete("/status/") { (id: Int, respondWith: (RequestError?) -> Void) in respondWith(nil) }
 
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.conflict, "Expected the '/users' route to be executed even though we passed '/users/'")
-
-                expectation.fulfill()
-            })
-        }
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/status/1").hasStatus(.OK).hasContentType(withPrefix: "application/json").hasData(status)
+            .request("put", path: "/status/1", data: status).hasStatus(.OK).hasContentType(withPrefix: "application/json").hasData(status)
+            .request("patch", path: "/status/1", data: status).hasStatus(.OK).hasContentType(withPrefix: "application/json").hasData(status)
+            .request("delete", path: "/status/1").hasStatus(.noContent).hasNoData()
+            .run()
     }
 
     func testRouteParameters() {
-        //Add this erroneous route which should not be hit by the test, should log an error but we can't test the log so we checkout for a 404 not found.
-        router.get("/users/:id") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
-            print("GET on /users")
-            //Returning an error that's not .notFound so the test will fail in a timely manner if this route is hit
-            respondWith(nil, .conflict)
+        //Add this erroneous route which should not be hit by the test, should log an error but we can't test the log so we check for a 404 not found.
+        let status = Status("Should not be seen")
+        router.get("/status/:id") { (id: Int, respondWith: (Status?, RequestError?) -> Void) in
+            print("GET on /status/:id that should not happen")
+            respondWith(status, nil)
         }
 
-        performServerTest(router, timeout: 30) { expectation in
-            self.performRequest("get", path: "/users/1", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.notFound, "HTTP Status code was \(String(describing: response.statusCode))")
-
-                expectation.fulfill()
-            })
-        }
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/status/1")
+            .hasStatus(.notFound)
+            .hasData("Cannot GET /status/1.")
+            .run()
     }
 
-    func testCodablePutBodyParsing() {
-        router.all(middleware: BodyParser())
-        router.put("/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
-            print("POST on /users for user \(user)")
-            // Let's keep the test simple
-            // We just want to test that we can register a handler that
-            // receives and sends back a Codable instance
-            self.userStore[user.id] = user
-            respondWith(user, nil)
-        }
-
-        performServerTest(router, timeout: 30) { expectation in
-            // Let's create a User instance
-            let expectedUser = User(id: 4, name: "David")
-            // Create JSON representation of User instance
-            guard let userData = try? JSONEncoder().encode(expectedUser) else {
-                XCTFail("Could not generate user data from string!")
-                return
-            }
-
-            self.performRequest("put", path: "/users/2", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.internalServerError, "HTTP Status code was \(String(describing: response.statusCode))")
-
-                expectation.fulfill()
-            }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json; charset=utf-8"
-                request.write(from: userData)
-            })
-        }
-    }
-
-    func testCodablePatchBodyParsing() {
+    // Test that we get an internalServerError when using BodyParser with a Codable route
+    func testCodableRoutesWithBodyParsingFail() {
+        // Add a BodyParser that covers everything
         router.all(middleware: BodyParser())
 
-        router.patch("/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
-            guard let existingUser = self.userStore[id] else {
-                respondWith(nil, .notFound)
-                return
-            }
-            if let patchUserName = patchUser.name {
-                let updatedUser = User(id: id, name: patchUserName)
-                self.userStore[id] = updatedUser
-                respondWith(updatedUser, nil)
-            } else {
-                respondWith(existingUser, nil)
-            }
-        }
+        let status = Status("Should not be seen")
+        router.put("/status") { (id: Int, status: Status, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, nil) }
+        router.patch("/status") { (id: Int, status: Status, respondWith: (Status?, RequestError?) -> Void) -> Void in respondWith(status, nil) }
+        router.post("/status") { (status: Status, respondWith: (Status?, RequestError?) -> Void) -> Void in respondWith(status, nil) }
 
-        performServerTest(router, timeout: 30) { expectation in
-            // Let's create a User instance
-            let patchUser = User(id: 2, name: "David")
-            // Create JSON representation of User instance
-            guard let userData = try? JSONEncoder().encode(patchUser) else {
-                XCTFail("Could not generate user data from string!")
-                return
-            }
-
-            self.performRequest("patch", path: "/users/2", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.internalServerError, "HTTP Status code was \(String(describing: response.statusCode))")
-
-                expectation.fulfill()
-            }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json; charset=utf-8"
-                request.write(from: userData)
-            })
-        }
-    }
-
-    func testCodablePostBodyParsing() {
-        router.all(middleware: BodyParser())
-
-        router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
-            print("POST on /users for user \(user)")
-            // Let's keep the test simple
-            // We just want to test that we can register a handler that
-            // receives and sends back a Codable instance
-            self.userStore[user.id] = user
-            respondWith(user, nil)
-        }
-
-        performServerTest(router, timeout: 30) { expectation in
-            // Let's create a User instance
-            let expectedUser = User(id: 4, name: "David")
-            // Create JSON representation of User instance
-            guard let userData = try? JSONEncoder().encode(expectedUser) else {
-                XCTFail("Could not generate user data from string!")
-                return
-            }
-
-            self.performRequest("post", path: "/users", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.internalServerError, "HTTP Status code was \(String(describing: response.statusCode))")
-
-                expectation.fulfill()
-            }, requestModifier: { request in
-                request.headers["Content-Type"] = "application/json; charset=utf-8"
-                request.write(from: userData)
-            })
-        }
+        buildServerTest(router, timeout: 30)
+            .request("put", path: "/status/2", data: status).hasStatus(.internalServerError).hasNoData()
+            .request("patch", path: "/status/2", data: status).hasStatus(.internalServerError).hasNoData()
+            .request("post", path: "/status", data: status).hasStatus(.internalServerError).hasNoData()
+            .run()
     }
 
     func testCodableGetQueryParameters() {
-
         /// Currently the milliseconds are cut off by our date formatter
         /// This synchronizes it for testing with the codable route
         let date: Date = Coder().dateFormatter.date(from: Coder().dateFormatter.string(from: Date()))!
@@ -680,44 +526,20 @@ class TestCodableRouter: KituraTest {
             respondWith([query], nil)
         }
 
-        performServerTest(router, timeout: 20, asyncTasks: { expectation in
-            self.performRequest("get", path: "/query\(queryStr)", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/query\(queryStr)")
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([expectedQuery])
 
-                var data = Data()
-                guard let length = try? response.readAllData(into: &data) else {
-                    XCTFail("Error reading response length!")
-                    return
-                }
+            .request("get", path: "/query?param=badRequest")
+            .hasStatus(.badRequest)
+            .hasNoData()
 
-                XCTAssert(length > 0, "Expected some bytes, received \(String(describing: length)) bytes.")
-
-                guard let myQuery = try? JSONDecoder().decode([MyQuery].self, from: data) else {
-                    XCTFail("Could not decode response! Expected response decodable to MyQuery, but got \(String(describing: String(data: data, encoding: .utf8)))")
-                    return
-                }
-                XCTAssertEqual(myQuery, [expectedQuery])
-                XCTAssert(response.headers.contains { (key: String, value: [String]) in return key == "Content-Type" && value.contains("application/json") })
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
-                expectation.fulfill()
-            })
-        }, { expectation in
-            self.performRequest("get", path: "/query?param=badRequest", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(String(describing: response.statusCode))")
-                expectation.fulfill()
-            })
-        })
+            .run()
     }
 
     func testCodableDeleteQueryParameters() {
-
         /// Currently the milliseconds are cut off by our date formatter
         /// This synchronizes it for testing with the codable route
         let date: Date = Coder().dateFormatter.date(from: Coder().dateFormatter.string(from: Date()))!
@@ -734,24 +556,15 @@ class TestCodableRouter: KituraTest {
             respondWith(nil)
         }
 
-        performServerTest(router, timeout: 20, asyncTasks: { expectation in
-            self.performRequest("delete", path: "/query\(queryStr)", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response.statusCode))")
-                expectation.fulfill()
-            })
-        },{ expectation in
-            self.performRequest("delete", path: "/query?param=badRequest", callback: { response in
-                guard let response = response else {
-                    XCTFail("ERROR!!! ClientRequest response object was nil")
-                    return
-                }
-                XCTAssertEqual(response.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(String(describing: response.statusCode))")
-                expectation.fulfill()
-            })
-        })
+        buildServerTest(router, timeout: 30)
+            .request("delete", path: "/query\(queryStr)")
+            .hasStatus(.OK)
+            .hasNoData()
+
+            .request("delete", path: "/query?param=badRequest")
+            .hasStatus(.badRequest)
+            .hasNoData()
+
+            .run()
     }
 }

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -206,11 +206,11 @@ class TestCodableRouter: KituraTest {
             respondWith(Status("GOOD"), nil)
         }
         router.get("/error/status") { (respondWith: (Status?, RequestError?) -> Void) in
-            print("GET on /status")
+            print("GET on /error/status")
             respondWith(nil, .serviceUnavailable)
         }
         router.get("/bodyerror/status") { (respondWith: (Status?, RequestError?) -> Void) in
-            print("GET on /status")
+            print("GET on /bodyerror/status")
             respondWith(nil, RequestError(.serviceUnavailable, body: Status("BAD")))
         }
 
@@ -546,7 +546,7 @@ class TestCodableRouter: KituraTest {
         buildServerTest(router, timeout: 30)
             .request("get", path: "/status/1")
             .hasStatus(.notFound)
-            .hasData("Cannot GET /status/1.")
+            .hasData()
             .run()
     }
 

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -143,7 +143,7 @@ class TestCodableRouter: KituraTest {
         }
         router.post("/bodyerror/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
             print("POST on /bodyerror/users for user \(user)")
-            respondWith(user, RequestError(.conflict, body: Conflict(on: "id")))
+            respondWith(nil, RequestError(.conflict, body: Conflict(on: "id")))
         }
 
         let user = User(id: 4, name: "David")
@@ -155,6 +155,7 @@ class TestCodableRouter: KituraTest {
 
             .request("post", path: "/error/users", data: user)
             .hasStatus(.conflict)
+            .hasNoData()
 
             .request("post", path: "/bodyerror/users", data: user)
             .hasStatus(.conflict)
@@ -188,6 +189,7 @@ class TestCodableRouter: KituraTest {
 
             .request("post", path: "/error/users", data: user)
             .hasStatus(.conflict)
+            .hasNoData()
 
             .request("post", path: "/bodyerror/users", data: user)
             .hasStatus(.conflict)
@@ -219,6 +221,7 @@ class TestCodableRouter: KituraTest {
 
             .request("get", path: "/error/status")
             .hasStatus(.serviceUnavailable)
+            .hasNoData()
 
             .request("get", path: "/bodyerror/status")
             .hasStatus(.serviceUnavailable)


### PR DESCRIPTION
Add the capability to provide a `Codable` object to `RequestError` that will be encoded and sent by the `Router` as the response body when passed to the completion handler of a codable route.

## Description
This PR is one part of a pair, this one is for `Kitura`, the other is for `KituraContracts` (https://github.com/IBM-Swift/KituraContracts/pull/12).

**In the `KituraContracts` PR** we add a new generic constructor to `RequestError` that can specify a "base" request error and a body `Codable`, for example: `RequestError(.unavailable, body: health.status)`.

This will assign the object to a new stored property `body` as a (type-erased) `Codable`. The fact the type is erased allow the `RequestError` struct to remain non-generic (changing it to be generic would be a breaking change to the API).

However, this means that the real type of the `body` is no longer know. In order for the `Router` to encode the `body` into `Data` in some format (currently we only support JSON, but in the future there may be other formats) we need to be able to access the real type to pass to the encoder.

To achieve this we also store a closure in a second new stored property `bodyData` at the same time (from within the generic `init` where we still have access to the real type of the body codable). This closure accepts an argument describing the format into which you want to encode the body and returns a `Data` containing the encoded form of the body.

A new struct `BodyFormat` has been added to enumerate the different supported format. Currently only JSON is supported. This was made as a struct rather than an enum to allow new formats to be added without breaking the API (enums are exhaustive and adding a case would break any switch statements relying on that.)

The `bodyData` closure performs a switch on the `BodyFormat` provided and calls the appropriate encoder on the body to convert it to `Data`. If the `BodyFormat` is not recognised, then an `UnsupportedBodyFormatError` (another new type added in this change) will be thrown. Since  `BodyFormat` only has a private initializer, no other code should be able to create them, and provided the generic initializer of `RequestError` and `BodyFormat` are kept in sync, then `UnsupportedBodyFormatError` should never be thrown.

**In this PR** the `Router` has been updated so that codable routes will check for the existence of a `bodyData` in any `RequestError` returned by a codable route handler, and if it is non-nil then will use it to get a `Data` to send as the body of the response.

This PR also adds a number of tests, and to prevent excessive code duplication a new test builder API has been added to allow construction of concise tests in a declarative style.

## Motivation and Context
This change allows codable route handlers to customise the body of error responses. One example of where this feature is needed is the health route generated by the Swift Server Generator and kitura-cli.

This route should send `HTTP 200 OK` when the application is healthy and `HTTP 503 Service Unavailable` when the application is not working. It should also provide a response body that is a JSON object describing the status of the application and each dependent service. This body should be sent both when the application is healthy and when it is not, and is arguably more important in the latter case as it will give information about which service is not available.

Without a custom body for `RequestError` it is not possible to send a response body if the status code is not 2xx (usually HTTP 200 OK, but it varies depending on the HTTP method, eg: `delete` uses HTTP 204 No content).

## How Has This Been Tested?
New tests have been added, tested with `swift test`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
