### PR TITLE
update bodyparser docs example

### DIFF
--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -24,7 +24,7 @@ import Foundation
 /// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a corresponding `ParsedBody` enumeration ("application/json" -> JSON, "text/*" -> text, "application/x-www-form-urlencoded" -> URLEncoded, "multipart/*" -> multiPart, no declared content type -> nil, any other Content-Type -> raw).
 /// In order for the BodyParser to be used it must first be registered with any routes that are interested in the ParsedBody payload.
 ///### Usage Example: ###
-/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. An request with "contentType" = application/json is received. It is then parse as JSON and the value for "name" is returned in the response.
+/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. A request with "contentType" = application/json is received. It is then parsed as JSON and the value for "name" is returned in the response.
 ///```swift
 ///router.all("/name", middleware: BodyParser())
 ///router.post("/name") { request, response, next in

--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -21,20 +21,31 @@ import Foundation
 
 // MARK: BodyParser
 
-/// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a corresponding `ParsedBody` enumeration ("application/json" -> JSON, "text/*" -> text, "application/x-www-form-urlencoded" -> URLEncoded, "multipart/*" -> multiPart, no declared content type -> nil, any other Content-Type -> raw).
+/// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a corresponding `ParsedBody` enumeration.
 /// In order for the BodyParser to be used it must first be registered with any routes that are interested in the ParsedBody payload.
