### PR TITLE
feat: Public TypeAliases

### DIFF
--- a/Sources/Kitura/TypeAliases.swift
+++ b/Sources/Kitura/TypeAliases.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corporation 2017
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,29 +21,58 @@ import KituraContracts
   The purpose is to expose these types at the top level without having to import a specific dependency.
 */
 
-/// Public TypeAlias for QueryParams Type from KituraContracts
+/// Bridge [QueryParams](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L525)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias QueryParams = KituraContracts.QueryParams
 
-/// Public TypeAlias for GreaterThan Type from KituraContracts
+/// Bridge [Identifier](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L568)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
+public typealias Identifier = KituraContracts.Identifier
+
+
+/// Bridge [GreaterThan](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L1159)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias GreaterThan = KituraContracts.GreaterThan
 
-/// Public TypeAlias for LowerThan Type from KituraContracts
+/// Bridge [LowerThan](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L1254)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias LowerThan = KituraContracts.LowerThan
 
-/// Public TypeAlias for GreaterThanOrEqual Type from KituraContracts
+/// Bridge [GreaterThanOrEqual](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L1206)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias GreaterThanOrEqual = KituraContracts.GreaterThanOrEqual
 
-/// Public TypeAlias for LowerThanOrEqual Type from KituraContracts
+/// Bridge [LowerThanOrEqual](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L1301)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias LowerThanOrEqual = KituraContracts.LowerThanOrEqual
 
-/// Public TypeAlias for InclusiveRange Type from KituraContracts
+/// Bridge [InclusiveRange](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L1348)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias InclusiveRange = KituraContracts.InclusiveRange
 
-/// Public TypeAlias for ExclusiveRange Type from KituraContracts
+/// Bridge [ExclusiveRange](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L1402)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias ExclusiveRange = KituraContracts.ExclusiveRange
 
-/// Public TypeAlias for Pagination Type from KituraContracts
+/// Bridge [Pagination](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L1057)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias Pagination = KituraContracts.Pagination
 
-/// Public TypeAlias for Ordering Type from KituraContracts
+/// Bridge [Ordering](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L983)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
 public typealias Ordering = KituraContracts.Ordering
+
+/// Bridge [Order](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift#L983)
+/// from [KituraContracts](https://ibm-swift.github.io/KituraContracts) so that you only need to import
+/// `Kitura` to access it.
+public typealias Order = KituraContracts.Order

--- a/Sources/Kitura/TypeAliases.swift
+++ b/Sources/Kitura/TypeAliases.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import KituraContracts
+
+/*
+  This file declares public typealiases for types stored in the dependencies.
+  The purpose is to expose these types at the top level without having to import a specific dependency.
+*/
+
+/// Public TypeAlias for QueryParams Type from KituraContracts
+public typealias QueryParams = KituraContracts.QueryParams
+
+/// Public TypeAlias for GreaterThan Type from KituraContracts
+public typealias GreaterThan = KituraContracts.GreaterThan
+
+/// Public TypeAlias for LowerThan Type from KituraContracts
+public typealias LowerThan = KituraContracts.LowerThan
+
+/// Public TypeAlias for GreaterThanOrEqual Type from KituraContracts
+public typealias GreaterThanOrEqual = KituraContracts.GreaterThanOrEqual
+
+/// Public TypeAlias for LowerThanOrEqual Type from KituraContracts
+public typealias LowerThanOrEqual = KituraContracts.LowerThanOrEqual
+
+/// Public TypeAlias for InclusiveRange Type from KituraContracts
+public typealias InclusiveRange = KituraContracts.InclusiveRange
+
+/// Public TypeAlias for ExclusiveRange Type from KituraContracts
+public typealias ExclusiveRange = KituraContracts.ExclusiveRange
+
+/// Public TypeAlias for Pagination Type from KituraContracts
+public typealias Pagination = KituraContracts.Pagination
+
+/// Public TypeAlias for Ordering Type from KituraContracts
+public typealias Ordering = KituraContracts.Ordering

--- a/Tests/KituraTests/TestTypeAliases.swift
+++ b/Tests/KituraTests/TestTypeAliases.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2017
+ * Copyright IBM Corporation 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Tests/KituraTests/TestTypeAliases.swift
+++ b/Tests/KituraTests/TestTypeAliases.swift
@@ -1,0 +1,53 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+
+@testable import Kitura
+
+class TestTypeAliases: KituraTest {
+    static var allTests: [(String, (TestTypeAliases) -> () throws -> Void)] {
+        return [
+            ("testKituraContractsTypes", testKituraContractsTypes)
+        ]
+    }
+
+    struct MyQuery: QueryParams {
+        public let greaterThan: GreaterThan<Int>
+        public let greaterThanOrEqual: GreaterThanOrEqual<Int>
+        public let lowerThan: LowerThan<Double>
+        public let lowerThanOrEqual: LowerThanOrEqual<Double>
+        public let inclusiveRange: InclusiveRange<UInt>
+        public let exclusiveRange: ExclusiveRange<UInt>
+        public let ordering: Ordering
+        public let pagination: Pagination
+    }
+
+    func testKituraContractsTypes() {
+      /// Test that it can constuct the Types without KituraContracts import statement
+
+      let query = MyQuery(
+        greaterThan: GreaterThan(value: 8),
+        greaterThanOrEqual: GreaterThanOrEqual(value: 10),
+        lowerThan: LowerThan(value: 7.0),
+        lowerThanOrEqual: LowerThanOrEqual(value: 12.0),
+        inclusiveRange: InclusiveRange(start: 0, end: 5),
+        exclusiveRange: ExclusiveRange(start: 4, end: 15),
+        ordering: Ordering(by: .asc("name"), .desc("age")),
+        pagination: Pagination(start: 8, size: 14)
+      )
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -63,5 +63,6 @@ XCTMain([
     testCase(TestBridgingHTTPStatusCode.allTests.shuffled()),
     testCase(TestBridgingRequestError.allTests.shuffled()),
     testCase(TestSwaggerGeneration.allTests.shuffled()),
+    testCase(TestTypeAliases.allTests.shuffled()),
 //    testCase(TestCRUDTypeRouter.allTests.shuffled()),
     ].shuffled())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding typealias for KituraContracts types.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For a user to use a type from KituraContracts, they would need to import KituraContacts in their application. Instead we expose these types in public typealiases in Kitura so that when they import Kitura they can access them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
