### PR TITLE
Allow Codable success responses with no data

### DIFF
--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -755,6 +755,7 @@ public struct CodableHelpers {
                     response.status(.internalServerError)
                 }
             } else {
+                Log.error("No id (unique identifier) value provided.")
                 response.status(.internalServerError)
             }
             completion()

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -35,7 +35,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct object that conforms to Codable
+     //User is a struct that conforms to Encodable
      router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void) in
 
         ...
@@ -46,7 +46,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A CodableArrayClosure that gets invoked when a request comes to the server.
      */
-    public func get<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    public func get<O: Encodable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
         getSafely(route, handler: handler)
     }
 
@@ -55,7 +55,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //Status is a struct object that conforms to Codable
+     //Status is a struct that conforms to Encodable
      router.get("/status") { (respondWith: (Status?, RequestError?) -> Void) in
 
         ...
@@ -66,7 +66,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A SimpleCodableClosure that gets invoked when a request comes to the server.
      */
-    public func get<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
+    public func get<O: Encodable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         getSafely(route, handler: handler)
     }
 
@@ -75,7 +75,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct object that conforms to Codable
+     //User is a struct that conforms to Encodable
      router.get("/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -86,7 +86,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An IdentifierSimpleCodableClosure that gets invoked when a request comes to the server.
      */
-    public func get<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
+    public func get<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
         getSafely(route, handler: handler)
     }
 
@@ -94,7 +94,7 @@ extension Router {
      Setup a IdentifierCodableArrayClosure on the provided route which will be invoked when a request comes to the server.
      ### Usage Example: ###
      ````
-     //User is a struct object that conforms to Codable
+     //User is a struct that conforms to Codable
      router.get("/users") { (respondWith: ([(Int, User)]?, RequestError?) -> Void) in
      
         ...
@@ -105,7 +105,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A IdentifierCodableArrayClosure that gets invoked when a request comes to the server.
      */
-    public func get<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
+    public func get<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
         getSafely(route, handler: handler)
     }
     
@@ -115,7 +115,7 @@ extension Router {
      ### Usage Example: ###
      ````
      // MyQuery is a codable struct defining the supported query parameters
-     // User is a struct object that conforms to Codable
+     // User is a struct that conforms to Codable
      router.get("/query") { (query: MyQuery, respondWith: ([User]?, RequestError?) -> Void) in
 
         ...
@@ -126,7 +126,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A (QueryParams, CodableArrayResultClosure) -> Void that gets invoked when a request comes to the server.
      */
-    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
+    public func get<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
         getSafely(route, handler: handler)
     }
 
@@ -136,7 +136,7 @@ extension Router {
      ### Usage Example: ###
      ````
      // MyQuery is a codable struct defining the supported query parameters
-     // User is a struct object that conforms to Codable
+     // User is a struct that conforms to Encodable
      router.get("/query") { (query: MyQuery, respondWith: (User?, RequestError?) -> Void) in
 
      ...
@@ -147,7 +147,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A (QueryParams, CodableResultClosure) -> Void that gets invoked when a request comes to the server.
      */
-    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
+    public func get<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
         getSafely(route, handler: handler)
     }
 
@@ -215,7 +215,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct object that conforms to Codable
+     //User is a struct that conforms to Codable
      router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -226,7 +226,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A Codable closure that gets invoked when a request comes to the server.
     */
-    public func post<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
+    public func post<I: Decodable, O: Encodable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
         postSafely(route, handler: handler)
     }
 
@@ -237,7 +237,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct object that conforms to Codable
+     //User is a struct that conforms to Codable
      router.post("/users") { (user: User, respondWith: (Int?, User?, RequestError?) -> Void) in
 
         ...
@@ -248,7 +248,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A Codable closure that gets invoked when a request comes to the server.
     */
-    public func post<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
+    public func post<I: Decodable, Id: Identifier, O: Encodable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
         postSafelyWithId(route, handler: handler)
     }
 
@@ -257,7 +257,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct object that conforms to Codable
+     //User is a struct that conforms to Codable
      router.put("/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -268,7 +268,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An Identifier Codable closure that gets invoked when a request comes to the server.
      */
-    public func put<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    public func put<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         putSafely(route, handler: handler)
     }
 
@@ -277,8 +277,8 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct object that conforms to Codable
-     //OptionalUser is a struct object that conforms to Codable where all properties are optional
+     //User is a struct that conforms to Codable
+     //OptionalUser is a struct that conforms to Codable where all properties are optional
      router.patch("/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
 
         ...
@@ -289,12 +289,12 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An Identifier Codable closure that gets invoked when a request comes to the server.
      */
-    public func patch<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    public func patch<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         patchSafely(route, handler: handler)
     }
 
     // POST
-    fileprivate func postSafely<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
+    fileprivate func postSafely<I: Decodable, O: Encodable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -306,7 +306,7 @@ extension Router {
     }
 
     // POST
-    fileprivate func postSafelyWithId<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
+    fileprivate func postSafelyWithId<I: Decodable, Id: Identifier, O: Encodable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -318,7 +318,7 @@ extension Router {
     }
 
     // PUT with Identifier
-    fileprivate func putSafely<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    fileprivate func putSafely<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -335,7 +335,7 @@ extension Router {
     }
 
     // PATCH
-    fileprivate func patchSafely<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    fileprivate func patchSafely<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -352,7 +352,7 @@ extension Router {
     }
 
     // Get single
-    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
+    fileprivate func getSafely<O: Encodable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (single no-identifier) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
@@ -360,15 +360,15 @@ extension Router {
     }
 
     // Get array
-    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    fileprivate func getSafely<O: Encodable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
         }
     }
     
