### PR TITLE
Make `RouterResponse.request` public so it can be used in extensions

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -74,7 +74,7 @@ public class RouterResponse {
     private var routerStack: Stack<Router>
 
     /// The associated request
-    let request: RouterRequest
+    public let request: RouterRequest
 
     /// The buffer used for output
     private let buffer = BufferList()


### PR DESCRIPTION
I'd like to propose this small change.

This greatly simplifies my use case:

- My app renders complex HTML pages.
- To keep routers small and focused, the creation of a rendering context (`[String: Any]`) is done using separate view model types.
- My Stencil templates use inheritance. As a result, all view models have a common base context.
- To avoid code duplication, the data for this base context is prepared by a middleware and stored in `request.userInfo`.
- To render a page, I call a custom extension method on `RouterResponse` that can render a view model. This method pulls the base context from `request.userInfo`, merges it with the contents of the view model and uses the result as a rendering context for the template:

```swift
@discardableResult
func render(_ resource: String, viewModel: ViewModel) throws -> RouterResponse {
    let baseContext = request.userInfo
    return try self.render(resource, context: baseContext.merging(viewModel.contents))
}
```

However, this only works when `request` is public. Without this change, I would have to pass the request to my extension method, which feels silly, because the instance already has the request as a property; it's just not public.