### PR TITLE
Refactor CodableRouter to ease code reuse

### DIFF
--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -616,7 +616,7 @@ class TestCodableRouter: KituraTest {
 
         buildServerTest(router, timeout: 30)
             .request("delete", path: "/query\(queryStr)")
-            .hasStatus(.OK)
+            .hasStatus(.noContent)
             .hasNoData()
 
             .request("delete", path: "/query?param=badRequest")


### PR DESCRIPTION
## Description
Remove code duplication in the CodableRouter and expose CodableHelpers as building blocks for extensions to the CodableRouter.

## Motivation and Context
While working on a prototype codable authentication extension to the router I needed to write variations of the existing route registration functions from CodableRouter. These functions have a lot of code duplication to begin with, and with this new extension each function would need to be duplicated again to add the variations.

This motivated a refactor of these functions so they could be constructed from building block functions. These could then be exposed for use by router extensions.


## How Has This Been Tested?
Automated testing


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
