### PR TITLE
Revert "Relax Codable Router type requirements"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "1.7.4"),
-        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "0.0.23")
+        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "0.0.22"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "1.7.4"),
-        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "0.0.22"),
+        .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "0.0.24"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -35,7 +35,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Encodable
+     //User is a struct object that conforms to Codable
      router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void) in
 
         ...
@@ -46,7 +46,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A CodableArrayClosure that gets invoked when a request comes to the server.
      */
-    public func get<O: Encodable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    public func get<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
         getSafely(route, handler: handler)
     }
 
@@ -55,7 +55,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //Status is a struct that conforms to Encodable
+     //Status is a struct object that conforms to Codable
      router.get("/status") { (respondWith: (Status?, RequestError?) -> Void) in
 
         ...
@@ -66,7 +66,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A SimpleCodableClosure that gets invoked when a request comes to the server.
      */
-    public func get<O: Encodable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
+    public func get<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         getSafely(route, handler: handler)
     }
 
@@ -75,7 +75,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Encodable
+     //User is a struct object that conforms to Codable
      router.get("/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -86,7 +86,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An IdentifierSimpleCodableClosure that gets invoked when a request comes to the server.
      */
-    public func get<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
+    public func get<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
         getSafely(route, handler: handler)
     }
 
@@ -94,7 +94,7 @@ extension Router {
      Setup a IdentifierCodableArrayClosure on the provided route which will be invoked when a request comes to the server.
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.get("/users") { (respondWith: ([(Int, User)]?, RequestError?) -> Void) in
      
         ...
@@ -105,7 +105,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A IdentifierCodableArrayClosure that gets invoked when a request comes to the server.
      */
-    public func get<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
+    public func get<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
         getSafely(route, handler: handler)
     }
     
@@ -115,7 +115,7 @@ extension Router {
      ### Usage Example: ###
      ````
      // MyQuery is a codable struct defining the supported query parameters
-     // User is a struct that conforms to Codable
+     // User is a struct object that conforms to Codable
      router.get("/query") { (query: MyQuery, respondWith: ([User]?, RequestError?) -> Void) in
 
         ...
@@ -126,7 +126,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A (QueryParams, CodableArrayResultClosure) -> Void that gets invoked when a request comes to the server.
      */
-    public func get<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
+    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
         getSafely(route, handler: handler)
     }
 
@@ -136,7 +136,7 @@ extension Router {
      ### Usage Example: ###
      ````
      // MyQuery is a codable struct defining the supported query parameters
-     // User is a struct that conforms to Encodable
+     // User is a struct object that conforms to Codable
      router.get("/query") { (query: MyQuery, respondWith: (User?, RequestError?) -> Void) in
 
      ...
@@ -147,7 +147,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A (QueryParams, CodableResultClosure) -> Void that gets invoked when a request comes to the server.
      */
-    public func get<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
+    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
         getSafely(route, handler: handler)
     }
 
@@ -215,7 +215,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -226,7 +226,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A Codable closure that gets invoked when a request comes to the server.
     */
-    public func post<I: Decodable, O: Encodable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
+    public func post<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
         postSafely(route, handler: handler)
     }
 
@@ -237,7 +237,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.post("/users") { (user: User, respondWith: (Int?, User?, RequestError?) -> Void) in
 
         ...
@@ -248,7 +248,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A Codable closure that gets invoked when a request comes to the server.
     */
-    public func post<I: Decodable, Id: Identifier, O: Encodable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
+    public func post<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
         postSafelyWithId(route, handler: handler)
     }
 
@@ -257,7 +257,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.put("/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -268,7 +268,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An Identifier Codable closure that gets invoked when a request comes to the server.
      */
-    public func put<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    public func put<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         putSafely(route, handler: handler)
     }
 
@@ -277,8 +277,8 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
-     //OptionalUser is a struct that conforms to Codable where all properties are optional
+     //User is a struct object that conforms to Codable
+     //OptionalUser is a struct object that conforms to Codable where all properties are optional
      router.patch("/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
 
         ...
@@ -289,12 +289,12 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An Identifier Codable closure that gets invoked when a request comes to the server.
      */
-    public func patch<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    public func patch<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         patchSafely(route, handler: handler)
     }
 
     // POST
-    fileprivate func postSafely<I: Decodable, O: Encodable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
+    fileprivate func postSafely<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -306,7 +306,7 @@ extension Router {
     }
 
     // POST
-    fileprivate func postSafelyWithId<I: Decodable, Id: Identifier, O: Encodable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
+    fileprivate func postSafelyWithId<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -318,7 +318,7 @@ extension Router {
     }
 
     // PUT with Identifier
-    fileprivate func putSafely<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    fileprivate func putSafely<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -335,7 +335,7 @@ extension Router {
     }
 
     // PATCH
-    fileprivate func patchSafely<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    fileprivate func patchSafely<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -352,7 +352,7 @@ extension Router {
     }
 
     // Get single
-    fileprivate func getSafely<O: Encodable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
+    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (single no-identifier) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
@@ -360,15 +360,15 @@ extension Router {
     }
 
     // Get array
-    fileprivate func getSafely<O: Encodable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
         }
     }
     
