### PR TITLE
fix: Map ORM errors to internalServerError

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -435,7 +435,7 @@ public struct CodableHelpers {
      */
     public static func httpStatusCode(from error: RequestError) -> HTTPStatusCode {
         // ORM status code 7XX mapped to internalServerError 500
-        if error.httpCode >= 700 && error.httpCode < 800 { return HTTPStatusCode.internalServerError ?? HTTPStatusCode.unknown }
+        if error.httpCode >= 700 && error.httpCode < 800 { return HTTPStatusCode.internalServerError }
         return HTTPStatusCode(rawValue: error.rawValue) ?? HTTPStatusCode.unknown
     }
 

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -435,7 +435,7 @@ public struct CodableHelpers {
      */
     public static func httpStatusCode(from error: RequestError) -> HTTPStatusCode {
         // ORM status code 7XX mapped to internalServerError 500
-        if error.httpCode >= 700 { return HTTPStatusCode(rawValue: 500) ?? HTTPStatusCode.unknown }
+        if error.httpCode >= 700 && error.httpCode < 800 { return HTTPStatusCode(rawValue: 500) ?? HTTPStatusCode.unknown }
         return HTTPStatusCode(rawValue: error.rawValue) ?? HTTPStatusCode.unknown
     }
 

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -435,7 +435,7 @@ public struct CodableHelpers {
      */
     public static func httpStatusCode(from error: RequestError) -> HTTPStatusCode {
         // ORM status code 7XX mapped to internalServerError 500
-        if error.httpCode >= 700 && error.httpCode < 800 { return HTTPStatusCode(rawValue: 500) ?? HTTPStatusCode.unknown }
+        if error.httpCode >= 700 && error.httpCode < 800 { return HTTPStatusCode.internalServerError ?? HTTPStatusCode.unknown }
         return HTTPStatusCode(rawValue: error.rawValue) ?? HTTPStatusCode.unknown
     }
 

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -434,6 +434,8 @@ public struct CodableHelpers {
      *            if valid, or HTTPStatusCode.unknown otherwise
      */
     public static func httpStatusCode(from error: RequestError) -> HTTPStatusCode {
+        // ORM status code 7XX mapped to internalServerError 500
+        if error.httpCode >= 700 { return HTTPStatusCode(rawValue: 500) ?? HTTPStatusCode.unknown }
         return HTTPStatusCode(rawValue: error.rawValue) ?? HTTPStatusCode.unknown
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Mapping the ORM errors to internalServerError to not expose sensitive information about the database




