### PR TITLE
[WIP]Allow users to opt for KituraNIO

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,18 @@
  **/
 
 import PackageDescription
+import Foundation
+
+var networkingTargetDependency: Target.Dependency
+var networkingPackageDependency: Package.Dependency
+
+if let _ = ProcessInfo.processInfo.environment["KITURA_NIO"] {
+    networkingTargetDependency = "KituraNIO"
+    networkingPackageDependency = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "0.0.0")
+} else {
+    networkingTargetDependency = "KituraNet"
+    networkingPackageDependency = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0")
+}
 
 let package = Package(
     name: "Kitura",
@@ -29,8 +41,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "0.0.0"),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
+        networkingPackageDependency,
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.0.0")
@@ -40,7 +51,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Kitura",
-            dependencies: ["KituraNIO", "KituraNet", "KituraTemplateEngine", "KituraContracts", "TypeDecoder"]
+            dependencies: [networkingTargetDependency, "KituraTemplateEngine", "KituraContracts", "TypeDecoder"]
         ),
         .testTarget(
             name: "KituraTests",

--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -18,7 +18,7 @@ import Foundation
 import LoggerAPI
 import KituraContracts
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -18,7 +18,7 @@ import Foundation
 import LoggerAPI
 import KituraContracts
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/HTTPStatusCode.swift
+++ b/Sources/Kitura/HTTPStatusCode.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet
@@ -26,7 +26,7 @@ private class DummyHTTPStatusCodeClass {}
 /// Bridge [HTTPStatusCode](http://ibm-swift.github.io/Kitura-net/Enums/HTTPStatusCode.html)
 /// from [KituraNet](http://ibm-swift.github.io/Kitura-net) so that you only need to import
 /// `Kitura` to access it.
-#if NIO
+#if KITURA_NIO
 public typealias HTTPStatusCode = KituraNIO.HTTPStatusCode
 #else
 public typealias HTTPStatusCode = KituraNet.HTTPStatusCode

--- a/Sources/Kitura/Headers.swift
+++ b/Sources/Kitura/Headers.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if NIO
+#if KITURA_NIO 
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -16,7 +16,7 @@
 import Foundation
 import LoggerAPI
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Sources/Kitura/staticFileServer/CacheRelatedHeadersSetter.swift
+++ b/Sources/Kitura/staticFileServer/CacheRelatedHeadersSetter.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Tests/KituraTests/ExternalSubrouter.swift
+++ b/Tests/KituraTests/ExternalSubrouter.swift
@@ -2,7 +2,7 @@
 
 import Kitura
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -17,7 +17,7 @@
 import XCTest
 import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet
@@ -131,7 +131,7 @@ class KituraTest: XCTestCase {
 
         let server = HTTP.createServer()
 
-        #if NIO
+        #if KITURA_NIO
         server.allowPortReuse = true
         #endif
 

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -17,7 +17,7 @@
 import XCTest
 import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/MiscellaneousTests.swift
+++ b/Tests/KituraTests/MiscellaneousTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -19,7 +19,7 @@ import Foundation
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestErrors.swift
+++ b/Tests/KituraTests/TestErrors.swift
@@ -16,7 +16,7 @@
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet

--- a/Tests/KituraTests/TestMultiplicity.swift
+++ b/Tests/KituraTests/TestMultiplicity.swift
@@ -18,7 +18,7 @@ import XCTest
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -20,7 +20,7 @@ import KituraContracts
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -19,7 +19,7 @@ import Foundation
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestRouteRegex.swift
+++ b/Tests/KituraTests/TestRouteRegex.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestRouterHTTPVerbs_generated.swift
+++ b/Tests/KituraTests/TestRouterHTTPVerbs_generated.swift
@@ -19,7 +19,7 @@ import Foundation
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -17,7 +17,7 @@
 import XCTest
 import Dispatch
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet
@@ -47,7 +47,7 @@ class TestServer: KituraTest {
     private func setupServerAndExpectations(expectStart: Bool, expectStop: Bool, expectFail: Bool, httpPort: Int?=nil, fastCgiPort: Int?=nil) {
         let router = Router()
 
-        #if NIO
+        #if KITURA_NIO
         let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? self.httpPort, with: router, allowPortReuse: true)
         #else
         let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? self.httpPort, with: router)
@@ -57,7 +57,7 @@ class TestServer: KituraTest {
         if expectStart {
             let httpStarted = expectation(description: "HTTPServer started()")
 
-            #if !NIO
+            #if !KITURA_NIO
             let fastCgiStarted = expectation(description: "FastCGIServer started()")
             #endif
 
@@ -65,7 +65,7 @@ class TestServer: KituraTest {
                 httpStarted.fulfill()
             }
 
-            #if !NIO
+            #if !KITURA_NIO
             fastCgiServer.started {
                 fastCgiStarted.fulfill()
             }
@@ -75,7 +75,7 @@ class TestServer: KituraTest {
                 XCTFail("httpServer.started should not have been called")
             }
 
-            #if !NIO
+            #if !KITURA_NIO
             fastCgiServer.started {
                 XCTFail("fastCgiServer.started should not have been called")
             }
@@ -85,7 +85,7 @@ class TestServer: KituraTest {
         if expectStop {
             let httpStopped = expectation(description: "HTTPServer stopped()")
 
-            #if !NIO
+            #if !KITURA_NIO
             let fastCgiStopped = expectation(description: "FastCGIServer stopped()")
             #endif
 
@@ -93,7 +93,7 @@ class TestServer: KituraTest {
                 httpStopped.fulfill()
             }
 
-            #if !NIO
+            #if !KITURA_NIO
             fastCgiServer.stopped {
                 fastCgiStopped.fulfill()
             }
@@ -103,7 +103,7 @@ class TestServer: KituraTest {
         if expectFail {
             let httpFailed = expectation(description: "HTTPServer failed()")
 
-            #if !NIO
+            #if !KITURA_NIO
             let fastCgiFailed = expectation(description: "FastCGIServer failed()")
             #endif
 
@@ -111,7 +111,7 @@ class TestServer: KituraTest {
                 httpFailed.fulfill()
             }
 
-            #if !NIO
+            #if !KITURA_NIO
             fastCgiServer.failed { error in
                 fastCgiFailed.fulfill()
             }
@@ -122,7 +122,7 @@ class TestServer: KituraTest {
                 XCTFail("\(error)")
             }
 
-            #if !NIO
+            #if !KITURA_NIO
             fastCgiServer.failed { error in
                 XCTFail("\(error)")
             }
@@ -185,7 +185,7 @@ class TestServer: KituraTest {
             next()
         }
 
-        #if NIO
+        #if KITURA_NIO
         let server = Kitura.addHTTPServer(onPort: port, with: router, allowPortReuse: true)
         #else
         let server = Kitura.addHTTPServer(onPort: port, with: router)

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -19,7 +19,7 @@ import Foundation
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestSubrouter.swift
+++ b/Tests/KituraTests/TestSubrouter.swift
@@ -19,7 +19,7 @@ import Foundation
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -17,7 +17,7 @@
 import XCTest
 import Dispatch
 
-#if NIO
+#if KITURA_NIO
 import KituraNIO
 #else
 import KituraNet
@@ -50,7 +50,7 @@ class TestSwaggerGeneration: KituraTest {
     private func setupServerAndExpectations(router: Router, expectStart: Bool, expectStop: Bool, expectFail: Bool, httpPort: Int?=nil) {
         let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? self.httpPort, with: router)
 
-        #if NIO
+        #if KITURA_NIO
         httpServer.allowPortReuse = true
         #endif
 

--- a/Tests/KituraTests/TestTemplateEngine.swift
+++ b/Tests/KituraTests/TestTemplateEngine.swift
@@ -21,7 +21,7 @@ import KituraContracts
 
 @testable import Kitura
 
-#if NIO
+#if KITURA_NIO
 @testable import KituraNIO
 #else
 @testable import KituraNet


### PR DESCRIPTION
Allow users to opt for KituraNIO while building their Kitura apps. 

## Description
KituraNIO support is currently available only on the `kitura-nio` branch. This pull request proposes introducing that support on the master branch and eventually making it generally available through a minor update. Users that desire to have the networking done via KituraNIO need to set up an env var and pass a compiler flag in the build step, in this way:
```
export KITURA_NIO=1 && swift build -Xswiftc -DKITURA_NIO
```
For users that desire to continue using KituraNet, there's no change required.

## Checklist:
- [ ] Add steps to travis.yml to use KituraNIO on trusty, xenial and macOS
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
