### PR TITLE
Add asRaw to ParsedBody

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -82,7 +82,7 @@ public class BodyParser: RouterMiddleware {
     /// - Returns: The parsed body.
     public class func parse(_ message: RouterRequest, contentType: String?) -> ParsedBody? {
         guard let contentType = contentType else {
-            return parse(message, parser: RawBodyParser())
+            return nil
         }
 
         if let parser = getParser(contentType: contentType) {

--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -82,7 +82,7 @@ public class BodyParser: RouterMiddleware {
     /// - Returns: The parsed body.
     public class func parse(_ message: RouterRequest, contentType: String?) -> ParsedBody? {
         guard let contentType = contentType else {
-            return nil
+            return parse(message, parser: RawBodyParser())
         }
 
         if let parser = getParser(contentType: contentType) {

--- a/Sources/Kitura/bodyParser/ParsedBody.swift
+++ b/Sources/Kitura/bodyParser/ParsedBody.swift
@@ -68,6 +68,18 @@ public indirect enum ParsedBody {
             return nil
         }
     }
+    
+    /// Extract a "raw" body from the `ParsedBody` enum
+    ///
+    /// - Returns: The "raw" body as a Data, or nil if the body wasn't in raw format.
+    public var asRaw: Data? {
+        switch self {
+        case .raw(let body):
+            return body
+        default:
+            return nil
+        }
+    }
 
     /// Extract a "text" body from the `ParsedBody` enum
     ///

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -1221,7 +1221,7 @@ class TestResponse: KituraTest {
                 } catch {
                     XCTFail("caught error: \(error)")
                 }
-            } else if case let .raw(data) = requestBody {
+            } else if let data = requestBody.asRaw {
                 XCTAssertNotNil(data)
                 let length = "2048"
                 _ = response.send("length: \(length)")


### PR DESCRIPTION
## Description
Added an as raw helper function to parsed body. 

## Motivation and Context

This means instead of:

if case let .raw(data) = requestBody {}

You can do:

if let data = requestBody.asRaw {}

Which is more readable and now matched the other types (JSON, URLEncoded, text)

## How Has This Been Tested?
Test for bodyparser has been changed to use this helper function and is passing

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