-    // Get array of (Id, Encodable) tuples
-    fileprivate func getSafely<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
+    // Get array of (Id, Codable) tuples
+    fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")
             handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
@@ -376,7 +376,7 @@ extension Router {
     }
 
     // Get w/Query Parameters
-    fileprivate func getSafely<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
+    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -392,7 +392,7 @@ extension Router {
     }
 
     // Get w/Query Parameters with CodableResultClosure
-    fileprivate func getSafely<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
+    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -409,7 +409,7 @@ extension Router {
     }
 
     // GET single identified element
-    fileprivate func getSafely<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
+    fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -571,7 +571,7 @@ public struct CodableHelpers {
 
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an optional `Encodable` body and an optional `RequestError`
+     * provides an optional `Codable` body and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -596,7 +596,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructOutResultHandler<OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
+    public static func constructOutResultHandler<OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -615,13 +615,9 @@ public struct CodableHelpers {
                 }
             } else {
                 do {
-                    if let codableOutput = codableOutput {
-                        let json = try JSONEncoder().encode(codableOutput)
-                        response.headers.setType("json")
-                        response.send(data: json)
-                    } else {
-                        Log.debug("Note: successful response ('\(status)') delivers no data.")
-                    }
+                    let json = try JSONEncoder().encode(codableOutput)
+                    response.headers.setType("json")
+                    response.send(data: json)
                 } catch {
                     Log.error("Could not encode result: \(error)")
                     response.status(.internalServerError)
@@ -633,7 +629,7 @@ public struct CodableHelpers {
 
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an array of tuples of (Identifier, Encodable) and an optional `RequestError`
+     * provides an array of tuples of (Identifier, Codable) and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -658,7 +654,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
+    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -677,14 +673,10 @@ public struct CodableHelpers {
                 }
             } else {
                 do {
-                    if let codableOutput = codableOutput {
-                        let entries = codableOutput.map({ [$0.value: $1] })
-                        let encoded = try JSONEncoder().encode(entries)
-                        response.headers.setType("json")
-                        response.send(data: encoded)
-                    } else {
-                        Log.debug("Note: successful response ('\(status)') delivers no data.")
-                    }
+                    let entries = codableOutput?.map({ [$0.value: $1] })
+                    let encoded = try JSONEncoder().encode(entries)
+                    response.headers.setType("json")
+                    response.send(data: encoded)
                 } catch {
                     Log.error("Could not encode result: \(error)")
                     response.status(.internalServerError)
@@ -696,7 +688,7 @@ public struct CodableHelpers {
     
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an optional `Identifier` id, optional `Encodable` body and an optional `RequestError`
+     * provides an optional `Identifier` id, optional `Codable` body and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -723,7 +715,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
+    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
         return { id, codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -743,18 +735,15 @@ public struct CodableHelpers {
             } else if let id = id {
                 response.headers["Location"] = String(id.value)
                 do {
-                    if let codableOutput = codableOutput {
-                        let json = try JSONEncoder().encode(codableOutput)
-                        response.headers.setType("json")
-                        response.send(data: json)
-                    } else {
-                        Log.debug("Note: successful response ('\(status)') delivers no data.")
-                    }
+                    let json = try JSONEncoder().encode(codableOutput)
+                    response.headers.setType("json")
+                    response.send(data: json)
                 } catch {
                     Log.error("Could not encode result: \(error)")
                     response.status(.internalServerError)
                 }
             } else {
+                Log.error("No id (unique identifier) value provided.")
                 response.status(.internalServerError)
             }
             completion()
@@ -769,14 +758,14 @@ public struct CodableHelpers {
      *         thereof. It will read the codable input object from the request that can be passed
      *         to a codable route handler.
      *
-     * - Parameter inputCodableType: The `InputType.Type` (a concrete type complying to `Decodable`)
+     * - Parameter inputCodableType: The `InputType.Type` (a concrete type complying to `Codable`)
      *                               to use to represent the decoded body data.
      * - Parameter request: The `RouterRequest` from which to read the body data.
      * - Parameter response: The `RouterResponse` on which to set any error HTTP status codes in
      *                       cases where reading or decoding the data fails.
      * - Returns: An instance of `InputType` representing the decoded body data.
      */
-    public static func readCodableOrSetResponseStatus<InputType: Decodable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse) -> InputType? {
+    public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse) -> InputType? {
         guard CodableHelpers.isContentTypeJSON(request) || CodableHelpers.isContentTypeURLEncoded(request) else {
             response.status(.unsupportedMediaType)
             return nil

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -44,7 +44,6 @@ protocol RequestTestBuilder {
     func request(_ method: String, path: String) -> AssertionTestBuilder
     func request<T: Encodable>(_ method: String, path: String, data: T) -> AssertionTestBuilder
     func request(_ method: String, path: String, urlEncodedString: String) -> AssertionTestBuilder
-    func request(_ method: String, path: String, json: String) -> AssertionTestBuilder
     func run()
 }
 
@@ -89,22 +88,12 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
             }
         }
         
-        init(_ test: KituraTest, _ method: String, _ path: String, urlEncodedString: String) {
+        init(_ test: KituraTest, _ method: String, _ path: String, _ urlEncodedString: String) {
             self.test = test
             self.invoker = { callback in
                 test.performRequest(method, path: path, callback: callback, requestModifier: { request in
                     request.headers["Content-Type"] = "application/x-www-form-urlencoded"
                     request.write(from: urlEncodedString)
-                })
-            }
-        }
-        
-        init(_ test: KituraTest, _ method: String, _ path: String, json: String) {
-            self.test = test
-            self.invoker = { callback in
-                test.performRequest(method, path: path, callback: callback, requestModifier: { request in
-                    request.headers["Content-Type"] = "application/json; charset=utf-8"
-                    request.write(from: json)
                 })
             }
         }
@@ -136,12 +125,7 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
     }
     
     public func request(_ method: String, path: String, urlEncodedString: String) -> AssertionTestBuilder {
-        requests.append(Request(test, method, path, urlEncodedString: urlEncodedString))
-        return self
-    }
-
-    public func request(_ method: String, path: String, json: String) -> AssertionTestBuilder {
-        requests.append(Request(test, method, path, json: json))
+        requests.append(Request(test, method, path, urlEncodedString))
         return self
     }
 

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -41,10 +41,7 @@ class TestCodableRouter: KituraTest {
             ("testCodableGetSingleQueryParameters", testCodableGetSingleQueryParameters),
             ("testCodableGetArrayQueryParameters", testCodableGetArrayQueryParameters),
             ("testCodableDeleteQueryParameters", testCodableDeleteQueryParameters),
-            ("testCodablePostSuccessStatuses", testCodablePostSuccessStatuses),
-            ("testEncodableType", testEncodableType),
-            ("testDecodableTypeCustomStatus", testDecodableTypeCustomStatus),
-            ("testDecodableTypeDefaultStatus", testDecodableTypeDefaultStatus),
+	    ("testCodablePostSuccessStatuses", testCodablePostSuccessStatuses)
         ]
     }
 
@@ -54,7 +51,6 @@ class TestCodableRouter: KituraTest {
 
     // Reset for each test
     override func setUp() {
-        super.setUp()           // Initialize logging
         router = Router()
         userStore = [1: User(id: 1, name: "Mike"), 2: User(id: 2, name: "Chris"), 3: User(id: 3, name: "Ricardo")]
     }
@@ -136,40 +132,6 @@ class TestCodableRouter: KituraTest {
 
         public static func ==(lhs: Nested, rhs: Nested) -> Bool {
             return lhs.nestedIntField == rhs.nestedIntField && lhs.nestedStringField == rhs.nestedStringField
-        }
-    }
-
-    enum OnlyEncodable: Encodable {
-        case data(String)
-
-        private enum CodingKeys: String, CodingKey {
-            case data
-        }
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            switch self {
-            case .data(let value):
-                try container.encode(value, forKey: .data)
-            }
-        }
-    }
-
-    enum OnlyDecodable: Decodable {
-        case data(String)
-
-        private enum CodingKeys: String, CodingKey {
-            case data
-        }
-
-        init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            if let value = try? values.decode(String.self, forKey: .data) {
-                self = .data(value)
-                return
-            }
-            XCTFail("Unable to decode \(dump(values))")
-            self = .data("FAIL")
         }
     }
 
@@ -421,19 +383,6 @@ class TestCodableRouter: KituraTest {
             .run()
     }
 
-    // Test that a type that only conforms to Encodable can be sent
-    func testEncodableType() {
-        router.get("/encodable") { (id: Int, respondWith: (OnlyEncodable?, RequestError?) -> Void) in
-            print("GET on /encodable/\(id)")
-            respondWith(.data("Hello"), nil)
-        }
-        buildServerTest(router, timeout: 30)
-            .request("get", path: "/encodable/1")
-            .hasContentType(withPrefix: "application/json")
-            .hasData("{\"data\":\"Hello\"}")
-            .run()
-    }
-
     func testBasicDelete() {
         router.delete("/users") { (respondWith: (RequestError?) -> Void) in
             print("DELETE on /users")
@@ -537,62 +486,6 @@ class TestCodableRouter: KituraTest {
             .hasContentType(withPrefix: "application/json")
             .hasData(Status("BAD: 1"))
 
-            .run()
-    }
-
-    // Test that a type that only conforms to Decodable can be received. Responses contain no
-    // result body, as the incoming type is not Encodable. Response handlers are tested with
-    // an explicit (nil, .someSuccessStatus) status code.
-    func testDecodableTypeCustomStatus() {
-        router.put("/decodable") { (id: Int, data: OnlyDecodable, respondWith: (OnlyEncodable?, RequestError?) -> Void) in
-            print("PUT on /decodable/\(id)")
-            respondWith(nil, .ok)
-        }
-        router.post("/decodable") { (data: OnlyDecodable, respondWith: (Int?, OnlyEncodable?, RequestError?) -> Void) in
-            print("POST on /decodable")
-            respondWith(1, nil, .created)
-        }
-        let encodedJson = "{\"data\":\"Hello\"}"
-        
-        buildServerTest(router, timeout: 30)
-
-            .request("post", path: "/decodable", json: encodedJson)
-            .hasStatus(.created)
-            .hasHeader("Location", only: "1")
-            .hasNoData()
-            
-            .request("put", path: "/decodable/1", json: encodedJson)
-            .hasStatus(.OK)
-            .hasNoData()
-            
-            .run()
-    }
-
-    // Test that a type that only conforms to Decodable can be received. Responses contain no
-    // result body, as the incoming type is not Encodable. Response handlers are tested with
-    // the default (nil, nil) status code response.
-    func testDecodableTypeDefaultStatus() {
-        router.put("/decodable") { (id: Int, data: OnlyDecodable, respondWith: (OnlyEncodable?, RequestError?) -> Void) in
-            print("PUT on /decodable/\(id)")
-            respondWith(nil, nil)
-        }
-        router.post("/decodable") { (data: OnlyDecodable, respondWith: (Int?, OnlyEncodable?, RequestError?) -> Void) in
-            print("POST on /decodable")
-            respondWith(1, nil, nil)
-        }
-        let encodedJson = "{\"data\":\"Hello\"}"
-        
-        buildServerTest(router, timeout: 30)
-            
-            .request("post", path: "/decodable", json: encodedJson)
-            .hasStatus(.created)
-            .hasHeader("Location", only: "1")
-            .hasNoData()
-            
-            .request("put", path: "/decodable/1", json: encodedJson)
-            .hasStatus(.OK)
-            .hasNoData()
-            
             .run()
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This reverts #1242.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We've found a problem with the relaxing of output types from `Codable` to `Encodable`, such that they are no longer compatible with the [TypeDecoder](https://github.com/IBM-Swift/TypeDecoder).

We need to revert the relaxing of types so that TypeDecoder can be used with the types used by Codable routes.  Unfortunately, this means #1235 is no longer resolved and should be reopened.  We'll still aim to reintroduce this in the future once a solution can be found.

Note - depends on https://github.com/IBM-Swift/KituraContracts/pull/22

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
