### PR TITLE
Allow POST success status codes besides 201 (CREATED)

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -268,12 +268,13 @@ extension Router {
                 // Define handler to process result from application
                 let resultHandler: CodableResultClosure<O> = { result, error in
                     do {
+                        var status = HTTPStatusCode.created
                         if let err = error {
-                            let status = self.httpStatusCode(from: err)
-                            response.status(status)
-                        } else {
+                            status = self.httpStatusCode(from: err)
+                        }
+                        response.status(status)
+                        if HTTPStatusCode.successRange.contains(status) {
                             let encoded = try JSONEncoder().encode(result)
-                            response.status(.created)
                             response.headers.setType("json")
                             response.send(data: encoded)
                         }
@@ -317,10 +318,12 @@ extension Router {
                 // Define handler to process result from application
                 let resultHandler: IdentifierCodableResultClosure<Id, O> = { id, result, error in
                     do {
+                        var status = HTTPStatusCode.created
                         if let err = error {
-                            let status = self.httpStatusCode(from: err)
-                            response.status(status)
-                        } else {
+                            status = self.httpStatusCode(from: err)
+                        }
+                        response.status(status)
+                        if HTTPStatusCode.successRange.contains(status) {
                             guard let id = id else {
                                 Log.error("No id (unique identifier) value provided.")
                                 response.status(.internalServerError)
@@ -328,7 +331,6 @@ extension Router {
                                 return
                             }
                             let encoded = try JSONEncoder().encode(result)
-                            response.status(.created)
                             response.headers["Location"] = String(id.value)
                             response.headers.setType("json")
                             response.send(data: encoded)


### PR DESCRIPTION
Allow POST success status codes besides 201 (CREATED)

## Description
This change allows Kitura to send any success response for a POST. This is dependent on a change in Kitura-net: https://github.com/IBM-Swift/Kitura-net/pull/240 . **This will fail to build unless/until the Kitura-net PR dependency is resolved.**

## Motivation and Context
When Kitura receives a POST, its success response is 201 (CREATED). If one explicitly specifies any other success response, such as 200 (OK), Kitura treats it like an error.

## How Has This Been Tested?
Ran `swift test`.
Have been using this modification at Capital One for several months.

## Checklist:
- [x ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.