-    // Get array of (Id, Codable) tuples
-    fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
+    // Get array of (Id, Encodable) tuples
+    fileprivate func getSafely<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")
             handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
@@ -376,7 +376,7 @@ extension Router {
     }
 
     // Get w/Query Parameters
-    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
+    fileprivate func getSafely<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -392,7 +392,7 @@ extension Router {
     }
 
     // Get w/Query Parameters with CodableResultClosure
-    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
+    fileprivate func getSafely<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -409,7 +409,7 @@ extension Router {
     }
 
     // GET single identified element
-    fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
+    fileprivate func getSafely<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -571,7 +571,7 @@ public struct CodableHelpers {
 
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an optional `Codable` body and an optional `RequestError`
+     * provides an optional `Encodable` body and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -596,7 +596,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructOutResultHandler<OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
+    public static func constructOutResultHandler<OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -615,9 +615,13 @@ public struct CodableHelpers {
                 }
             } else {
                 do {
-                    let json = try JSONEncoder().encode(codableOutput)
-                    response.headers.setType("json")
-                    response.send(data: json)
+                    if let codableOutput = codableOutput {
+                        let json = try JSONEncoder().encode(codableOutput)
+                        response.headers.setType("json")
+                        response.send(data: json)
+                    } else {
+                        Log.debug("Note: successful response ('\(status)') delivers no data.")
+                    }
                 } catch {
                     Log.error("Could not encode result: \(error)")
                     response.status(.internalServerError)
@@ -629,7 +633,7 @@ public struct CodableHelpers {
 
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an array of tuples of (Identifier, Codable) and an optional `RequestError`
+     * provides an array of tuples of (Identifier, Encodable) and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -654,7 +658,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
+    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -673,10 +677,14 @@ public struct CodableHelpers {
                 }
             } else {
                 do {
-                    let entries = codableOutput?.map({ [$0.value: $1] })
-                    let encoded = try JSONEncoder().encode(entries)
-                    response.headers.setType("json")
-                    response.send(data: encoded)
+                    if let codableOutput = codableOutput {
+                        let entries = codableOutput.map({ [$0.value: $1] })
+                        let encoded = try JSONEncoder().encode(entries)
+                        response.headers.setType("json")
+                        response.send(data: encoded)
+                    } else {
+                        Log.debug("Note: successful response ('\(status)') delivers no data.")
+                    }
                 } catch {
                     Log.error("Could not encode result: \(error)")
                     response.status(.internalServerError)
@@ -688,7 +696,7 @@ public struct CodableHelpers {
     
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an optional `Identifier` id, optional `Codable` body and an optional `RequestError`
+     * provides an optional `Identifier` id, optional `Encodable` body and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -715,7 +723,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
+    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
         return { id, codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -735,15 +743,18 @@ public struct CodableHelpers {
             } else if let id = id {
                 response.headers["Location"] = String(id.value)
                 do {
-                    let json = try JSONEncoder().encode(codableOutput)
-                    response.headers.setType("json")
-                    response.send(data: json)
+                    if let codableOutput = codableOutput {
+                        let json = try JSONEncoder().encode(codableOutput)
+                        response.headers.setType("json")
+                        response.send(data: json)
+                    } else {
+                        Log.debug("Note: successful response ('\(status)') delivers no data.")
+                    }
                 } catch {
                     Log.error("Could not encode result: \(error)")
                     response.status(.internalServerError)
                 }
             } else {
-                Log.error("No id (unique identifier) value provided.")
                 response.status(.internalServerError)
             }
             completion()
@@ -758,14 +769,14 @@ public struct CodableHelpers {
      *         thereof. It will read the codable input object from the request that can be passed
      *         to a codable route handler.
      *
-     * - Parameter inputCodableType: The `InputType.Type` (a concrete type complying to `Codable`)
+     * - Parameter inputCodableType: The `InputType.Type` (a concrete type complying to `Decodable`)
      *                               to use to represent the decoded body data.
      * - Parameter request: The `RouterRequest` from which to read the body data.
      * - Parameter response: The `RouterResponse` on which to set any error HTTP status codes in
      *                       cases where reading or decoding the data fails.
      * - Returns: An instance of `InputType` representing the decoded body data.
      */
-    public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse) -> InputType? {
+    public static func readCodableOrSetResponseStatus<InputType: Decodable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse) -> InputType? {
         guard CodableHelpers.isContentTypeJSON(request) || CodableHelpers.isContentTypeURLEncoded(request) else {
             response.status(.unsupportedMediaType)
             return nil

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -35,7 +35,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Encodable
+     //User is a struct object that conforms to Codable
      router.get("/users") { (respondWith: ([User]?, RequestError?) -> Void) in
 
         ...
@@ -46,7 +46,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A CodableArrayClosure that gets invoked when a request comes to the server.
      */
-    public func get<O: Encodable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    public func get<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
         getSafely(route, handler: handler)
     }
 
@@ -55,7 +55,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //Status is a struct that conforms to Encodable
+     //Status is a struct object that conforms to Codable
      router.get("/status") { (respondWith: (Status?, RequestError?) -> Void) in
 
         ...
@@ -66,7 +66,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A SimpleCodableClosure that gets invoked when a request comes to the server.
      */
-    public func get<O: Encodable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
+    public func get<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         getSafely(route, handler: handler)
     }
 
@@ -75,7 +75,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Encodable
+     //User is a struct object that conforms to Codable
      router.get("/users") { (id: Int, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -86,7 +86,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An IdentifierSimpleCodableClosure that gets invoked when a request comes to the server.
      */
-    public func get<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
+    public func get<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
         getSafely(route, handler: handler)
     }
 
@@ -94,7 +94,7 @@ extension Router {
      Setup a IdentifierCodableArrayClosure on the provided route which will be invoked when a request comes to the server.
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.get("/users") { (respondWith: ([(Int, User)]?, RequestError?) -> Void) in
      
         ...
@@ -105,7 +105,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A IdentifierCodableArrayClosure that gets invoked when a request comes to the server.
      */
-    public func get<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
+    public func get<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
         getSafely(route, handler: handler)
     }
     
@@ -115,7 +115,7 @@ extension Router {
      ### Usage Example: ###
      ````
      // MyQuery is a codable struct defining the supported query parameters
-     // User is a struct that conforms to Codable
+     // User is a struct object that conforms to Codable
      router.get("/query") { (query: MyQuery, respondWith: ([User]?, RequestError?) -> Void) in
 
         ...
@@ -126,7 +126,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A (QueryParams, CodableArrayResultClosure) -> Void that gets invoked when a request comes to the server.
      */
-    public func get<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
+    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
         getSafely(route, handler: handler)
     }
 
@@ -136,7 +136,7 @@ extension Router {
      ### Usage Example: ###
      ````
      // MyQuery is a codable struct defining the supported query parameters
-     // User is a struct that conforms to Encodable
+     // User is a struct object that conforms to Codable
      router.get("/query") { (query: MyQuery, respondWith: (User?, RequestError?) -> Void) in
 
      ...
@@ -147,7 +147,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A (QueryParams, CodableResultClosure) -> Void that gets invoked when a request comes to the server.
      */
-    public func get<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
+    public func get<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
         getSafely(route, handler: handler)
     }
 
@@ -215,7 +215,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -226,7 +226,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A Codable closure that gets invoked when a request comes to the server.
     */
-    public func post<I: Decodable, O: Encodable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
+    public func post<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
         postSafely(route, handler: handler)
     }
 
@@ -237,7 +237,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.post("/users") { (user: User, respondWith: (Int?, User?, RequestError?) -> Void) in
 
         ...
@@ -248,7 +248,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: A Codable closure that gets invoked when a request comes to the server.
     */
-    public func post<I: Decodable, Id: Identifier, O: Encodable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
+    public func post<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
         postSafelyWithId(route, handler: handler)
     }
 
@@ -257,7 +257,7 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
+     //User is a struct object that conforms to Codable
      router.put("/users") { (id: Int, user: User, respondWith: (User?, RequestError?) -> Void) in
 
         ...
@@ -268,7 +268,7 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An Identifier Codable closure that gets invoked when a request comes to the server.
      */
-    public func put<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    public func put<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         putSafely(route, handler: handler)
     }
 
@@ -277,8 +277,8 @@ extension Router {
 
      ### Usage Example: ###
      ````
-     //User is a struct that conforms to Codable
-     //OptionalUser is a struct that conforms to Codable where all properties are optional
+     //User is a struct object that conforms to Codable
+     //OptionalUser is a struct object that conforms to Codable where all properties are optional
      router.patch("/users") { (id: Int, patchUser: OptionalUser, respondWith: (User?, RequestError?) -> Void) -> Void in
 
         ...
@@ -289,12 +289,12 @@ extension Router {
      - Parameter route: A String specifying the pattern that needs to be matched, in order for the handler to be invoked.
      - Parameter handler: An Identifier Codable closure that gets invoked when a request comes to the server.
      */
-    public func patch<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    public func patch<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         patchSafely(route, handler: handler)
     }
 
     // POST
-    fileprivate func postSafely<I: Decodable, O: Encodable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
+    fileprivate func postSafely<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -306,7 +306,7 @@ extension Router {
     }
 
     // POST
-    fileprivate func postSafelyWithId<I: Decodable, Id: Identifier, O: Encodable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
+    fileprivate func postSafelyWithId<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -318,7 +318,7 @@ extension Router {
     }
 
     // PUT with Identifier
-    fileprivate func putSafely<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    fileprivate func putSafely<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -335,7 +335,7 @@ extension Router {
     }
 
     // PATCH
-    fileprivate func patchSafely<Id: Identifier, I: Decodable, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
+    fileprivate func patchSafely<Id: Identifier, I: Codable, O: Codable>(_ route: String, handler: @escaping IdentifierCodableClosure<Id, I, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -352,7 +352,7 @@ extension Router {
     }
 
     // Get single
-    fileprivate func getSafely<O: Encodable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
+    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (single no-identifier) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
@@ -360,15 +360,15 @@ extension Router {
     }
 
     // Get array
-    fileprivate func getSafely<O: Encodable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
+    fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
         }
     }
     
-    // Get array of (Id, Encodable) tuples
-    fileprivate func getSafely<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
+    // Get array of (Id, Codable) tuples
+    fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")
             handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
@@ -376,7 +376,7 @@ extension Router {
     }
 
     // Get w/Query Parameters
-    fileprivate func getSafely<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
+    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -392,7 +392,7 @@ extension Router {
     }
 
     // Get w/Query Parameters with CodableResultClosure
-    fileprivate func getSafely<Q: QueryParams, O: Encodable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
+    fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -409,7 +409,7 @@ extension Router {
     }
 
     // GET single identified element
-    fileprivate func getSafely<Id: Identifier, O: Encodable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
+    fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierSimpleCodableClosure<Id, O>) {
         if parameterIsPresent(in: route) {
             return
         }
@@ -571,7 +571,7 @@ public struct CodableHelpers {
 
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an optional `Encodable` body and an optional `RequestError`
+     * provides an optional `Codable` body and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -596,7 +596,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructOutResultHandler<OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
+    public static func constructOutResultHandler<OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -633,7 +633,7 @@ public struct CodableHelpers {
 
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an array of tuples of (Identifier, Encodable) and an optional `RequestError`
+     * provides an array of tuples of (Identifier, Codable) and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -658,7 +658,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
+    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -696,7 +696,7 @@ public struct CodableHelpers {
     
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides an optional `Identifier` id, optional `Encodable` body and an optional `RequestError`
+     * provides an optional `Identifier` id, optional `Codable` body and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions
      *         thereof. It will create a closure that can be passed to the registered
@@ -723,7 +723,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Encodable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
+    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
         return { id, codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -769,14 +769,14 @@ public struct CodableHelpers {
      *         thereof. It will read the codable input object from the request that can be passed
      *         to a codable route handler.
      *
-     * - Parameter inputCodableType: The `InputType.Type` (a concrete type complying to `Decodable`)
+     * - Parameter inputCodableType: The `InputType.Type` (a concrete type complying to `Codable`)
      *                               to use to represent the decoded body data.
      * - Parameter request: The `RouterRequest` from which to read the body data.
      * - Parameter response: The `RouterResponse` on which to set any error HTTP status codes in
      *                       cases where reading or decoding the data fails.
      * - Returns: An instance of `InputType` representing the decoded body data.
      */
-    public static func readCodableOrSetResponseStatus<InputType: Decodable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse) -> InputType? {
+    public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse) -> InputType? {
         guard CodableHelpers.isContentTypeJSON(request) || CodableHelpers.isContentTypeURLEncoded(request) else {
             response.status(.unsupportedMediaType)
             return nil

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -100,16 +100,6 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
                 })
             }
         }
-        
-        init(_ test: KituraTest, _ method: String, _ path: String, json: String) {
-            self.test = test
-            self.invoker = { callback in
-                test.performRequest(method, path: path, callback: callback, requestModifier: { request in
-                    request.headers["Content-Type"] = "application/json; charset=utf-8"
-                    request.write(from: json)
-                })
-            }
-        }
     }
     let test: KituraTest
     let router: ServerDelegate

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -100,6 +100,16 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
                 })
             }
         }
+        
+        init(_ test: KituraTest, _ method: String, _ path: String, json: String) {
+            self.test = test
+            self.invoker = { callback in
+                test.performRequest(method, path: path, callback: callback, requestModifier: { request in
+                    request.headers["Content-Type"] = "application/json; charset=utf-8"
+                    request.write(from: json)
+                })
+            }
+        }
     }
     let test: KituraTest
     let router: ServerDelegate

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -41,10 +41,7 @@ class TestCodableRouter: KituraTest {
             ("testCodableGetSingleQueryParameters", testCodableGetSingleQueryParameters),
             ("testCodableGetArrayQueryParameters", testCodableGetArrayQueryParameters),
             ("testCodableDeleteQueryParameters", testCodableDeleteQueryParameters),
-            ("testCodablePostSuccessStatuses", testCodablePostSuccessStatuses),
-            ("testEncodableType", testEncodableType),
-            ("testDecodableTypeCustomStatus", testDecodableTypeCustomStatus),
-            ("testDecodableTypeDefaultStatus", testDecodableTypeDefaultStatus),
+	    ("testCodablePostSuccessStatuses", testCodablePostSuccessStatuses)
         ]
     }
 
@@ -136,40 +133,6 @@ class TestCodableRouter: KituraTest {
 
         public static func ==(lhs: Nested, rhs: Nested) -> Bool {
             return lhs.nestedIntField == rhs.nestedIntField && lhs.nestedStringField == rhs.nestedStringField
-        }
-    }
-
-    enum OnlyEncodable: Encodable {
-        case data(String)
-
-        private enum CodingKeys: String, CodingKey {
-            case data
-        }
-
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            switch self {
-            case .data(let value):
-                try container.encode(value, forKey: .data)
-            }
-        }
-    }
-
-    enum OnlyDecodable: Decodable {
-        case data(String)
-
-        private enum CodingKeys: String, CodingKey {
-            case data
-        }
-
-        init(from decoder: Decoder) throws {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            if let value = try? values.decode(String.self, forKey: .data) {
-                self = .data(value)
-                return
-            }
-            XCTFail("Unable to decode \(dump(values))")
-            self = .data("FAIL")
         }
     }
 
@@ -418,19 +381,6 @@ class TestCodableRouter: KituraTest {
             .hasContentType(withPrefix: "application/json")
             .hasData(Status("BAD: 1"))
 
-            .run()
-    }
-
-    // Test that a type that only conforms to Encodable can be sent
-    func testEncodableType() {
-        router.get("/encodable") { (id: Int, respondWith: (OnlyEncodable?, RequestError?) -> Void) in
-            print("GET on /encodable/\(id)")
-            respondWith(.data("Hello"), nil)
-        }
-        buildServerTest(router, timeout: 30)
-            .request("get", path: "/encodable/1")
-            .hasContentType(withPrefix: "application/json")
-            .hasData("{\"data\":\"Hello\"}")
             .run()
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR reintroduces a change originally developed under #1242 that allows a successful response from a Codable handler with no body (ie. a `nil` return type).

## Motivation and Context
#1254 relaxed the constraints on the return type from a Codable route, to allow response with a custom success code (a `RequestError` representing a status code in the 2xx range) rather than `nil`, which returns a default success status dependent on the method (`.created` for POST, `.OK` for PUT, etc).

As part of #1242 I took this further, and allowed a `nil` body response with either a default (`nil`) or custom (2xx) response code.  In that context it was to allow a POST of a type that could be decoded but not encoded (ie. received, but not sent).  Unfortunately we had to back out #1242, but permitting an empty body as a return type with a success status code is of value in other cases too.

## How Has This Been Tested?
Tests have been added to test both default and custom success return codes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
