### PR TITLE
feat: Add optional QueryParams in closure for  get and delete

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -481,6 +481,7 @@ extension Router {
 
     // Get w/Optional Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableArrayResultClosure<O>) -> Void) {
+        registerGetRoute(route: route, id: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -488,7 +489,7 @@ extension Router {
                 var query: Q? = nil
                 let queryParameters = request.queryParameters
                 if queryParameters.count > 0 {
-                  query = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
+                    query = try QueryDecoder(dictionary: queryParameters).decode(Q.self)
                 }
                 handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
             } catch {
@@ -501,6 +502,7 @@ extension Router {
 
     // Get w/Optional Query Parameters with CodableResultClosure
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableResultClosure<O>) -> Void) {
+        registerGetRoute(route: route, id: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -509,7 +511,7 @@ extension Router {
                 var query: Q? = nil
                 let queryParameters = request.queryParameters
                 if queryParameters.count > 0 {
-                  query = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
+                    query = try QueryDecoder(dictionary: queryParameters).decode(Q.self)
                 }
                 handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
             } catch {
@@ -579,6 +581,7 @@ extension Router {
 
     // DELETE w/Optional Query Parameters
     fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q?, @escaping ResultClosure) -> Void) {
+        registerDeleteRoute(route: route, id: false)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -586,7 +589,7 @@ extension Router {
                 var query: Q? = nil
                 let queryParameters = request.queryParameters
                 if queryParameters.count > 0 {
-                  query = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
+                    query = try QueryDecoder(dictionary: queryParameters).decode(Q.self)
                 }
                 handler(query, CodableHelpers.constructResultHandler(response: response, completion: next))
             } catch {

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -152,6 +152,48 @@ extension Router {
     }
 
     /**
+     Setup a (QueryParams?, CodableArrayResultClosure) -> Void on the provided route which will be invoked when a request comes to the server.
+
+     ### Usage Example: ###
+     ````
+     // MyQuery is a codable struct defining the supported query parameters
+     // User is a struct object that conforms to Codable
+     router.get("/query") { (query: MyQuery?, respondWith: ([User]?, RequestError?) -> Void) in
+
+        ...
+
+        respondWith(users, nil)
+     }
+     ````
+     - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
+     - Parameter handler: A (QueryParams?, CodableArrayResultClosure) -> Void that gets invoked when a request comes to the server.
+     */
+    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableArrayResultClosure<O>) -> Void) {
+        getSafely(route, handler: handler)
+    }
+
+   /**
+     Setup a (QueryParams?, CodableResultClosure) -> Void on the provided route which will be invoked when a request comes to the server.
+
+     ### Usage Example: ###
+     ````
+     // MyQuery is a codable struct defining the supported query parameters
+     // User is a struct object that conforms to Codable
+     router.get("/query") { (query: MyQuery?, respondWith: (User?, RequestError?) -> Void) in
+
+     ...
+
+     respondWith(user, nil)
+     }
+     ````
+     - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
+     - Parameter handler: A (QueryParams?, CodableResultClosure) -> Void that gets invoked when a request comes to the server.
+     */
+    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableResultClosure<O>) -> Void) {
+        getSafely(route, handler: handler)
+    }
+
+    /**
      Setup a NonCodableClosure on the provided route which will be invoked when a request comes to the server.
 
      ### Usage Example: ###
@@ -206,6 +248,26 @@ extension Router {
      - Parameter handler: A (QueryParams, ResultClosure) -> Void that gets invoked when a request comes to the server.
      */
     public func delete<Q: QueryParams>(_ route: String, handler: @escaping (Q, @escaping ResultClosure) -> Void) {
+        deleteSafely(route, handler: handler)
+    }
+
+    /**
+     Setup a (QueryParams?, ResultClosure) -> Void on the provided route which will be invoked when a request comes to the server.
+
+     ### Usage Example: ###
+     ````
+     // MyQuery is a codable struct defining the supported query parameters
+     router.delete("/query") { (query: MyQuery?, respondWith: (RequestError?) -> Void) in
+
+     ...
+
+     respondWith(nil)
+     }
+     ````
+     - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
+     - Parameter handler: A (QueryParams?, ResultClosure) -> Void that gets invoked when a request comes to the server.
+     */
+    public func delete<Q: QueryParams>(_ route: String, handler: @escaping (Q?, @escaping ResultClosure) -> Void) {
         deleteSafely(route, handler: handler)
     }
 
@@ -417,6 +479,46 @@ extension Router {
         }
     }
 
+    // Get w/Optional Query Parameters
+    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableArrayResultClosure<O>) -> Void) {
+        get(route) { request, response, next in
+            Log.verbose("Received GET (plural) type-safe request with Query Parameters")
+            Log.verbose("Query Parameters: \(request.queryParameters)")
+            do {
+                var query: Q? = nil
+                let queryParameters = request.queryParameters
+                if queryParameters.count > 0 {
+                  query = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
+                }
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+            } catch {
+                // Http 400 error
+                response.status(.badRequest)
+                next()
+            }
+        }
+    }
+
+    // Get w/Optional Query Parameters with CodableResultClosure
+    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableResultClosure<O>) -> Void) {
+        get(route) { request, response, next in
+            Log.verbose("Received GET (singular) type-safe request with Query Parameters")
+            Log.verbose("Query Parameters: \(request.queryParameters)")
+            // Define result handler
+            do {
+                var query: Q? = nil
+                let queryParameters = request.queryParameters
+                if queryParameters.count > 0 {
+                  query = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
+                }
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+            } catch {
+                // Http 400 error
+                response.status(.badRequest)
+                next()
+            }
+        }
+    }
     // GET single identified element
     fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
         if parameterIsPresent(in: route) {
@@ -459,13 +561,33 @@ extension Router {
     }
 
     // DELETE w/Query Parameters
-    fileprivate func deleteSafely<Q: Codable>(_ route: String, handler: @escaping (Q, @escaping ResultClosure) -> Void) {
+    fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q, @escaping ResultClosure) -> Void) {
         registerDeleteRoute(route: route, id: false)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
             do {
                 let query: Q = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
+                handler(query, CodableHelpers.constructResultHandler(response: response, completion: next))
+            } catch {
+                // Http 400 error
+                response.status(.badRequest)
+                next()
+            }
+        }
+    }
+
+    // DELETE w/Optional Query Parameters
+    fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q?, @escaping ResultClosure) -> Void) {
+        delete(route) { request, response, next in
+            Log.verbose("Received DELETE type-safe request with Query Parameters")
+            Log.verbose("Query Parameters: \(request.queryParameters)")
+            do {
+                var query: Q? = nil
+                let queryParameters = request.queryParameters
+                if queryParameters.count > 0 {
+                  query = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
+                }
                 handler(query, CodableHelpers.constructResultHandler(response: response, completion: next))
             } catch {
                 // Http 400 error

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -41,7 +41,7 @@ class TestCodableRouter: KituraTest {
             ("testCodableGetSingleQueryParameters", testCodableGetSingleQueryParameters),
             ("testCodableGetArrayQueryParameters", testCodableGetArrayQueryParameters),
             ("testCodableDeleteQueryParameters", testCodableDeleteQueryParameters),
-	    ("testCodablePostSuccessStatuses", testCodablePostSuccessStatuses),
+            ("testCodablePostSuccessStatuses", testCodablePostSuccessStatuses),
             ("testNoDataCustomStatus", testNoDataCustomStatus),
             ("testNoDataDefaultStatus", testNoDataDefaultStatus)
         ]
@@ -716,6 +716,15 @@ class TestCodableRouter: KituraTest {
             respondWith(query, nil)
         }
 
+        router.get("/optionalquery") { (query: MyQuery?, respondWith: (MyQuery?, RequestError?) -> Void) in
+            if let query = query {
+              XCTAssertEqual(query, expectedQuery)
+              respondWith(query, nil)
+            } else {
+              respondWith(nil, nil)
+            }
+        }
+
         buildServerTest(router, timeout: 30)
             .request("get", path: "/query\(queryStr)")
             .hasStatus(.OK)
@@ -723,6 +732,19 @@ class TestCodableRouter: KituraTest {
             .hasData(expectedQuery)
 
             .request("get", path: "/query?param=badRequest")
+            .hasStatus(.badRequest)
+            .hasNoData()
+
+            .request("get", path: "/optionalquery\(queryStr)")
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(expectedQuery)
+
+            .request("get", path: "/optionalquery")
+            .hasStatus(.OK)
+            .hasNoData()
+
+            .request("get", path: "/optionalquery?param=badRequest")
             .hasStatus(.badRequest)
             .hasNoData()
 
@@ -746,13 +768,35 @@ class TestCodableRouter: KituraTest {
             respondWith([query], nil)
         }
 
+        router.get("/optionalquery") { (query: MyQuery?, respondWith: ([MyQuery]?, RequestError?) -> Void) in
+            if let query = query {
+              XCTAssertEqual(query, expectedQuery)
+              respondWith([query], nil)
+            } else {
+              respondWith(nil, nil)
+            }
+        }
+
         buildServerTest(router, timeout: 30)
             .request("get", path: "/query\(queryStr)")
             .hasStatus(.OK)
             .hasContentType(withPrefix: "application/json")
             .hasData([expectedQuery])
 
+            .request("get", path: "/optionalquery\(queryStr)")
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([expectedQuery])
+
+            .request("get", path: "/optionalquery")
+            .hasStatus(.OK)
+            .hasNoData()
+
             .request("get", path: "/query?param=badRequest")
+            .hasStatus(.badRequest)
+            .hasNoData()
+
+            .request("get", path: "/optionalquery?param=badRequest")
             .hasStatus(.badRequest)
             .hasNoData()
 
@@ -776,12 +820,31 @@ class TestCodableRouter: KituraTest {
             respondWith(nil)
         }
 
+        router.delete("/optionalquery") { (query: MyQuery?, respondWith: (RequestError?) -> Void) in
+            if let query = query {
+              XCTAssertEqual(query, expectedQuery)
+            }
+            respondWith(nil)
+        }
+
         buildServerTest(router, timeout: 30)
             .request("delete", path: "/query\(queryStr)")
             .hasStatus(.noContent)
             .hasNoData()
 
             .request("delete", path: "/query?param=badRequest")
+            .hasStatus(.badRequest)
+            .hasNoData()
+
+            .request("delete", path: "/optionalquery\(queryStr)")
+            .hasStatus(.noContent)
+            .hasNoData()
+
+            .request("delete", path: "/optionalquery")
+            .hasStatus(.noContent)
+            .hasNoData()
+
+            .request("delete", path: "/optionalquery?param=badRequest")
             .hasStatus(.badRequest)
             .hasNoData()
 

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -718,10 +718,10 @@ class TestCodableRouter: KituraTest {
 
         router.get("/optionalquery") { (query: MyQuery?, respondWith: (MyQuery?, RequestError?) -> Void) in
             if let query = query {
-              XCTAssertEqual(query, expectedQuery)
-              respondWith(query, nil)
+                XCTAssertEqual(query, expectedQuery)
+                respondWith(query, nil)
             } else {
-              respondWith(nil, nil)
+                respondWith(nil, nil)
             }
         }
 
@@ -770,10 +770,10 @@ class TestCodableRouter: KituraTest {
 
         router.get("/optionalquery") { (query: MyQuery?, respondWith: ([MyQuery]?, RequestError?) -> Void) in
             if let query = query {
-              XCTAssertEqual(query, expectedQuery)
-              respondWith([query], nil)
+                XCTAssertEqual(query, expectedQuery)
+                respondWith([query], nil)
             } else {
-              respondWith(nil, nil)
+                respondWith(nil, nil)
             }
         }
 
@@ -822,7 +822,7 @@ class TestCodableRouter: KituraTest {
 
         router.delete("/optionalquery") { (query: MyQuery?, respondWith: (RequestError?) -> Void) in
             if let query = query {
-              XCTAssertEqual(query, expectedQuery)
+                XCTAssertEqual(query, expectedQuery)
             }
             respondWith(nil)
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR enables optional QueryParams structure in `get` and `delete` routes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When declaring a route with QueryParameters, such as: 
```
router.get("/query") { (query: MyQuery, respondWith: @escaping ([User]?, RequestError?) -> Void) in
```
Currently, we cannot make the query optional, and we would have to declare another route.
This issue resolves this by adding a new closure to the **get** and **delete** accepting an optional QueryParams, so we could write:
```
router.get("/query") { (query: MyQuery?, respondWith: @escaping ([User]?, RequestError?) -> Void) in
```

This route would accept a **get** call on `/query` and `/query?age=5`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test have been added.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [X] If applicable, I have added tests to cover my changes.
