### PR TITLE
Custom success status codes for Tuple return types

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -613,8 +613,12 @@ public struct CodableHelpers {
      */
     public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
         return { codableOutput, error in
+            var status = successStatus
             if let error = error {
-                response.status(httpStatusCode(from: error))
+                status = httpStatusCode(from: error)
+            }
+            response.status(status)
+            if status.class != .successful, let error = error {
                 do {
                     if let bodyData = try error.encodeBody(.json) {
                         response.headers.setType("json")
@@ -630,7 +634,6 @@ public struct CodableHelpers {
                     let encoded = try JSONEncoder().encode(entries)
                     response.headers.setType("json")
                     response.send(data: encoded)
-                    response.status(successStatus)
                 } catch {
                     Log.error("Could not encode result: \(error)")
                     response.status(.internalServerError)
@@ -677,7 +680,6 @@ public struct CodableHelpers {
             }
             response.status(status)
             if status.class != .successful, let error = error {
-                response.status(CodableHelpers.httpStatusCode(from: error))
                 do {
                     if let bodyData = try error.encodeBody(.json) {
                         response.headers.setType("json")

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -303,6 +303,11 @@ class TestCodableRouter: KituraTest {
             respondWith(intTuple, nil)
         }
         
+        router.get("/int/explicitStatus") { (respondWith: ([(Int, User)]?, RequestError?) -> Void) in
+            print("GET on /int/explicitStatus")
+            respondWith(intTuple, .ok)
+        }
+        
         router.get("/string/users") { (respondWith: ([(String, User)]?, RequestError?) -> Void) in
             print("GET on /string/users")
             respondWith(stringTuple, nil)
@@ -315,6 +320,11 @@ class TestCodableRouter: KituraTest {
         
         buildServerTest(router, timeout: 30)
             .request("get", path: "/int/users")
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(expectedIntData)
+        
+            .request("get", path: "/int/explicitStatus")
             .hasStatus(.OK)
             .hasContentType(withPrefix: "application/json")
             .hasData(expectedIntData)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR applies the logic from #1254 to the TupleArrayOutResultHandler.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1254 updated the logic for Codable result handlers to check the status class of a `RequestError`.  If it represents a success status, take the successful path but using the specified status code in preference to the default for that method (such as `.created` for POST).

Although that PR was focused on the status code for a POST, it has the nice effect of applying that same logic to all methods, so it is now valid to return a Codable response and any success code in place of a `RequestError`, rather than `nil` as before.  This handler was missed from the original PR as there is no POST method that returns an array of tuples.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A test has been added that explicitly sets the `.ok` status code for a GET on a tuple array.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
