### PR TITLE
Issue.843 option2 kitura 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
     - master
     - develop
     - /^issue.*$/
-    - /^kitura/
+    - /^kitura.*$/
 
 # the matrix of builds should cover each combination of Swift version
 # and platform that is supported. The version of Swift used is specified

--- a/Sources/Kitura/FileResourceServer.swift
+++ b/Sources/Kitura/FileResourceServer.swift
@@ -1,0 +1,96 @@
+/*
+ * Copyright IBM Corporation 2016, 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import LoggerAPI
+
+class FileResourceServer {
+
+    /// if file found - send it in response
+    func sendIfFound(resource: String, usingResponse response: RouterResponse) {
+        guard let resourceFileName = getFilePath(for: resource) else {
+            do {
+                try response.send("Cannot find resource: \(resource)").status(.notFound).end()
+            } catch {
+                Log.error("failed to send not found response for resource: \(resource)")
+            }
+            return
+        }
+
+        do {
+            try response.send(fileName: resourceFileName)
+            try response.status(.OK).end()
+        } catch {
+            Log.error("failed to send response with resource \(resourceFileName)")
+        }
+    }
+
+    private func getFilePath(for resource: String) -> String? {
+        let fileManager = FileManager.default
+        var potentialResource = getResourcePathBasedOnSourceLocation(for: resource)
+
+        if potentialResource.hasSuffix("/") {
+            potentialResource += "index.html"
+        }
+
+        let fileExists = fileManager.fileExists(atPath: potentialResource)
+        if fileExists {
+            return potentialResource
+        } else {
+            return getResourcePathBasedOnCurrentDirectory(for: resource, withFileManager: fileManager)
+        }
+    }
+
+    private func getResourcePathBasedOnSourceLocation(for resource: String) -> String {
+        let fileName = NSString(string: #file)
+        let resourceFilePrefixRange: NSRange
+        let lastSlash = fileName.range(of: "/", options: .backwards)
+        if  lastSlash.location != NSNotFound {
+            resourceFilePrefixRange = NSRange(location: 0, length: lastSlash.location+1)
+        } else {
+            resourceFilePrefixRange = NSRange(location: 0, length: fileName.length)
+        }
+        return fileName.substring(with: resourceFilePrefixRange) + "resources/" + resource
+    }
+
+    private func getResourcePathBasedOnCurrentDirectory(for resource: String, withFileManager fileManager: FileManager) -> String? {
+        for suffix in ["/Packages", "/.build/checkouts"] {
+            let packagePath: String
+            #if os(iOS)
+                guard let resourcePath = Bundle.main.resourcePath else {
+                    continue
+                }
+                packagePath = resourcePath + suffix
+            #else
+                packagePath = fileManager.currentDirectoryPath + suffix
+            #endif
+
+            do {
+                let packages = try fileManager.contentsOfDirectory(atPath: packagePath)
+                for package in packages {
+                    let potentialResource = "\(packagePath)/\(package)/Sources/Kitura/resources/\(resource)"
+                    let resourceExists = fileManager.fileExists(atPath: potentialResource)
+                    if resourceExists {
+                        return potentialResource
+                    }
+                }
+            } catch {
+              Log.error("No packages found in \(packagePath)")
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -59,8 +59,11 @@ public class Router {
         }
     }
 
+    /// Prefix for special page resources
+    fileprivate let kituraResourcePrefix = "/@@Kitura-router@@/"
+
     /// Helper for serving file resources
-    private let fileResourceServer: StaticFileServer?
+    fileprivate let fileResourceServer = FileResourceServer()
 
     /// Flag to enable/disable access to parent router's params
     private let mergeParameters: Bool
@@ -101,21 +104,8 @@ public class Router {
     ///                                 from its parent router. Defaults to `false` if not specified.
     public init(mergeParameters: Bool = false) {
         self.mergeParameters = mergeParameters
-        guard let resourcePath = Router.getKituraResourcePath() else {
-            self.fileResourceServer = nil
-            return
-        }
-        self.fileResourceServer = StaticFileServer(path: resourcePath)
 
         Log.verbose("Router initialized")
-    }
-
-    fileprivate static func getKituraResourcePath() -> String? {
-        guard let currentFilePath = NSURL(string: #file),
-            let folderPath = currentFilePath.deletingLastPathComponent else {
-            return nil
-        }
-        return folderPath.appendingPathComponent("resources").absoluteString
     }
 
     func routingHelper(_ method: RouterMethod, pattern: String?, handler: [RouterHandler]) -> Router {
@@ -500,16 +490,24 @@ extension Router : ServerDelegate {
     /// - Parameter next: The closure called to invoke the next handler or middleware
     ///                     associated with the request.
     fileprivate func process(request: RouterRequest, response: RouterResponse, callback: @escaping () -> Void) {
-        if let fileServer = fileResourceServer,
-            fileServer.serveKituraResource(request: request, response: response) {
+        guard let urlPath = request.parsedURLPath.path else {
+            Log.error("request.parsedURLPath.path is nil. Failed to process request")
+            callback()
             return
         }
-        let looper = RouterElementWalker(elements: self.elements,
-                                         parameterHandlers: self.parameterHandlers,
-                                         request: request,
-                                         response: response,
-                                         callback: callback)
-        looper.next()
+
+        if  urlPath.hasPrefix(kituraResourcePrefix) {
+            let resource = String(urlPath[kituraResourcePrefix.endIndex...])
+            fileResourceServer.sendIfFound(resource: resource, usingResponse: response)
+        } else {
+            let looper = RouterElementWalker(elements: self.elements,
+                                             parameterHandlers: self.parameterHandlers,
+                                             request: request,
+                                             response: response,
+                                             callback: callback)
+
+            looper.next()
+        }
     }
 
     /// Send default index.html file and its resources if appropriate, otherwise send
@@ -520,9 +518,8 @@ extension Router : ServerDelegate {
     /// - Parameter response: The `RouterResponse` object used to respond to the
     ///                     HTTP request.
     private func sendDefaultResponse(request: RouterRequest, response: RouterResponse) {
-        if let fileServer = fileResourceServer,
-            request.parsedURLPath.path == "/" {
-            fileServer.handle(request: request, response: response, next: {})
+        if request.parsedURLPath.path == "/" {
+            fileResourceServer.sendIfFound(resource: "index.html", usingResponse: response)
         } else {
             do {
                 let errorMessage = "Cannot \(request.method) \(request.parsedURLPath.path ?? "")."

--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -198,7 +198,8 @@ extension StaticFileServer {
         }
 
         private func isValidFilePath(_ filePath: String) -> Bool {
-            guard let absoluteBasePath = NSURL(fileURLWithPath: servingFilesPath).standardizingPath?.absoluteString, let standardisedPath = NSURL(fileURLWithPath: filePath).standardizingPath?.absoluteString else {
+            guard let absoluteBasePath = NSURL(fileURLWithPath: servingFilesPath).standardizingPath?.absoluteString,
+                let standardisedPath = NSURL(fileURLWithPath: filePath).standardizingPath?.absoluteString else {
                 return false
             }
             return  standardisedPath.hasPrefix(absoluteBasePath)

--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -198,14 +198,10 @@ extension StaticFileServer {
         }
 
         private func isValidFilePath(_ filePath: String) -> Bool {
-            // Check that no-one is using ..'s in the path to poke around the filesystem
-            let absoluteBasePath = NSURL(fileURLWithPath: servingFilesPath).absoluteString
-            let absoluteFilePath = NSURL(fileURLWithPath: filePath).absoluteString
-            #if os(Linux)
-                return  absoluteFilePath.hasPrefix(absoluteBasePath)
-            #else
-                return  absoluteFilePath!.hasPrefix(absoluteBasePath!)
-            #endif
+            guard let absoluteBasePath = NSURL(fileURLWithPath: servingFilesPath).standardizingPath?.absoluteString, let standardisedPath = NSURL(fileURLWithPath: filePath).standardizingPath?.absoluteString else {
+                return false
+            }
+            return  standardisedPath.hasPrefix(absoluteBasePath)
         }
 
         private func serveNotSatisfiable(_ filePath: String, fileSize: UInt64, response: RouterResponse) {

--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -22,8 +22,6 @@ extension StaticFileServer {
     // MARK: FileServer
     class FileServer {
 
-        private static let kituraResourcePrefix = "/@@Kitura-router@@/"
-
         /// Serve "index.html" files in response to a request on a directory.
         private let serveIndexForDirectory: Bool
 
@@ -53,41 +51,7 @@ extension StaticFileServer {
             self.responseHeadersSetter = responseHeadersSetter
         }
 
-        internal func isRequestForKituraResource(in request: RouterRequest) -> Bool {
-            guard let requestPath = request.parsedURLPath.path else {
-                return false
-            }
-            if requestPath.hasPrefix(FileServer.kituraResourcePrefix) {
-                return true
-            }
-            return false
-        }
-
-        internal func getKituraResourcePath(from request: RouterRequest, for response: RouterResponse) -> String? {
-            var filePath = servingFilesPath + "/"
-            guard let requestPath = request.parsedURLPath.path else {
-                return nil
-            }
-            let url = String(requestPath[FileServer.kituraResourcePrefix.endIndex...])
-            if let decodedURL = url.removingPercentEncoding {
-                filePath += decodedURL
-            } else {
-                Log.warning("unable to decode url \(url)")
-                do {
-                    try response.status(.badRequest).end()
-                } catch {
-                    Log.error("Unable to send \"Invalid Request\" for url: \(url) from request path: \(requestPath)")
-                }
-                return nil
-            }
-
-            if filePath.hasSuffix("/") {
-                filePath += "index.html"
-            }
-            return filePath
-        }
-
-        func getFilePath(from request: RouterRequest, for response: RouterResponse) -> String? {
+        func getFilePath(from request: RouterRequest) -> String? {
             var filePath = servingFilesPath
             guard let requestPath = request.parsedURLPath.path else {
                 return nil
@@ -107,12 +71,7 @@ extension StaticFileServer {
                     filePath += decodedURL
                 } else {
                     Log.warning("unable to decode url \(url)")
-                    do {
-                        try response.status(.badRequest).end()
-                    } catch {
-                        Log.error("Unable to send \"Invalid Request\" for url: \(url) from request path: \(requestPath)")
-                    }
-                    return nil
+                    filePath += url
                 }
             }
 
@@ -128,15 +87,6 @@ extension StaticFileServer {
         }
 
         func serveFile(_ filePath: String, requestPath: String, response: RouterResponse) {
-            if  !isValidFilePath(filePath) {
-                Log.error("Invalid request for resource: \(filePath) from request path: \(requestPath)")
-                do {
-                    try response.status(.badRequest).end()
-                } catch {
-                    Log.error("Unable to send \"Invalid Request\" for: \(filePath) from request path: \(requestPath)")
-                }
-                return
-            }
             let fileManager = FileManager()
             var isDirectory = ObjCBool(false)
 
@@ -151,23 +101,14 @@ extension StaticFileServer {
                 return
             }
 
-            if !tryToServeWithExtensions(filePath, response: response) {
-                do {
-                    try response.send("Cannot GET \(requestPath)").status(.notFound).end()
-                } catch {
-                    Log.error("failed to send not found response for resource: \(filePath)")
-                }
-            }
+            tryToServeWithExtensions(filePath, response: response)
         }
 
-        private func tryToServeWithExtensions(_ filePath: String, response: RouterResponse) -> Bool {
+        private func tryToServeWithExtensions(_ filePath: String, response: RouterResponse) {
             let filePathWithPossibleExtensions = possibleExtensions.map { filePath + "." + $0 }
             for filePathWithExtension in filePathWithPossibleExtensions {
-                if serveIfNonDirectoryFile(atPath: filePathWithExtension, response: response) {
-                    return true
-                }
+                serveIfNonDirectoryFile(atPath: filePathWithExtension, response: response)
             }
-            return false
         }
 
         private func serveExistingFile(_ filePath: String, requestPath: String, isDirectory: Bool,
@@ -195,14 +136,18 @@ extension StaticFileServer {
                     let isDirectoryBool = isDirectory
                 #endif
                 if !isDirectoryBool {
-                    return serveNonDirectoryFile(path, response: response)
+                    serveNonDirectoryFile(path, response: response)
+                    return true
                 }
             }
             return false
         }
 
-        @discardableResult
-        private func serveNonDirectoryFile(_ filePath: String, response: RouterResponse) -> Bool {
+        private func serveNonDirectoryFile(_ filePath: String, response: RouterResponse) {
+            if  !isValidFilePath(filePath) {
+                return
+            }
+
             do {
                 let fileAttributes = try FileManager().attributesOfItem(atPath: filePath)
 
@@ -228,49 +173,47 @@ extension StaticFileServer {
                             // If-Range header prevented a partial response. Send the entire file
                             try response.send(fileName: filePath)
                             response.statusCode = .OK
-                            return true
                         } else {
                             // Send a partial response
-                            return serveNonDirectoryPartialFile(filePath, fileSize: fileSize, ranges: rangeHeaderValue.ranges, response: response)
+                            serveNonDirectoryPartialFile(filePath, fileSize: fileSize, ranges: rangeHeaderValue.ranges, response: response)
                         }
                     } else {
                         // Send not satisfiable response
-                        return serveNotSatisfiable(filePath, fileSize: fileSize, response: response)
+                        serveNotSatisfiable(filePath, fileSize: fileSize, response: response)
                     }
                 } else {
                     // Regular request OR Syntactically invalid range request OR fileSize was not available
                     if method == "HEAD" {
                         // Send only headers
                         _ = response.send(status: .OK)
-                        return true
                     } else {
                         // Send the entire file
                         try response.send(fileName: filePath)
                         response.statusCode = .OK
-                        return true
                     }
                 }
             } catch {
                 Log.error("serving file at path \(filePath), error: \(error)")
-                return false
             }
         }
 
         private func isValidFilePath(_ filePath: String) -> Bool {
             // Check that no-one is using ..'s in the path to poke around the filesystem
-            guard let absoluteBasePath = NSURL(fileURLWithPath: servingFilesPath).standardizingPath?.absoluteString, let standardisedPath = NSURL(fileURLWithPath: filePath).standardizingPath?.absoluteString else {
-                return false
-            }
-            return  standardisedPath.hasPrefix(absoluteBasePath)
+            let absoluteBasePath = NSURL(fileURLWithPath: servingFilesPath).absoluteString
+            let absoluteFilePath = NSURL(fileURLWithPath: filePath).absoluteString
+            #if os(Linux)
+                return  absoluteFilePath.hasPrefix(absoluteBasePath)
+            #else
+                return  absoluteFilePath!.hasPrefix(absoluteBasePath!)
+            #endif
         }
 
-        private func serveNotSatisfiable(_ filePath: String, fileSize: UInt64, response: RouterResponse) -> Bool {
+        private func serveNotSatisfiable(_ filePath: String, fileSize: UInt64, response: RouterResponse) {
             response.headers["Content-Range"] = "bytes */\(fileSize)"
             _ = response.send(status: .requestedRangeNotSatisfiable)
