### PR TITLE
Raw if no content

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -28,7 +28,7 @@ import Foundation
 ///```swift
 ///router.all("/name", middleware: BodyParser())
 ///router.post("/name") { request, response, next in
-///    guard let parsedBody = request.body, let jsonBody = parsedBody.asJSON else {
+///    guard let jsonBody = request.body?.asJSON else {
 ///        next()
 ///        return
 ///    }

--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -21,12 +21,20 @@ import Foundation
 
 // MARK: BodyParser
 
-/// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a `ParsedBody` enumeration (e.g. json, raw, text, urlEncoded).
+/// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a corresponding `ParsedBody` enumeration ("application/json" -> JSON, "text/*" -> text, "application/x-www-form-urlencoded" -> URLEncoded, "multipart/*" -> multiPart, missing or any other Content-Type -> raw).
 /// In order for the BodyParser to be used it must first be registered with any routes that are interested in the ParsedBody payload.
 ///### Usage Example: ###
-/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware.
+/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. An request with "contentType" = application/json is received. It is then parse as JSON and the value for "name" is returned in the response.
 ///```swift
-///   router.all("/*", middleware: BodyParser())
+///router.all("/name", middleware: BodyParser())
+///router.post("/name") { request, response, next in
+///    guard let parsedBody = request.body, let jsonBody = parsedBody.asJSON else {
+///        next()
+///        return
+///    }
+///    let name = jsonBody["name"] as? String ?? ""
+///    try response.send("Hello \(name)").end()
+///}
 ///```
 /// __Note__: When using Codable Routing in Kitura 2.x the BodyParser should not be registered to any codable routes (doing so will log the following error "No data in request. Codable routes do not allow the use of a BodyParser." and the route handler will not be executed).
 public class BodyParser: RouterMiddleware {
@@ -82,7 +90,7 @@ public class BodyParser: RouterMiddleware {
     /// - Returns: The parsed body.
     public class func parse(_ message: RouterRequest, contentType: String?) -> ParsedBody? {
         guard let contentType = contentType else {
-            return nil
+            return parse(message, parser: RawBodyParser())
         }
 
         if let parser = getParser(contentType: contentType) {

--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -68,11 +68,10 @@ public class BodyParser: RouterMiddleware {
             return next() // the body was already parsed
         }
 
-        guard request.headers["Content-Length"] != nil,
-            let contentType = request.headers["Content-Type"] else {
-                return next()
+        guard request.headers["Content-Length"] != nil else {
+            return next()
         }
-
+        let contentType = request.headers["Content-Type"]
         request.body = BodyParser.parse(request, contentType: contentType)
         next()
     }
@@ -92,7 +91,6 @@ public class BodyParser: RouterMiddleware {
         guard let contentType = contentType else {
             return parse(message, parser: RawBodyParser())
         }
-
         if let parser = getParser(contentType: contentType) {
             return parse(message, parser: parser)
         }

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -167,9 +167,6 @@ class KituraTest: XCTestCase {
                 allHeaders[headerName] = headerValue
             }
         }
-        if allHeaders["Content-Type"] == nil {
-            allHeaders["Content-Type"] = "text/plain"
-        }
 
         let schema = useSSL ? "https" : "http"
         var options: [ClientRequest.Options] =

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -280,7 +280,7 @@ class TestResponse: KituraTest {
     func testRawDataNoContentHeaderPost() {
         performServerTest(router) { expectation in
             self.performRequest("post",
-                                path: "/bodytesthardway",
+                                path: "/bodytest",
                                 callback: { response in
                                     guard let response = response else {
                                         XCTFail("Client response was nil on raw data post.")
@@ -291,7 +291,7 @@ class TestResponse: KituraTest {
                                     XCTAssertNotNil(response.headers["Date"], "There was No Date header in the response")
                                     do {
                                         let responseString = try response.readString()
-                                        XCTAssertEqual("Read 2048 bytes", responseString)
+                                        XCTAssertEqual("length: 2048", responseString)
                                     } catch {
                                         XCTFail("Failed posting raw data")
                                     }

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -195,6 +195,7 @@ class TestResponse: KituraTest {
                 }
                 expectation.fulfill()
             }) {req in
+                req.headers["Content-Type"] = "text/plain"
                 req.write(from: "plover\n")
                 req.write(from: "xyzzy\n")
             }
@@ -269,12 +270,43 @@ class TestResponse: KituraTest {
                 }
                 expectation.fulfill()
             }) {req in
+                req.headers["Content-Type"] = "text/plain"
                 req.write(from: "plover\n")
                 req.write(from: "xyzzy\n")
             }
         }
     }
-
+    
+    func testRawDataNoContentHeaderPost() {
+        performServerTest(router) { expectation in
+            self.performRequest("post",
+                                path: "/bodytesthardway",
+                                callback: { response in
+                                    guard let response = response else {
+                                        XCTFail("Client response was nil on raw data post.")
+                                        expectation.fulfill()
+                                        return
+                                    }
+                                    
+                                    XCTAssertNotNil(response.headers["Date"], "There was No Date header in the response")
+                                    do {
+                                        let responseString = try response.readString()
+                                        XCTAssertEqual("Read 2048 bytes", responseString)
+                                    } catch {
+                                        XCTFail("Failed posting raw data")
+                                    }
+                                    expectation.fulfill()
+            },
+                                
+                                requestModifier: { request in
+                                    let length = 2048
+                                    let bytes = [UInt32](repeating: 0, count: length).map { _ in 0 }
+                                    let randomData = Data(bytes: bytes, count: length)
+                                    request.write(from: randomData)
+            })
+        }
+    }
+    
     func testPostRequestUrlEncoded() {
         performServerTest(router) { expectation in
             self.performRequest("post", path: "/bodytest", callback: {response in


### PR DESCRIPTION
## Description
Changed the BodyParser to parse the body as raw data if no Content-Type header is present. This then makes the behavior match if the Content-Type provides is unknown.

Have updated the Docs to reflect this change and expanded on the usage Example.

Have added a test for this behaviour

## Motivation and Context
This was requested on the slack channel after a user got stuck trying to use the Body parser without having specified a Content-Type. 

## How Has This Been Tested?
- Test has been added and is passing
- Previous Kitura tests are also passing

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
