### PR TITLE
Fix: URLEncoded forms treat empty string as nil

### DIFF
--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -26,7 +26,7 @@ extension String {
         var result: [String: String] = [:]
         for item in self.components(separatedBy: "&") {
             let (key, value) = item.keyAndDecodedValue
-            if let value = value {
+            if let value = value, !value.isEmpty {
                 // If value already exists for this key, append it
                 if let existingValue = result[key] {
                     result[key] = "\(existingValue),\(value)"
@@ -46,7 +46,7 @@ extension String {
 
         for item in self.components(separatedBy: "&") {
             let (key, value) = item.keyAndDecodedValue
-            if let value = value {
+            if let value = value, !value.isEmpty {
                 result[key, default: []].append(value)
             }
         }

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -152,8 +152,13 @@ class TestCodableRouter: KituraTest {
             print("POST on /urlencoded for user \(user)")
             respondWith(user, nil)
         }
+        router.post("/optionalurlencoded") { (OptionalUser: OptionalUser, respondWith: (OptionalUser?, RequestError?) -> Void) in
+            print("POST on /urlencoded for user \(OptionalUser)")
+            respondWith(OptionalUser, nil)
+        }
 
         let user = User(id: 4, name: "David")
+        let optionalUser = OptionalUser(id: nil, name: "David")
         buildServerTest(router, timeout: 30)
             .request("post", path: "/users", data: user)
             .hasStatus(.created)
@@ -178,6 +183,19 @@ class TestCodableRouter: KituraTest {
             .hasStatus(.created)
             .hasContentType(withPrefix: "application/json")
             .hasData(user)
+            
+            .request("post", path: "/optionalurlencoded", urlEncodedString: "id=&name=David")
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(optionalUser)
+            
+            .request("post", path: "/urlencoded", urlEncodedString: "id=&name=David")
+            .hasStatus(.unprocessableEntity)
+            .hasNoData()
+            
+            .request("post", path: "/urlencoded", urlEncodedString: "id=4&name=")
+            .hasStatus(.unprocessableEntity)
+            .hasNoData()
             
             .request("post", path: "/urlencoded", urlEncodedString: "encoding=valid&failed=match")
             .hasStatus(.unprocessableEntity)


### PR DESCRIPTION
## Description
This pull requests changes the read as function for URLEncoded forms to treat the empty string as nil. 

## Motivation and Context
In response to issue #1261. When using HTML forms to send data, An empty form will send an empty string to signify nil for all data types (e.g. numbers, dates). 

When decoding a form with optional inputs for these data types the user would get unprocessableEntity since the empty string cannot be converted to a Bool/ date etc. 

This change will also mean that a form submitting an empty string will treat it as being nil instead of the empty string and it will be rejected if the field is non optional.

## How Has This Been Tested?
Tests have been added to check for a number submitted as an empty string being accepted for a struct with an optional value. Test have also been added to show an empty string being rejected for a non optional String and number.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