-            return true
         }
 
-        private func serveNonDirectoryPartialFile(_ filePath: String, fileSize: UInt64, ranges: [Range<UInt64>], response: RouterResponse) -> Bool {
+        private func serveNonDirectoryPartialFile(_ filePath: String, fileSize: UInt64, ranges: [Range<UInt64>], response: RouterResponse) {
             let contentType =  ContentType.sharedInstance.getContentType(forFileName: filePath)
             if ranges.count == 1 {
                 let data = FileServer.read(contentsOfFile: filePath, inRange: ranges[0])
@@ -279,7 +222,7 @@ extension StaticFileServer {
                 response.headers["Content-Range"] = "bytes \(ranges[0].lowerBound)-\(ranges[0].upperBound)/\(fileSize)"
                 response.send(data: data ?? Data())
                 response.statusCode = .partialContent
-                return true
+
             } else {
                 // Send multi part response
                 let boundary = "KituraBoundary\(UUID().uuidString)" // Maybe a better boundary can be calculated in the future
@@ -298,7 +241,6 @@ extension StaticFileServer {
                 data.append("--\(boundary)--".data(using: .utf8)!)
                 response.send(data: data)
                 response.statusCode = .partialContent
-                return true
             }
         }
 

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -117,7 +117,7 @@ open class StaticFileServer: RouterMiddleware {
             return
         }
 
-        guard let filePath = fileServer.getFilePath(from: request, for: response) else {
+        guard let filePath = fileServer.getFilePath(from: request) else {
             return
         }
 
@@ -126,28 +126,5 @@ open class StaticFileServer: RouterMiddleware {
         }
 
         fileServer.serveFile(filePath, requestPath: requestPath, response: response)
-    }
-
-    @discardableResult
-    internal func serveKituraResource(request: RouterRequest, response: RouterResponse) -> Bool {
-
-        if !fileServer.isRequestForKituraResource(in: request) {
-            return false
-        }
-
-        guard request.serverRequest.method == "GET" else {
-            return false
-        }
-
-        guard let filePath = fileServer.getKituraResourcePath(from: request, for: response) else {
-            return false
-        }
-
-        guard let requestPath = request.parsedURLPath.path else {
-            return false
-        }
-
-        fileServer.serveFile(filePath, requestPath: requestPath, response: response)
-        return true
     }
 }

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -161,6 +161,9 @@ class TestStaticFileServer: KituraTest {
     static func setupRouter() -> Router {
         let router = Router()
 
+        // The route below ensures that the static file server does not prevent all routes being walked
+        router.all("/", middleware: StaticFileServer())
+
         var cacheOptions = StaticFileServer.CacheOptions(maxAgeCacheControlHeader: 2)
         var options = StaticFileServer.Options(possibleExtensions: ["exe", "html"], cacheOptions: cacheOptions)
         router.all("/qwer", middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/", options:options, customResponseHeadersSetter: HeaderSetter()))
@@ -175,9 +178,6 @@ class TestStaticFileServer: KituraTest {
 
         options = StaticFileServer.Options(possibleExtensions: ["exe", "html"], cacheOptions: cacheOptions, acceptRanges: false)
         router.all("/tyui", middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/", options:options, customResponseHeadersSetter: HeaderSetter()))
-
-        // The route below ensures that the static file server does not prevent all routes being walked
-        router.all("/", middleware: StaticFileServer())
 
         return router
     }
@@ -235,11 +235,11 @@ class TestStaticFileServer: KituraTest {
     }
 
     func testGetTraversedFileKituraResource() {
-        runGetResponseTest(path: "/@@Kitura-router@@/../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
+        runGetResponseTest(path: "/@@Kitura-router@@/../../../../../../../../../../../../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
     }
 
     func testGetTraversedFile() {
-        runGetResponseTest(path: "/../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
+        runGetResponseTest(path: "/../../../../../../../../../../../../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
     }
 
     func testAbsolutePathFunction() {

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -235,11 +235,11 @@ class TestStaticFileServer: KituraTest {
     }
 
     func testGetTraversedFileKituraResource() {
-        runGetResponseTest(path: "/@@Kitura-router@@/../../../../../../../../../../../../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
+        runGetResponseTest(path: "/@@Kitura-router@@/../../../Tests/KituraTests/TestStaticFileServer.swift", expectedStatusCode: HTTPStatusCode.notFound)
     }
 
     func testGetTraversedFile() {
-        runGetResponseTest(path: "/../../../../../../../../../../../../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
+        runGetResponseTest(path: "../Tests/KituraTests/TestStaticFileServer.swift", expectedStatusCode: HTTPStatusCode.notFound)
     }
 
     func testAbsolutePathFunction() {

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -35,7 +35,6 @@ class TestStaticFileServer: KituraTest {
             ("testGetWithSpecialCharacters", testGetWithSpecialCharacters),
             ("testGetWithSpecialCharactersEncoded", testGetWithSpecialCharactersEncoded),
             ("testGetKituraResource", testGetKituraResource),
-            ("testGetDefaultResponse", testGetDefaultResponse),
             ("testGetMissingKituraResource", testGetMissingKituraResource),
             ("testAbsolutePathFunction", testAbsolutePathFunction),
             ("testAbsoluteRootPath", testAbsoluteRootPath),
@@ -224,10 +223,6 @@ class TestStaticFileServer: KituraTest {
 
     func testGetKituraResource() {
         runGetResponseTest(path: "/@@Kitura-router@@/")
-    }
-
-    func testGetDefaultResponse() {
-        runGetResponseTest(path: "/")
     }
 
     func testGetMissingKituraResource() {

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -36,6 +36,8 @@ class TestStaticFileServer: KituraTest {
             ("testGetWithSpecialCharactersEncoded", testGetWithSpecialCharactersEncoded),
             ("testGetKituraResource", testGetKituraResource),
             ("testGetMissingKituraResource", testGetMissingKituraResource),
+            ("testGetTraversedFileKituraResource", testGetTraversedFileKituraResource),
+            ("testGetTraversedFile", testGetTraversedFile),
             ("testAbsolutePathFunction", testAbsolutePathFunction),
             ("testAbsoluteRootPath", testAbsoluteRootPath),
             ("testRangeRequests", testRangeRequests),
@@ -174,6 +176,9 @@ class TestStaticFileServer: KituraTest {
         options = StaticFileServer.Options(possibleExtensions: ["exe", "html"], cacheOptions: cacheOptions, acceptRanges: false)
         router.all("/tyui", middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/", options:options, customResponseHeadersSetter: HeaderSetter()))
 
+        // The route below ensures that the static file server does not prevent all routes being walked
+        router.all("/", middleware: StaticFileServer())
+
         return router
     }
 
@@ -227,6 +232,14 @@ class TestStaticFileServer: KituraTest {
 
     func testGetMissingKituraResource() {
         runGetResponseTest(path: "/@@Kitura-router@@/missing.file", expectedStatusCode: HTTPStatusCode.notFound)
+    }
+
+    func testGetTraversedFileKituraResource() {
+        runGetResponseTest(path: "/@@Kitura-router@@/../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
+    }
+
+    func testGetTraversedFile() {
+        runGetResponseTest(path: "/../../../../../../../../../etc/hosts", expectedStatusCode: HTTPStatusCode.notFound)
     }
 
     func testAbsolutePathFunction() {


### PR DESCRIPTION
Revert changes to serve internal resources using static file server.
Ensure serving path are standardized.
Add further tests to check serving boundaries.