### PR TITLE
Add a userInfo property to RouterResponse

### DIFF
--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -144,6 +144,7 @@ public class RouterRequest {
         }()
 
     /// User info.
+    /// Can be used by middlewares and handlers to store and pass information on to subsequent handlers.
     public var userInfo: [String: Any] = [:]
 
     /// Body of the message.

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -116,6 +116,9 @@ public class RouterResponse {
         }
     }
 
+    /// User info.
+    public var userInfo: [String: Any] = [:]
+    
     /// Initialize a `RouterResponse` instance
     ///
     /// - Parameter response: The `ServerResponse` object to work with

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -117,6 +117,7 @@ public class RouterResponse {
     }
 
     /// User info.
+    /// Can be used by middlewares and handlers to store and pass information on to subsequent handlers.
     public var userInfo: [String: Any] = [:]
     
     /// Initialize a `RouterResponse` instance

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -1087,6 +1087,22 @@ class TestResponse: KituraTest {
         })
     }
 
+    func testUserInfo() {
+        performServerTest(router) { expectation in
+            self.performRequest("get", path: "/user_info", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
+                do {
+                    let body = try response?.readString()
+                    XCTAssertEqual(body, "hello world")
+                } catch {
+                    XCTFail("Error reading body. Error=\(error.localizedDescription)")
+                }
+                expectation.fulfill()
+            })
+        }
+    }
+    
     static func setupRouter() -> Router {
         let router = Router()
 
@@ -1481,6 +1497,22 @@ class TestResponse: KituraTest {
             XCTAssert(response.statusCode == .notFound)
         }
 
+        
+        router.get("user_info", handler: {
+            _, response, next in
+            // Store something in userInfo
+            response.userInfo["greeting"] = "hello"
+            next()
+        }, {
+            _, response, next in
+            // Read the value that should be stored in userInfo
+            guard let greeting = response.userInfo["greeting"] as? String else {
+                return XCTFail()
+            }
+            response.send("\(greeting) world")
+            next()
+        })
+        
         router.error { _, response, next in
             response.headers["Content-Type"] = "text/html; charset=utf-8"
             do {

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -61,7 +61,8 @@ class TestResponse: KituraTest {
             ("testLifecycle", testLifecycle),
             ("testSend", testSend),
             ("testSendAfterEnd", testSendAfterEnd),
-            ("testChangeStatusCodeOnInvokedSend", testChangeStatusCodeOnInvokedSend)
+            ("testChangeStatusCodeOnInvokedSend", testChangeStatusCodeOnInvokedSend),
+            ("testUserInfo", testUserInfo)
         ]
     }
 


### PR DESCRIPTION
This change adds a `userInfo` property to `RouterResponse`. The associated test checks if one handler can store data in `userInfo` and a subsequent handler can read it.

## Motivation and Context

This supports the use case of building a response in several steps. Handlers/middlewares can store intermediate data in `userInfo` so it can be used by the final handler to build the response.

## How Has This Been Tested?

A test scenario is included.

## Checklist:

- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.