### PR TITLE
Update Router Templating API docs

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -27,7 +27,7 @@ import KituraTemplateEngine
 ///   - Routing requests to closures of type `RouterHandler`
 ///   - Routing requests to the handle function of classes that implement the
 ///    `RouterMiddleware` protocol.
-///   - Routing requests to a template engine to generate the appropriate output.
+///   - Routing requests to a `TemplateEngine` to generate the appropriate output.
 ///   - Serving the landing page when someone makes an HTTP request with a path of slash (/).
 ///
 /// When initialising a `Router`, `mergeParameters` allows you to control whether
@@ -126,14 +126,19 @@ public class Router {
 
     // MARK: Template Engine
 
-    /// Register a templating engine. The templating engine will handle files in the `viewsPath`
-    /// that match the file extension it supports.
+    /// Register a template engine to a given router instance.
+    /// A template engine allows rendering of documents using static templates.
+    ///
+    /// By default the templating engine will handle files in the `./Views` directory
+    /// that match the file extension it supports. You can change this default location using the `viewsPath` property.
     /// ### Usage Example: ###
     /// ```swift
     /// let router = Router()
     /// router.add(templateEngine: MyTemplateEngine())
     /// router.add(templateEngine: MyOtherTemplateEngine(), forFileExtensions: ["html"], useDefaultFileExtension: false)
     /// ```
+    /// If multiple different template engines are registered for the same extension, the template engine
+    /// that is registered last will be the one that attempts to render all template files with the chosen extension.
     /// - Parameter templateEngine: The templating engine to register.
     /// - Parameter forFileExtensions: The extensions of the files to apply the template engine on.
     /// - Parameter useDefaultFileExtension: The flag to specify if the default file extension of the
@@ -156,6 +161,10 @@ public class Router {
     /// let router = Router()
     /// router.setDefault(templateEngine: MyTemplateEngine())
     /// ```
+    /// If the template engine doesn't provide a default extension you can provide one using
+    /// `add(templateEngine:forFileExtensions:useDefaultFileExtension:)`. If a router instance doesn't
+    /// have a template engine registered that can render the given template file a
+    /// "No template engine defined for extension" `TemplatingError` is thrown.
     /// - Parameter templateEngine: The templating engine to set as default.
     public func setDefault(templateEngine: TemplateEngine?) {
         if let templateEngine = templateEngine {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update the `TemplateEngine` docs to provide more information regarding edge cases such as registering multiple different template engines to use the same extension. 

## Motivation and Context
Makes the API docs clearer for users. 

