### PR TITLE
Swagger: handle models with only optional properties

### DIFF
--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -636,6 +636,8 @@ struct SwaggerDocument: Encodable {
                     let encodedData = try encoder.encode(modelRef.required)
                     if let json = String(data: encodedData, encoding: .utf8) {
                         contentStr.append("\(sp)\"required\": \(json),\(nl)")
+                    } else {
+                        throw SwaggerGenerationError.encodingError
                     }
                 }
                 contentStr.append("\(sp)\"properties\": {\(nl)")

--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -173,7 +173,7 @@ typealias SwaggerProperties = OrderedDictionary<String, SwaggerProperty>
 struct SwaggerModel {
     var type: String
     var properties: SwaggerProperties
-    var required: [String]?
+    var required: [String]
 }
 
 // Enum of supported Swift types.
@@ -508,7 +508,7 @@ struct SwaggerDocument: Encodable {
                 if modelInfo.required.count > 0 {
                     modelDefinition = SwaggerModel(type: "object", properties: modelInfo.properties, required: Array(modelInfo.required))
                 } else {
-                    modelDefinition = SwaggerModel(type: "object", properties: modelInfo.properties, required: nil)
+                    modelDefinition = SwaggerModel(type: "object", properties: modelInfo.properties, required: [])
                 }
                 self.definitions[model] = modelDefinition
             }
@@ -631,16 +631,18 @@ struct SwaggerDocument: Encodable {
         do {
             if let modelRef = self.definitions[model] {
                 contentStr.append("\(sp)\"type\": \"\(modelRef.type)\",\(nl)")
-                let encoder = JSONEncoder()
-                let encodedData = try encoder.encode(modelRef.required)
-                if let json = String(data: encodedData, encoding: .utf8) {
-                    contentStr.append("\(sp)\"required\": \(json),\(nl)")
-                    contentStr.append("\(sp)\"properties\": {\(nl)")
-                    contentStr.append(try JSONEncodeModelProperties(properties: modelRef.properties, pretty: pretty, depth: depth + 1))
-                    contentStr.append("\(sp)}\(nl)")
-                } else {
-                    throw SwaggerGenerationError.encodingError
+                if modelRef.required.count > 0 {
+                    let encoder = JSONEncoder()
+                    let encodedData = try encoder.encode(modelRef.required)
+                    if let json = String(data: encodedData, encoding: .utf8) {
+                        contentStr.append("\(sp)\"required\": \(json),\(nl)")
+                    }
                 }
+                contentStr.append("\(sp)\"properties\": {\(nl)")
+                contentStr.append(try JSONEncodeModelProperties(properties: modelRef.properties, pretty: pretty, depth: depth + 1))
+                contentStr.append("\(sp)}\(nl)")
+            } else {
+                throw SwaggerGenerationError.encodingError
             }
         } catch {
             throw SwaggerGenerationError.encodingError

--- a/Tests/KituraTests/Models/Uglifruit.swift
+++ b/Tests/KituraTests/Models/Uglifruit.swift
@@ -15,8 +15,8 @@
  */
 public struct Uglifruit: Codable {
 
-    let auth: String
-    let colour: String
-    let flavour: String
-    let test: Pear
+    let auth: String?
+    let colour: String?
+    let flavour: String?
+    let test: Pear?
 }

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -220,7 +220,7 @@ class TestSwaggerGeneration: KituraTest {
                         XCTAssertTrue(required.contains("answer"), "model Apple: required is incorrect")
                         XCTAssertTrue(required.count == 1, "model Apple: required.count is incorrect")
                     } else {
-                        XCTFail("model Apple: type is missing")
+                        XCTFail("model Apple: required is missing")
                     }
 
                     if let properties = model["properties"] as? [String: Any] {
@@ -261,6 +261,40 @@ class TestSwaggerGeneration: KituraTest {
                     } else {
                         XCTFail("model Apple: properties is missing")
                     }
+                }
+            } else {
+                XCTFail("definitions section is missing")
+            }
+        } else {
+            XCTFail("got unexpected nil from router.swaggerJSON")
+        }
+    }
+
+    func uglifruitDefinitionsAssertions(json: String?) {
+        if let jsonString = json {
+            guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+            guard let dict = json as? [String: Any] else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+
+            // test for definitions section
+            if let definitions = dict["definitions"] as? [String: Any] {
+                if let model = definitions["Uglifruit"] as? [String: Any] {
+                    if let type = model["type"] as? String {
+                        XCTAssertTrue(type == "object", "model Uglifruit: type is incorrect")
+                    } else {
+                        XCTFail("model Uglifruit: type is missing")
+                    }
+
+                    XCTAssertTrue(model["required"] == nil, "model uglifruit: required should not be here")
                 }
             } else {
                 XCTFail("definitions section is missing")
@@ -623,6 +657,7 @@ class TestSwaggerGeneration: KituraTest {
         sectionsAssertions(json: router.swaggerJSON)
         appleDefinitionsAssertions(json: router.swaggerJSON)
         pearDefinitionsAssertions(json: router.swaggerJSON)
+        uglifruitDefinitionsAssertions(json: router.swaggerJSON)
         pathAssertions(json: router.swaggerJSON)
         pathContentAssertions1(json: router.swaggerJSON)
         pathContentAssertions2(json: router.swaggerJSON)


### PR DESCRIPTION
Currently, the Swagger generation does not work if a model only contains optional properties.

For example:

```swift
public struct Foo {
  public let id: Int?
}
 
router.post("/", handler: postHandler)
 
func postHandler(foo: Foo, completion: (Foo?, RequestError?) -> Void ) {
     completion(foo, nil)
 }
```

This fails because the model serialization code defines `required` as an optional array, and if it's nil the serialization fails.

This PR reworks the code so `required` is non-optional, and uses the empty array if there are no required properties.  Then, check if the array is empty before attempting to serialize it, because serializing an empty `required` array is not valid Swagger.