### PR TITLE
Update index.html to reference Swift-Kuery-ORM

### DIFF
--- a/Sources/Kitura/resources/index.html
+++ b/Sources/Kitura/resources/index.html
@@ -132,9 +132,9 @@
                     <div class="contentTrailingRepo">
                         <img src="/@@Kitura-router@@/git-logo.png"/>
                         <div class="contentSectionTextWrapper">
-                            <a href="https://github.com/IBM-Swift/Swift-Kuery" class="contentSectionTitle">IBM-Swift/Swift-Kuery</a>
+                            <a href="https://github.com/IBM-Swift/Swift-Kuery-ORM" class="contentSectionTitle">IBM-Swift/Swift-Kuery-ORM</a>
                             <div class="contentSectionText">
-                                Swifty SQL-like API for use with relational databases.
+                                A Codable Object Relational Mapping (ORM) library for Swift.
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Description
Change the reference in the Kitura server landing page (index.html) from Swift-Kuery to Swift-Kuery-ORM.

## Motivation and Context
To promote the newly released Swift-Kuery-ORM github repository ahead of the Swift-Kuery github repo which is currently referenced on the index.html page.

## How Has This Been Tested?
The modified Sources/Kitura/resources/index.html file was placed in the .build/checkouts/Kitura.git-6522211175291160341 directory of a working HelloWorld Kitura application and the changes checked.