-///### Usage Example: ###
-/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. A request with "contentType" = application/json is received. It is then parsed as JSON and the value for "name" is returned in the response.
-///```swift
-///router.all("/name", middleware: BodyParser())
-///router.post("/name") { request, response, next in
-///    guard let jsonBody = request.body?.asJSON else {
-///        next()
-///        return
-///    }
-///    let name = jsonBody["name"] as? String ?? ""
-///    try response.send("Hello \(name)").end()
-///}
+/// ### ParsedBody enumerations: ###
+/// ```swift
+/// "application/json" -> JSON: [String: Any]
+/// "text/*" -> text: String
+/// "application/x-www-form-urlencoded" -> URLEncoded: [String:String]
+/// "multipart/*" -> multiPart: [`Part`]
+/// ```
+/// If you provide any other Content-Type header, `ParsedBody` will be the raw bytes as a `Data` object.
+///
+/// If you have not declared a content type, `ParsedBody` will be `nil`
+/// ### Usage Example: ###
+/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. A request with "contentType" == "application/json" is received. It is then parsed as JSON and the value for "name" is returned in the response.
+/// ```swift
+/// router.all("/name", middleware: BodyParser())
+/// router.post("/name") { request, response, next in
+///     guard let jsonBody = request.body?.asJSON else {
+///         next()
+///         return
+///     }
+///     let name = jsonBody["name"] as? String ?? ""
+///     try response.send("Hello \(name)").end()
+/// }
+/// ```
 /// __Note__: When using Codable Routing in Kitura 2.x the BodyParser should not be registered to any codable routes (doing so will log the following error "No data in request. Codable routes do not allow the use of a BodyParser." and the route handler will not be executed).
 public class BodyParser: RouterMiddleware {
 

--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -20,34 +20,42 @@ import LoggerAPI
 import Foundation
 
 // MARK: BodyParser
-/**
- The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a corresponding `ParsedBody` enumeration.  Each enumerations has a helper function, e.g. `asURLEncoded`, for accessing the data.
- In order for the BodyParser to be used it must first be registered with any routes that are interested in the `ParsedBody` payload.
- ### ParsedBody enumerations: ###
- The mapping from the incoming Content-Type to an internal representation of the body data and its helper function, are as follows:
- - "application/json": .json([String: Any])
- - "text/": .text(String)
- - "application/x-www-form-urlencoded": .urlEncoded([String:String])
- - "multipart/": .multipart([`Part`])
- - Content-Type not defined above: .raw(Data)
- 
- If you have not declared a Content-Type header, `ParsedBody` will be `nil`.
- 
- ### Usage Example: ###
- In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. A request with "application/json", ContentType header is received. It is then parsed as JSON and the value for "name" is returned in the response.
- ```swift
- router.all("/name", middleware: BodyParser())
- router.post("/name") { request, response, next in
-     guard let jsonBody = request.parsedBody?.asJSON else {
-         next()
-         return
-     }
-     let name = jsonBody["name"] as? String ?? ""
-     try response.send("Hello \(name)").end()
- }
- ```
- __Note__: When using Codable Routing in Kitura 2.x the BodyParser should not be registered to any codable routes (doing so will log the following error "No data in request. Codable routes do not allow the use of a BodyParser." and the route handler will not be executed).
- */
+
+/// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a corresponding `ParsedBody` enumeration.
+/// 
+/// In order for the BodyParser to be used it must first be registered with any routes that are interested in the `ParsedBody` payload.
+/// 
+/// ### ParsedBody enumeration: ###
+/// 
+/// The mappings from the incoming Content-Type to an internal representation of the body are as follows:
+/// 
+/// ```swift
+///    .json([String: Any])          // "application/json"
+///    .text(String)                 // "text/*"
+///    .urlEncoded([String:String])  // "application/x-www-form-urlencoded"
+///    .multipart([Part])            // "multipart/form-data"
+///    .raw(Data)                    // Any other Content-Type
+/// ```
+///
+/// Each case has a corresponding convenience property, e.g. `asURLEncoded: [String:String]`, for accessing the associated data.
+/// 
+/// __Note__: If you have not declared a Content-Type header, `ParsedBody` will be `nil`.
+/// 
+/// ### Usage Example: ###
+/// 
+/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. A request with "application/json", ContentType header is received. It is then parsed as JSON and the value for "name" is returned in the response.
+/// ```swift
+/// router.all("/name", middleware: BodyParser())
+/// router.post("/name") { request, response, next in
+///     guard let jsonBody = request.parsedBody?.asJSON else {
+///         next()
+///         return
+///     }
+///     let name = jsonBody["name"] as? String ?? ""
+///     try response.send("Hello \(name)").end()
+/// }
+/// ```
+/// __Note__: When using Codable Routing in Kitura 2.x the BodyParser should not be registered to any codable routes (doing so will log the following error "No data in request. Codable routes do not allow the use of a BodyParser." and the route handler will not be executed).
 public class BodyParser: RouterMiddleware {
 
     /// Static buffer size (in bytes)

--- a/Sources/Kitura/bodyParser/BodyParser.swift
+++ b/Sources/Kitura/bodyParser/BodyParser.swift
@@ -21,13 +21,20 @@ import Foundation
 
 // MARK: BodyParser
 
-/// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a `ParsedBody` enumeration (e.g. json, raw, text, urlEncoded).
+/// The `BodyParser` parses the body of the request prior to sending it to the handler. It reads the Content-Type of the message header and populates the `RouterRequest` body field with a corresponding `ParsedBody` enumeration ("application/json" -> JSON, "text/*" -> text, "application/x-www-form-urlencoded" -> URLEncoded, "multipart/*" -> multiPart, no declared content type -> nil, any other Content-Type -> raw).
 /// In order for the BodyParser to be used it must first be registered with any routes that are interested in the ParsedBody payload.
 ///### Usage Example: ###
-/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware.
+/// In this example, all routes to the BodyParser middleware are registered to the `BodyParser` middleware. An request with "contentType" = application/json is received. It is then parse as JSON and the value for "name" is returned in the response.
 ///```swift
-///   router.all("/*", middleware: BodyParser())
-///```
+///router.all("/name", middleware: BodyParser())
+///router.post("/name") { request, response, next in
+///    guard let jsonBody = request.body?.asJSON else {
+///        next()
+///        return
+///    }
+///    let name = jsonBody["name"] as? String ?? ""
+///    try response.send("Hello \(name)").end()
+///}
 /// __Note__: When using Codable Routing in Kitura 2.x the BodyParser should not be registered to any codable routes (doing so will log the following error "No data in request. Codable routes do not allow the use of a BodyParser." and the route handler will not be executed).
 public class BodyParser: RouterMiddleware {
 


### PR DESCRIPTION
## Description
Updated the Jazzy docs for Body parser to say which content type headers match to ParsedBody types.
Have also added a usage example for getting a JSON body

## Motivation and Context
Requested by a user on slack after he was getting nil from the body parser when he wasn't sending a content type header.

## How Has This Been Tested?
Only a docs change so no added tests
