### PR TITLE
Store URL encoded key-value pairs as [String: [String]]

### DIFF
--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -138,7 +138,7 @@ public class RouterRequest {
     public internal(set) var parameters: [String:String] = [:]
 
     /// List of query parameters.
-    public lazy var queryParameters: [String:String] = { [unowned self] in
+    public lazy var queryParameters: [String:[String]] = { [unowned self] in
         return self.urlURL.query?.urlDecodedFieldValuePairs ?? [:]
         }()
 

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -507,7 +507,7 @@ extension RouterResponse {
 
         let jsonStr = String(data: try encoder.encode(jsonp), encoding: .utf8)!
 
-        let taintedJSCallbackName = request.queryParameters[callbackParameter]
+        let taintedJSCallbackName = request.queryParameters[callbackParameter]?.first
 
         if let jsCallbackName = validJsonpCallbackName(taintedJSCallbackName) {
             headers.setType("js")

--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -18,11 +18,12 @@ import Foundation
 import LoggerAPI
 
 /// String Utils
+
 extension String {
 
     /// Parses percent encoded string into query parameters
-    var urlDecodedFieldValuePairs: [String : String] {
-        var result: [String:String] = [:]
+    var urlDecodedFieldValuePairs: [String: [String]] {
+        var result: [String: [String]] = [:]
 
         for item in self.components(separatedBy: "&") {
             guard let range = item.range(of: "=") else {
@@ -35,14 +36,14 @@ extension String {
 
             let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
             if let decodedValue = valueReplacingPlus.removingPercentEncoding {
-                if let value = result[key] {
-                    result[key] = "\(value),\(decodedValue)"
+                if let _ = result[key] {
+                    result[key]!.append(decodedValue)
                 } else {
-                    result[key] = decodedValue
+                    result[key] = [decodedValue]
                 }
             } else {
                 Log.warning("Unable to decode query parameter \(key)")
-                result[key] = valueReplacingPlus
+                result[key] = [valueReplacingPlus]
             }
         }
 

--- a/Sources/Kitura/bodyParser/ParsedBody.swift
+++ b/Sources/Kitura/bodyParser/ParsedBody.swift
@@ -25,8 +25,8 @@ public indirect enum ParsedBody {
 
     /// If the content type was "application/x-www-form-urlencoded" this
     /// associated value will contain a representation of the body as a
-    /// dictionary of key-value pairs.
-    case urlEncoded([String:String])
+    /// dictionary of key-[value] pairs.
+    case urlEncoded([String: [String]])
 
     /// If the content type was "text" this associated value will contain a
     /// representation of the body as a String.
@@ -85,7 +85,7 @@ public indirect enum ParsedBody {
     ///
     /// - Returns: The parsed body as a Dictionary<String, String>, or nil if the body wasn't in
     ///           url encoded form format.
-    public var asURLEncoded: [String:String]? {
+    public var asURLEncoded: [String: [String]]? {
         switch self {
         case .urlEncoded(let body):
             return body

--- a/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
+++ b/Sources/Kitura/bodyParser/URLEncodedBodyParser.swift
@@ -23,6 +23,6 @@ class URLEncodedBodyParser: BodyParserProtocol {
         }
         
         let parsedBody = bodyAsString.urlDecodedFieldValuePairs
-        return parsedBody.count > 0 ? .urlEncoded(parsedBody) : nil
+        return parsedBody.isEmpty ? nil : .urlEncoded(parsedBody)
     }
 }

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -74,7 +74,7 @@ class TestRequests: KituraTest {
             let expectedQueryParams = ["key1" : "value1", "key2" : "value2", "key3" : "value3"]
             XCTAssertEqual(expectedQueryParams.count, request.queryParameters.count, "Unexpected number of query parameters!")
             for (key, value) in expectedQueryParams {
-                guard let v = request.queryParameters[key] else {
+                guard let v = request.queryParameters[key]?.first else {
                     XCTFail("Query parameter \(key) was nil!")
                     return
                 }
@@ -85,7 +85,7 @@ class TestRequests: KituraTest {
 
         // Test query parameters with multiple values assigned to a single key (array)
         router.get("/abc") { request, _, next in
-            let expectedQueryParams = ["key1" : "value1", "key2" : "value2", "key3" : "value3.1,value3.2,value3.3"]
+            let expectedQueryParams = ["key1" : ["value1"], "key2" : ["value2"], "key3" : ["value3.1", "value3.2", "value3.3"]]
             XCTAssertEqual(expectedQueryParams.count, request.queryParameters.count, "Unexpected number of query parameters!")
             for (key, value) in expectedQueryParams {
                 guard let v = request.queryParameters[key] else {
@@ -162,7 +162,7 @@ class TestRequests: KituraTest {
         router.get("/zxcv/:p1") { request, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             let p1 = request.parameters["p1"] ?? "(nil)"
-            let q = request.queryParameters["q"] ?? "(nil)"
+            let q = request.queryParameters["q"]?.first ?? "(nil)"
             let u1 = request.userInfo["u1"] as? NSString ?? "(nil)"
             do {
                 try response.send("<!DOCTYPE html><html><body><b>Received /zxcv</b><p><p>p1=\(p1)<p><p>q=\(q)<p><p>u1=\(u1)</body></html>\n\n").end()

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -282,7 +282,7 @@ class TestResponse: KituraTest {
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
                     let body = try response?.readString()
-                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": [\"rocks\"]] </body></html>\n\n")
                 } catch {
                     XCTFail("Error reading body")
                 }
@@ -299,7 +299,7 @@ class TestResponse: KituraTest {
                 XCTAssertNotNil(response?.headers["Date"], "There was No Date header in the response")
                 do {
                     let body = try response?.readString()
-                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": \"rocks\"] </body></html>\n\n")
+                    XCTAssertEqual(body, "<!DOCTYPE html><html><body><b>Received URL encoded body</b><br> [\"swift\": [\"rocks\"]] </body></html>\n\n")
                 } catch {
                     XCTFail("Error reading body")
                 }
@@ -1121,8 +1121,8 @@ class TestResponse: KituraTest {
 
         router.get("/largeGet") { request, response, _ in
             do {
-                let uint8 = UInt8(request.queryParameters["uint8"] ?? "NA")
-                let count = Int(request.queryParameters["count"] ?? "NA")
+                let uint8 = UInt8(request.queryParameters["uint8"]?.first ?? "NA")
+                let count = Int(request.queryParameters["count"]?.first ?? "NA")
                 if let uint8 = uint8, let count = count {
                     response.send(data: Data(repeating: uint8, count: count))
                 }
@@ -1153,7 +1153,7 @@ class TestResponse: KituraTest {
         router.get("/zxcv/:p1") { request, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             let p1 = request.parameters["p1"] ?? "(nil)"
-            let q = request.queryParameters["q"] ?? "(nil)"
+            let q = request.queryParameters["q"]?.first ?? "(nil)"
             let u1 = request.userInfo["u1"] as? String ?? "(nil)"
             do {
                 try response.send("<!DOCTYPE html><html><body><b>Received /zxcv</b><p><p>p1=\(p1)<p><p>q=\(q)<p><p>u1=\(u1)</body></html>\n\n").end()


### PR DESCRIPTION
… rather than a [String: String].

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a GET request is done with query parameters, such as `http://example.com/search?query=foobar`, those parameters are accessible in the `.queryParameters` property of the RouterRequest object in the handler. If a POST is done with the default "application/x-www-form-urlencoded" enctype, those parameters are accessible by calling `.body?.asURLEncoded` on the RouterRequest object. Both of these are [String: String] dictionaries. These changes change them to be [String: [String]] dictionaries; in other words, rather than each key having a single string value, they have an array of strings.

A [PR for KituraContracts](https://github.com/IBM-Swift/KituraContracts/pull/16) will also need to be accepted to reflect these changes. For now, if you clone my branch to test, you'll need to change the line for KituraContracts in Kitura's `Package.swift` to:

```swift
        .package(url: "https://github.com/NocturnalSolutions/KituraContracts.git", .branch("UrlEncodingValuesArray")),
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 The code that decodes the URL encoding to create these dictionaries is in [String+Extensions.swift](https://github.com/IBM-Swift/Kitura/blob/master/Sources/Kitura/String%2BExtensions.swift).

Consider a form such as: 

```html
<h1>What are your favorite pizza toppings?</h1>
<form method="get">
  <label><input type="checkbox" name="toppings" value="extraCheese" />Extra cheese</label>
  <label><input type="checkbox" name="toppings" value="pepperoni" />Pepperoni</label>
  <label><input type="checkbox" name="toppings" value="pineapple" />Pineapple</label>
  <label><input type="checkbox" name="toppings" value="anchovies" />Anchovies</label>
  <input type="submit" />
</form>
```

If you were to select both "Extra cheese" and "Pineapple," the resulting URL-encoded string would look something like `toppings=extraCheese&toppings=pineapple`. So there are two values for the same key.

However, Kitura will only allow a single string value for each key. So Kitura works around this by using a comma to concatenate all of the values. The result is that `request.queryParameters["toppings"]` will be `"extraCheese,pineapple"`.

I don't like this. For one, it makes it impossible to simply count how many values you have for a key without doing something like `.split(separator: ",").count`. For another, what if a value itself has a comma? Now we're in painful territory.

Unfortunately, this is a fairly significant change that will break existing sites that use forms. Basically, instead of using `let name = request.queryParameters["name"]`, they'll have to use `let name = request.queryParameters["name"]?.first` if they're just expecting a single value in the request. On the other hand, for those if they're doing silliness like `let names = request.queryParameters["name"]?.split(separator: ",")`, it'll just become `let names = request.queryParameters["name"]`.

I'm willing to bet Swift has a way to make a thing which acts like a dictionary if you do a subscript operation on it but acts like a string otherwise, but I think that might be overengineering in this case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests have been adjusted to work with the change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.