### PR TITLE
calculateExtension now appends path extension using URL.appendingPath…

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -183,20 +183,16 @@ public class Router {
         let fileExtension: String
         let resourceWithExtension: String
 
-        guard let resourceExtension = URL(string: template)?.pathExtension else {
+        guard let url = URL(string: template) else {
             return (fileExtension: nil, resourceWithExtension: template)
         }
 
-        if resourceExtension.isEmpty {
+        if url.pathExtension.isEmpty {
             fileExtension = defaultEngineFileExtension ?? ""
-  
-            guard let urlWithExtension = URL(string: template)?.appendingPathExtension(fileExtension) else {
-                return (fileExtension: fileExtension, resourceWithExtension: template)
-            }
             
-            resourceWithExtension = urlWithExtension.absoluteString
+            resourceWithExtension = url.appendingPathExtension(fileExtension).absoluteString
         } else {
-            fileExtension = resourceExtension
+            fileExtension = url.pathExtension
             resourceWithExtension = template
         }
 

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -189,10 +189,12 @@ public class Router {
 
         if resourceExtension.isEmpty {
             fileExtension = defaultEngineFileExtension ?? ""
-            // swiftlint:disable todo
-            //TODO: Use stringByAppendingPathExtension once issue https://bugs.swift.org/browse/SR-999 is resolved
-            // swiftlint:enable todo
-            resourceWithExtension = template + "." + fileExtension
+  
+            guard let urlWithExtension = URL(string: template)?.appendingPathExtension(fileExtension) else {
+                return (fileExtension: fileExtension, resourceWithExtension: template)
+            }
+            
+            resourceWithExtension = urlWithExtension.absoluteString
         } else {
             fileExtension = resourceExtension
             resourceWithExtension = template


### PR DESCRIPTION
…Extension.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Completed Todo task in calculateExtension by moving to using the URL.appendingPathExtension method, (as opposed to the recommended NSString method).

## Motivation and Context
It solves the Todo listed in the original source, which was waiting on https://bugs.swift.org/browse/SR-999 to be resolved, (it has).

## How Has This Been Tested?
Ran through the tests via `swift test` and tested it on a test Kitura application locally. All 147 tests passed on macOS.

## Checklist:
Neither of the following is necessary as the existing tests and documentation should this.
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
