### PR TITLE
feat: Add Content-Type to custom encoder/decoder 

### DIFF
--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -807,7 +807,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                handler(typeSafeMiddleware, CodableHelpers.constructResultHandler(response: response, completion: next))
             }
         }
     }
@@ -840,7 +840,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructResultHandler(response: response, completion: next))
             }
         }
     }
@@ -873,7 +873,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructResultHandler(response: response, completion: next))
             }
         }
     }
@@ -918,7 +918,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                handler(typeSafeMiddleware, identifier, CodableHelpers.constructResultHandler(response: response, completion: next))
             }
         }
     }
@@ -958,7 +958,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructResultHandler(response: response, completion: next))
             }
         }
     }
@@ -998,7 +998,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructResultHandler(response: response, completion: next))
             }
         }
     }
@@ -1042,7 +1042,7 @@ extension Router {
                     guard let typeSafeMiddleware = typeSafeMiddleware else {
                         return next()
                     }
-                    handler(typeSafeMiddleware, query, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                    handler(typeSafeMiddleware, query, CodableHelpers.constructResultHandler(response: response, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -1086,7 +1086,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructResultHandler(response: response, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -1130,7 +1130,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructResultHandler(response: response, completion: next))
                 }
             } catch {
                 // Http 400 error

--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -60,7 +60,8 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -95,7 +96,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -130,7 +132,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -170,7 +173,8 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -205,7 +209,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -240,7 +245,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -287,7 +293,8 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -329,7 +336,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -371,7 +379,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -411,7 +420,8 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -446,7 +456,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -481,7 +492,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -528,7 +540,8 @@ extension Router {
                     guard let typeSafeMiddleware = typeSafeMiddleware else {
                         return next()
                     }
-                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                    let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -575,7 +588,8 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                    let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -622,7 +636,8 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                    let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -673,7 +688,8 @@ extension Router {
                     guard let typeSafeMiddleware = typeSafeMiddleware else {
                         return next()
                     }
-                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                    let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -719,7 +735,8 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                    let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -765,7 +782,8 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                    let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -1173,7 +1191,7 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 next()
                 return
             }
@@ -1181,7 +1199,8 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1214,7 +1233,7 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 next()
                 return
             }
@@ -1222,7 +1241,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1255,7 +1275,7 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 next()
                 return
             }
@@ -1263,7 +1283,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1298,14 +1319,15 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 return next()
             }
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1336,14 +1358,15 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 return next()
             }
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1374,14 +1397,15 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 return next()
             }
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1419,7 +1443,7 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
                 else {
                     next()
                     return
@@ -1428,7 +1452,8 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1461,7 +1486,7 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
                 else {
                     next()
                     return
@@ -1470,7 +1495,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1503,7 +1529,7 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
                 else {
                     next()
                     return
@@ -1512,7 +1538,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             }
         }
     }
@@ -1555,7 +1582,7 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
                 else {
                     next()
                     return
@@ -1564,7 +1591,8 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
 
             }
         }
@@ -1603,7 +1631,7 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
                 else {
                     next()
                     return
@@ -1612,7 +1640,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
 
             }
         }
@@ -1651,7 +1680,7 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
                 else {
                     next()
                     return
@@ -1660,7 +1689,8 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
 
             }
         }

--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -60,7 +60,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -95,7 +95,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -130,7 +130,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -170,7 +170,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -205,7 +205,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -240,7 +240,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -287,7 +287,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -329,7 +329,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -371,7 +371,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -411,7 +411,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -446,7 +446,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -481,7 +481,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -528,7 +528,7 @@ extension Router {
                     guard let typeSafeMiddleware = typeSafeMiddleware else {
                         return next()
                     }
-                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -575,7 +575,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -622,7 +622,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -673,7 +673,7 @@ extension Router {
                     guard let typeSafeMiddleware = typeSafeMiddleware else {
                         return next()
                     }
-                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -719,7 +719,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -765,7 +765,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -807,7 +807,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, CodableHelpers.constructResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -840,7 +840,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -873,7 +873,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -918,7 +918,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, CodableHelpers.constructResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, identifier, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -958,7 +958,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -998,7 +998,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1042,7 +1042,7 @@ extension Router {
                     guard let typeSafeMiddleware = typeSafeMiddleware else {
                         return next()
                     }
-                    handler(typeSafeMiddleware, query, CodableHelpers.constructResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware, query, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -1086,7 +1086,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, query, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -1130,7 +1130,7 @@ extension Router {
                     guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                         return next()
                     }
-                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructResultHandler(response: response, completion: next))
+                    handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, query, CodableHelpers.constructResultHandler(response: response, encoder: self.encoder, completion: next))
                 }
             } catch {
                 // Http 400 error
@@ -1173,7 +1173,7 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 next()
                 return
             }
@@ -1181,7 +1181,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, completion: next))
+                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1214,7 +1214,7 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 next()
                 return
             }
@@ -1222,7 +1222,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1255,7 +1255,7 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 next()
                 return
             }
@@ -1263,7 +1263,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1298,14 +1298,14 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 return next()
             }
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, completion: next))
+                handler(typeSafeMiddleware, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1336,14 +1336,14 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 return next()
             }
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1374,14 +1374,14 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 return next()
             }
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1419,7 +1419,7 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
                 else {
                     next()
                     return
@@ -1428,7 +1428,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1461,7 +1461,7 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
                 else {
                     next()
                     return
@@ -1470,7 +1470,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1503,7 +1503,7 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
                 else {
                     next()
                     return
@@ -1512,7 +1512,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             }
         }
     }
@@ -1555,7 +1555,7 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
                 else {
                     next()
                     return
@@ -1564,7 +1564,7 @@ extension Router {
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
                     return next()
                 }
-                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
 
             }
         }
@@ -1603,7 +1603,7 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
                 else {
                     next()
                     return
@@ -1612,7 +1612,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
 
             }
         }
@@ -1651,7 +1651,7 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
                 else {
                     next()
                     return
@@ -1660,7 +1660,7 @@ extension Router {
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
                     return next()
                 }
-                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3, identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
 
             }
         }

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -634,7 +634,8 @@ extension Router {
 //
 public struct CodableHelpers {
     
-    public static var defaultDecoders: [String: () -> BodyDecoder] = ["application/json": {return JSONDecoder()}]
+    /// The default decoders which will be used by `readCodableOrSetResponseStatus` to decode the content type if no decoders are provided.
+    public static var defaultDecoders: [String: () -> BodyDecoder] = ["application/json": {return JSONDecoder()}, "application/x-www-form-urlencoded": {return QueryDecoder()}]
     
     /**
      * Check if the given request has content type JSON
@@ -686,6 +687,27 @@ public struct CodableHelpers {
             }
         }
         return bestEncoder()
+    }
+    
+    /**
+     * Return the highest rated encoder using the request's Accepts header
+     *
+     * ### Usage Example: ###
+     * ```swift
+     * let decoders: [String: () -> BodyDecoder] = ["application/json": {return JSONEncoder()}]
+     * let decoder = CodableHelpers.selectRequestDecoder(request, decoders: decoders)
+     * ```
+     * - Parameter request: The RouterRequest to check
+     * - Parameter decoders: A dictionary of Content-type to BodyDecoder generators
+     * - Returns: A decoder for the request content type or nil if none match.
+     */
+    public static func selectRequestDecoder(_ request: RouterRequest, decoders: [String: () -> BodyDecoder]) -> BodyDecoder? {
+        guard let contentType = request.headers["Content-Type"],
+              let decoder = decoders[contentType.components(separatedBy: ";")[0]]
+        else {
+            return nil
+        }
+        return decoder()
     }
     
     /**
@@ -745,7 +767,7 @@ public struct CodableHelpers {
             completion()
         }
     }
-    
+
     /**
      * Create a closure that can be called by a codable route handler that
      * provides an optional `Codable` body and an optional `RequestError`
@@ -783,7 +805,7 @@ public struct CodableHelpers {
             if status.class != .successful, let error = error {
                 do {
                     if let bodyData = try error.encodeBody(.json) {
-                        response.headers.setType(encoder.contentType)
+                        response.headers.setType("json")
                         response.send(data: bodyData)
                     }
                 } catch {
@@ -845,7 +867,7 @@ public struct CodableHelpers {
             if status.class != .successful, let error = error {
                 do {
                     if let bodyData = try error.encodeBody(.json) {
-                        response.headers.setType(encoder.contentType)
+                        response.headers.setType("json")
                         response.send(data: bodyData)
                     }
                 } catch {
@@ -910,7 +932,7 @@ public struct CodableHelpers {
             if status.class != .successful, let error = error {
                 do {
                     if let bodyData = try error.encodeBody(.json) {
-                        response.headers.setType(encoder.contentType)
+                        response.headers.setType("json")
                         response.send(data: bodyData)
                     }
                 } catch {
@@ -955,10 +977,7 @@ public struct CodableHelpers {
      * - Returns: An instance of `InputType` representing the decoded body data.
      */
     public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse, decoders: [String: () -> BodyDecoder] = defaultDecoders) -> InputType? {
-        
-        guard let contentType = request.headers["Content-Type"],
-              let decoderGenerator = decoders[contentType.components(separatedBy: ";")[0]]
-        else {
+        guard let decoder = selectRequestDecoder(request, decoders: decoders) else {
             response.status(.unsupportedMediaType)
             return nil
         }
@@ -968,15 +987,15 @@ public struct CodableHelpers {
             return nil
         }
         do {
-            return try request.read(as: InputType.self, decoder: decoderGenerator())
+            return try request.read(as: InputType.self, decoder: decoder)
         } catch {
             Log.error("Failed to read Codable input from request: \(error)")
             response.status(.unprocessableEntity)
             if let decodingError = error as? DecodingError {
-                response.send("Could not decode received \(contentType): \(decodingError.humanReadableDescription)")
+                response.send("Could not decode received \(decoder.contentType): \(decodingError.humanReadableDescription)")
             } else {
                 // Linux Swift does not send a DecodingError when the JSON is invalid, instead it sends Error "The operation could not be completed"
-                response.send("Could not decode received \(contentType).")
+                response.send("Could not decode received \(decoder.contentType).")
             }
             return nil
         }

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -709,51 +709,6 @@ public struct CodableHelpers {
     
     /**
      * Create a closure that can be called by a codable route handler that
-     * provides only an optional `RequestError`
-     *
-     * - Note: This function is intended for use by the codable router or extensions
-     *         thereof. It will create a closure that can be passed to the registered
-     *         route handler.
-     *
-     * - Parameter response: The `RouterResponse` to which the codable response error and
-     *                       status code will be written
-     * - Parameter completion: The completion to be called after the returned
-     *                         closure completes execution.
-     * - Returns: The closure to pass to the codable route handler. The closure takes one argument
-     *            `(RequestError?)`.
-     *            If the argument is `nil` then the response will be considered successful, otherwise
-     *            it will be considered failed.
-     *
-     *            If successful, the HTTP status code will be set to `HTTPStatusCode.noContent` and no
-     *            body will be sent.
-     *
-     *            If failed, the HTTP status code used for the response will be set to either the
-     *            `httpCode` of the `RequestError`, if that is a valid HTTP status code, or
-     *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
-     *            it will be encoded and sent as the body of the response.
-     */
-    public static func constructResultHandler(response: RouterResponse, encoder: BodyEncoder = JSONEncoder(), completion: @escaping () -> Void) -> ResultClosure {
-        return { error in
-            if let error = error {
-                response.status(httpStatusCode(from: error))
-                do {
-                    if let bodyData = try error.encodeBody(.json) {
-                        response.headers.setType(encoder.contentType)
-                        response.send(data: bodyData)
-                    }
-                } catch {
-                    Log.error("Could not encode error: \(error)")
-                    response.status(.internalServerError)
-                }
-            } else {
-                response.status(.noContent)
-            }
-            completion()
-        }
-    }
-
-    /**
-     * Create a closure that can be called by a codable route handler that
      * provides an optional `Codable` body and an optional `RequestError`
      *
      * - Note: This function is intended for use by the codable router or extensions

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -360,11 +360,11 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 next()
                 return
             }
-            handler(codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, completion: next))
+            handler(codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
         }
     }
 
@@ -373,11 +373,11 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
                 next()
                 return
             }
-            handler(codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, completion: next))
+            handler(codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
         }
     }
 
@@ -390,12 +390,12 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
             else {
                 next()
                 return
             }
-            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
         }
     }
 
@@ -408,12 +408,12 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
+                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
             else {
                 next()
                 return
             }
-            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
         }
     }
 
@@ -422,7 +422,7 @@ extension Router {
         registerGetRoute(route: route, id: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (single no-identifier) type-safe request")
-            handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
+            handler(CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
         }
     }
 
@@ -431,7 +431,7 @@ extension Router {
         registerGetRoute(route: route, id: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
-            handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
+            handler(CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
         }
     }
     
@@ -440,7 +440,7 @@ extension Router {
         registerGetRoute(route: route, id: true, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")
-            handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
+            handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
         }
     }
 
@@ -452,7 +452,7 @@ extension Router {
             Log.verbose("Query Parameters: \(request.queryParameters)")
             do {
                 let query: Q = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -470,7 +470,7 @@ extension Router {
             // Define result handler
             do {
                 let query: Q = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -491,7 +491,7 @@ extension Router {
                 if queryParameters.count > 0 {
                     query = try QueryDecoder(dictionary: queryParameters).decode(Q.self)
                 }
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -513,7 +513,7 @@ extension Router {
                 if queryParameters.count > 0 {
                     query = try QueryDecoder(dictionary: queryParameters).decode(Q.self)
                 }
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -533,7 +533,7 @@ extension Router {
                 next()
                 return
             }
-            handler(identifier, CodableHelpers.constructOutResultHandler(response: response, completion: next))
+            handler(identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
         }
     }
 
@@ -706,6 +706,51 @@ public struct CodableHelpers {
             completion()
         }
     }
+    
+    /**
+     * Create a closure that can be called by a codable route handler that
+     * provides only an optional `RequestError`
+     *
+     * - Note: This function is intended for use by the codable router or extensions
+     *         thereof. It will create a closure that can be passed to the registered
+     *         route handler.
+     *
+     * - Parameter response: The `RouterResponse` to which the codable response error and
+     *                       status code will be written
+     * - Parameter completion: The completion to be called after the returned
+     *                         closure completes execution.
+     * - Returns: The closure to pass to the codable route handler. The closure takes one argument
+     *            `(RequestError?)`.
+     *            If the argument is `nil` then the response will be considered successful, otherwise
+     *            it will be considered failed.
+     *
+     *            If successful, the HTTP status code will be set to `HTTPStatusCode.noContent` and no
+     *            body will be sent.
+     *
+     *            If failed, the HTTP status code used for the response will be set to either the
+     *            `httpCode` of the `RequestError`, if that is a valid HTTP status code, or
+     *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
+     *            it will be encoded and sent as the body of the response.
+     */
+    public static func constructResultHandler(response: RouterResponse, encoder: BodyEncoder = JSONEncoder(), completion: @escaping () -> Void) -> ResultClosure {
+        return { error in
+            if let error = error {
+                response.status(httpStatusCode(from: error))
+                do {
+                    if let bodyData = try error.encodeBody(.json) {
+                        response.headers.setType(encoder.contentType)
+                        response.send(data: bodyData)
+                    }
+                } catch {
+                    Log.error("Could not encode error: \(error)")
+                    response.status(.internalServerError)
+                }
+            } else {
+                response.status(.noContent)
+            }
+            completion()
+        }
+    }
 
     /**
      * Create a closure that can be called by a codable route handler that
@@ -734,7 +779,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructOutResultHandler<OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
+    public static func constructOutResultHandler<OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, encoder: BodyEncoder = JSONEncoder(), completion: @escaping () -> Void) -> CodableResultClosure<OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -744,7 +789,7 @@ public struct CodableHelpers {
             if status.class != .successful, let error = error {
                 do {
                     if let bodyData = try error.encodeBody(.json) {
-                        response.headers.setType("json")
+                        response.headers.setType(encoder.contentType)
                         response.send(data: bodyData)
                     }
                 } catch {
@@ -754,8 +799,8 @@ public struct CodableHelpers {
             } else {
                 do {
                     if let codableOutput = codableOutput {
-                        let json = try JSONEncoder().encode(codableOutput)
-                        response.headers.setType("json")
+                        let json = try encoder.encode(codableOutput)
+                        response.headers.setType(encoder.contentType)
                         response.send(data: json)
                     } else {
                         Log.debug("Note: successful response ('\(status)') delivers no data.")
@@ -796,7 +841,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
+    public static func constructTupleArrayOutResultHandler<Id: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, encoder: BodyEncoder = JSONEncoder(), completion: @escaping () -> Void) -> IdentifierCodableArrayResultClosure<Id, OutputType> {
         return { codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -806,7 +851,7 @@ public struct CodableHelpers {
             if status.class != .successful, let error = error {
                 do {
                     if let bodyData = try error.encodeBody(.json) {
-                        response.headers.setType("json")
+                        response.headers.setType(encoder.contentType)
                         response.send(data: bodyData)
                     }
                 } catch {
@@ -817,8 +862,8 @@ public struct CodableHelpers {
                 do {
                     if let codableOutput = codableOutput {
                         let entries = codableOutput.map({ [$0.value: $1] })
-                        let encoded = try JSONEncoder().encode(entries)
-                        response.headers.setType("json")
+                        let encoded = try encoder.encode(entries)
+                        response.headers.setType(encoder.contentType)
                         response.send(data: encoded)
                     } else {
                         Log.debug("Note: successful response ('\(status)') delivers no data.")
@@ -861,7 +906,7 @@ public struct CodableHelpers {
      *            `HTTPStatusCode.unknown` otherwise. If the `RequestError` has a codable `body` then
      *            it will be encoded and sent as the body of the response.
      */
-    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
+    public static func constructIdentOutResultHandler<IdType: Identifier, OutputType: Codable>(successStatus: HTTPStatusCode = .OK, response: RouterResponse, encoder: BodyEncoder = JSONEncoder(), completion: @escaping () -> Void) -> IdentifierCodableResultClosure<IdType, OutputType> {
         return { id, codableOutput, error in
             var status = successStatus
             if let error = error {
@@ -871,7 +916,7 @@ public struct CodableHelpers {
             if status.class != .successful, let error = error {
                 do {
                     if let bodyData = try error.encodeBody(.json) {
-                        response.headers.setType("json")
+                        response.headers.setType(encoder.contentType)
                         response.send(data: bodyData)
                     }
                 } catch {
@@ -882,8 +927,8 @@ public struct CodableHelpers {
                 response.headers["Location"] = String(id.value)
                 do {
                     if let codableOutput = codableOutput {
-                        let json = try JSONEncoder().encode(codableOutput)
-                        response.headers.setType("json")
+                        let json = try encoder.encode(codableOutput)
+                        response.headers.setType(encoder.contentType)
                         response.send(data: json)
                     } else {
                         Log.debug("Note: successful response ('\(status)') delivers no data.")
@@ -915,8 +960,12 @@ public struct CodableHelpers {
      *                       cases where reading or decoding the data fails.
      * - Returns: An instance of `InputType` representing the decoded body data.
      */
-    public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse) -> InputType? {
-        guard CodableHelpers.isContentTypeJSON(request) || CodableHelpers.isContentTypeURLEncoded(request) else {
+    public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse, decoder: BodyDecoder = JSONDecoder()) -> InputType? {
+        
+        guard let contentType = request.headers["Content-Type"],
+              let decoderType = ContentType.sharedInstance.getContentType(forExtension: decoder.contentType),
+                  contentType.hasPrefix(decoderType) || contentType.hasPrefix("application/x-www-form-urlencoded")
+        else {
             response.status(.unsupportedMediaType)
             return nil
         }
@@ -926,7 +975,7 @@ public struct CodableHelpers {
             return nil
         }
         do {
-            return try request.read(as: InputType.self)
+            return try request.read(as: InputType.self, decoder: decoder)
         } catch {
             Log.error("Failed to read Codable input from request: \(error)")
             response.status(.unprocessableEntity)

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -360,11 +360,12 @@ extension Router {
         registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 next()
                 return
             }
-            handler(codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(codableInput, CodableHelpers.constructOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
         }
     }
 
@@ -373,11 +374,12 @@ extension Router {
         registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
-            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder) else {
+            guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders) else {
                 next()
                 return
             }
-            handler(codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(codableInput, CodableHelpers.constructIdentOutResultHandler(successStatus: .created, response: response, encoder: encoder, completion: next))
         }
     }
 
@@ -390,12 +392,13 @@ extension Router {
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
             else {
                 next()
                 return
             }
-            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
         }
     }
 
@@ -408,12 +411,13 @@ extension Router {
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
-                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoder: self.decoder)
+                  let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response, decoders: self.decoders)
             else {
                 next()
                 return
             }
-            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(identifier, codableInput, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
         }
     }
 
@@ -422,7 +426,8 @@ extension Router {
         registerGetRoute(route: route, id: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (single no-identifier) type-safe request")
-            handler(CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
         }
     }
 
@@ -431,7 +436,8 @@ extension Router {
         registerGetRoute(route: route, id: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
-            handler(CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
         }
     }
     
@@ -440,7 +446,8 @@ extension Router {
         registerGetRoute(route: route, id: true, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")
-            handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, encoder: encoder, completion: next))
         }
     }
 
@@ -452,7 +459,8 @@ extension Router {
             Log.verbose("Query Parameters: \(request.queryParameters)")
             do {
                 let query: Q = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -470,7 +478,8 @@ extension Router {
             // Define result handler
             do {
                 let query: Q = try QueryDecoder(dictionary: request.queryParameters).decode(Q.self)
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -491,7 +500,8 @@ extension Router {
                 if queryParameters.count > 0 {
                     query = try QueryDecoder(dictionary: queryParameters).decode(Q.self)
                 }
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -513,7 +523,8 @@ extension Router {
                 if queryParameters.count > 0 {
                     query = try QueryDecoder(dictionary: queryParameters).decode(Q.self)
                 }
-                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+                let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+                handler(query, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
             } catch {
                 // Http 400 error
                 response.status(.badRequest)
@@ -533,7 +544,8 @@ extension Router {
                 next()
                 return
             }
-            handler(identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: self.encoder, completion: next))
+            let encoder = CodableHelpers.selectResponseEncoder(request, encoders: self.encoders)
+            handler(identifier, CodableHelpers.constructOutResultHandler(response: response, encoder: encoder, completion: next))
         }
     }
 
@@ -621,6 +633,9 @@ extension Router {
 // Building blocks for Codable routing
 //
 public struct CodableHelpers {
+    
+    public static var defaultDecoders: [String: () -> BodyDecoder] = ["application/json": {return JSONDecoder()}]
+    
     /**
      * Check if the given request has content type JSON
      *
@@ -647,6 +662,30 @@ public struct CodableHelpers {
             return false
         }
         return contentType.hasPrefix("application/x-www-form-urlencoded")
+    }
+    
+    /**
+     * Return the highest rated encoder using the request's Accepts header
+     *
+     * ### Usage Example: ###
+     * ```swift
+     * let encoders: [String: () -> BodyEncoder] = ["application/json": {return JSONEncoder()}]
+     * let encoder = CodableHelpers.selectResponseEncoder(request, encoders: encoders)
+     * ```
+     * - Parameter request: The RouterRequest to check
+     * - Parameter encoders: A dictionary of Content-type to BodyEncoder generators
+     * - Returns: The highest rated Encoder, or a JSONEncoder() if no encoders match the Accepts header.
+     */
+    public static func selectResponseEncoder(_ request: RouterRequest, encoders: [String: () -> BodyEncoder]) -> BodyEncoder {
+        let encoderAcceptsTypes = Array(encoders.keys)
+        guard let bestAccepts = request.accepts(types: encoderAcceptsTypes), let bestEncoder = encoders[bestAccepts] else {
+            if let jsonEncoder = encoders["application/json"] {
+                return jsonEncoder()
+            } else {
+                return JSONEncoder()
+            }
+        }
+        return bestEncoder()
     }
     
     /**
@@ -915,11 +954,10 @@ public struct CodableHelpers {
      *                       cases where reading or decoding the data fails.
      * - Returns: An instance of `InputType` representing the decoded body data.
      */
-    public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse, decoder: BodyDecoder = JSONDecoder()) -> InputType? {
+    public static func readCodableOrSetResponseStatus<InputType: Codable>(_ inputCodableType: InputType.Type, from request: RouterRequest, response: RouterResponse, decoders: [String: () -> BodyDecoder] = defaultDecoders) -> InputType? {
         
         guard let contentType = request.headers["Content-Type"],
-              let decoderType = ContentType.sharedInstance.getContentType(forExtension: decoder.contentType),
-                  contentType.hasPrefix(decoderType) || contentType.hasPrefix("application/x-www-form-urlencoded")
+              let decoderGenerator = decoders[contentType.components(separatedBy: ";")[0]]
         else {
             response.status(.unsupportedMediaType)
             return nil
@@ -930,15 +968,15 @@ public struct CodableHelpers {
             return nil
         }
         do {
-            return try request.read(as: InputType.self, decoder: decoder)
+            return try request.read(as: InputType.self, decoder: decoderGenerator())
         } catch {
             Log.error("Failed to read Codable input from request: \(error)")
             response.status(.unprocessableEntity)
             if let decodingError = error as? DecodingError {
-                response.send("Could not decode received JSON: \(decodingError.humanReadableDescription)")
+                response.send("Could not decode received \(contentType): \(decodingError.humanReadableDescription)")
             } else {
                 // Linux Swift does not send a DecodingError when the JSON is invalid, instead it sends Error "The operation could not be completed"
-                response.send("Could not decode received JSON.")
+                response.send("Could not decode received \(contentType).")
             }
             return nil
         }

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -18,6 +18,7 @@ import KituraNet
 import LoggerAPI
 import Foundation
 import KituraTemplateEngine
+import KituraContracts
 
 // MARK Router
 
@@ -33,6 +34,11 @@ import KituraTemplateEngine
 
 public class Router {
 
+    /// The encoder instance used for encoding Codable objects
+    internal let encoder: BodyEncoder
+    /// The decoder instance used for encoding Codable objects
+    internal let decoder: BodyDecoder
+    
     /// Contains the list of routing elements
     var elements: [RouterElement] = []
 
@@ -116,10 +122,11 @@ public class Router {
     /// ```
     /// - Parameter mergeParameters: Optional parameter to specify if the router should be able to access parameters
     ///                                 from its parent router. Defaults to `false` if not specified.
-    public init(mergeParameters: Bool = false) {
+    public init(mergeParameters: Bool = false, encoder: BodyEncoder = JSONEncoder(), decoder: BodyDecoder = JSONDecoder()) {
         self.swagger = SwaggerDocument()
         self.mergeParameters = mergeParameters
-
+        self.encoder = encoder
+        self.decoder = decoder
         Log.verbose("Router initialized")
     }
 

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -34,10 +34,10 @@ import KituraContracts
 
 public class Router {
 
-    /// The encoder instance used for encoding Codable objects
-    public var encoders: [String: () -> BodyEncoder] = ["application/json": {return JSONEncoder()}]
-    /// The decoder instance used for encoding Codable objects
-    public var decoders: [String: () -> BodyDecoder] = ["application/json": {return JSONDecoder()}]
+    /// A dictionary of Content-type to BodyEncoder generators
+    public var encoders: [String: () -> BodyEncoder] = ["application/json": {return JSONEncoder()}, "application/x-www-form-urlencoded": {return QueryEncoder()}]
+    /// A dictionary of Content-type to BodyDecoder generators
+    public var decoders: [String: () -> BodyDecoder] = ["application/json": {return JSONDecoder()}, "application/x-www-form-urlencoded": {return QueryDecoder()}]
     
     /// Contains the list of routing elements
     var elements: [RouterElement] = []
@@ -125,6 +125,7 @@ public class Router {
     public init(mergeParameters: Bool = false) {
         self.swagger = SwaggerDocument()
         self.mergeParameters = mergeParameters
+        
         Log.verbose("Router initialized")
     }
 

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -18,6 +18,7 @@ import KituraNet
 import LoggerAPI
 import Foundation
 import KituraTemplateEngine
+import KituraContracts
 
 // MARK Router
 
@@ -34,9 +35,9 @@ import KituraTemplateEngine
 public class Router {
 
     /// The encoder instance used for encoding Codable objects
-    internal let encoder: BodyEncoder
+    let encoder: BodyEncoder
     /// The decoder instance used for encoding Codable objects
-    internal let decoder: BodyDecoder
+    let decoder: BodyDecoder
     
     /// Contains the list of routing elements
     var elements: [RouterElement] = []

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -18,7 +18,6 @@ import KituraNet
 import LoggerAPI
 import Foundation
 import KituraTemplateEngine
-import KituraContracts
 
 // MARK Router
 

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -35,9 +35,9 @@ import KituraContracts
 public class Router {
 
     /// The encoder instance used for encoding Codable objects
-    let encoder: BodyEncoder
+    public var encoders: [String: () -> BodyEncoder] = ["application/json": {return JSONEncoder()}]
     /// The decoder instance used for encoding Codable objects
-    let decoder: BodyDecoder
+    public var decoders: [String: () -> BodyDecoder] = ["application/json": {return JSONDecoder()}]
     
     /// Contains the list of routing elements
     var elements: [RouterElement] = []
@@ -122,11 +122,9 @@ public class Router {
     /// ```
     /// - Parameter mergeParameters: Optional parameter to specify if the router should be able to access parameters
     ///                                 from its parent router. Defaults to `false` if not specified.
-    public init(mergeParameters: Bool = false, encoder: BodyEncoder = JSONEncoder(), decoder: BodyDecoder = JSONDecoder()) {
+    public init(mergeParameters: Bool = false) {
         self.swagger = SwaggerDocument()
         self.mergeParameters = mergeParameters
-        self.encoder = encoder
-        self.decoder = decoder
         Log.verbose("Router initialized")
     }
 

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -194,7 +194,7 @@ public class RouterRequest {
     /// - Throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
     /// - Throws: An error if any value throws an error during decoding.
     /// - Returns: The instantiated Codable object
-    public func read<T: Decodable>(as type: T.Type, decoder: BodyDecoder = JSONDecoder()) throws -> T {
+    public func read<T: Decodable>(as type: T.Type) throws -> T {
         // FIXME: RouterRequest should cache the content type, so that this is just a lookup
         if CodableHelpers.isContentTypeURLEncoded(self) {
             let body = try self.readString()
@@ -203,6 +203,19 @@ public class RouterRequest {
             }
             return try QueryDecoder(dictionary: urlKeyValuePairs).decode(type)
         }
+        var data = Data()
+        _ = try serverRequest.read(into: &data)
+        return try JSONDecoder().decode(type, from: data)
+    }
+    
+    /// Read the body of the request as a Codable object using the given `BodyDecoder`
+    /// - Parameter as: Codable object to which the body of the request will be converted.
+    /// - Parameter decoder: The BodyDecoder which will be used to decode the request as the Codable object.
+    /// - Throws: Socket.Error if an error occurred while reading from a socket.
+    /// - Throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
+    /// - Throws: An error if any value throws an error during decoding.
+    /// - Returns: The instantiated Codable object
+    public func read<T: Decodable>(as type: T.Type, decoder: BodyDecoder) throws -> T {
         var data = Data()
         _ = try serverRequest.read(into: &data)
         return try decoder.decode(type, from: data)

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -194,7 +194,7 @@ public class RouterRequest {
     /// - Throws: `DecodingError.dataCorrupted` if values requested from the payload are corrupted, or if the given data is not valid JSON.
     /// - Throws: An error if any value throws an error during decoding.
     /// - Returns: The instantiated Codable object
-    public func read<T: Decodable>(as type: T.Type) throws -> T {
+    public func read<T: Decodable>(as type: T.Type, decoder: BodyDecoder = JSONDecoder()) throws -> T {
         // FIXME: RouterRequest should cache the content type, so that this is just a lookup
         if CodableHelpers.isContentTypeURLEncoded(self) {
             let body = try self.readString()
@@ -205,7 +205,7 @@ public class RouterRequest {
         }
         var data = Data()
         _ = try serverRequest.read(into: &data)
-        return try JSONDecoder().decode(type, from: data)
+        return try decoder.decode(type, from: data)
     }
     
     /// Read the body of the request as String.

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -187,16 +187,16 @@ class TestCodableRouter: KituraTest {
             .hasStatus(.created)
             .hasContentType(withPrefix: "application/json")
             .hasData(user)
-            
+
             .request("post", path: "/urlencoded", urlEncodedString: "id=4&name=David&extra=yes")
             .hasStatus(.created)
             .hasContentType(withPrefix: "application/json")
             .hasData(user)
-            
+
             .request("post", path: "/urlencoded", urlEncodedString: "encoding=valid&failed=match")
             .hasStatus(.unprocessableEntity)
             .hasData()
-            
+
             .request("post", path: "/urlencoded", urlEncodedString: "invalidEncoding")
             .hasStatus(.unprocessableEntity)
             .hasData()
@@ -902,13 +902,20 @@ class TestCodableRouter: KituraTest {
         struct SimpleQuery: QueryParams {
             let string: String
         }
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.dateEncodingStrategy = .secondsSince1970
-        let jsonDecoder = JSONDecoder()
-        jsonDecoder.dateDecodingStrategy = .secondsSince1970
-
+        let jsonEncoder: () -> BodyEncoder = {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            return encoder
+        }
+        let jsonDecoder: () -> BodyDecoder = {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .secondsSince1970
+            return decoder
+        }
+        let customRouter = Router()
+        customRouter.decoders["application/json"] = jsonDecoder
+        customRouter.encoders["application/json"] = jsonEncoder
         
-        let customRouter = Router(encoder: jsonEncoder, decoder: jsonDecoder)
         let date = Date(timeIntervalSince1970: 1519206456)
         let codableDate = CodableDate(date: date)
         print("codableDate \(codableDate)")

--- a/Tests/KituraTests/TestTypeSafeMiddleware.swift
+++ b/Tests/KituraTests/TestTypeSafeMiddleware.swift
@@ -49,6 +49,7 @@ class TestTypeSafeMiddleware: KituraTest {
             ("testMultipleMiddlewarePut", testMultipleMiddlewarePut),
             ("testSingleMiddlewarePatch", testSingleMiddlewarePatch),
             ("testMultipleMiddlewarePatch", testMultipleMiddlewarePatch),
+            ("testCustomCoder", testCustomCoder),
         ]
     }
 
@@ -850,6 +851,296 @@ class TestTypeSafeMiddleware: KituraTest {
             .hasStatus(.badRequest)
             .hasNoData()
 
+            .run()
+    }
+    
+    func testCustomCoder() {
+        struct SimpleQuery: QueryParams {
+            let string: String
+        }
+        struct CodableDate: Codable, Equatable {
+            let date: Date
+            init(date: Date) {
+                self.date = date
+            }
+            public static func == (lhs: CodableDate, rhs: CodableDate) -> Bool {
+                return lhs.date == rhs.date
+            }
+        }
+        let jsonEncoder: () -> BodyEncoder = {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .secondsSince1970
+            return encoder
+        }
+        let jsonDecoder: () -> BodyDecoder = {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .secondsSince1970
+            return decoder
+        }
+        let customRouter = Router()
+        customRouter.decoders["application/json"] = jsonDecoder
+        customRouter.encoders["application/json"] = jsonEncoder
+        
+        let date = Date(timeIntervalSince1970: 1519206456)
+        let codableDate = CodableDate(date: date)
+        print("codableDate \(codableDate)")
+        customRouter.get("/customCoder1") { (middleware: UserMiddleware, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("GET on /customCoder")
+            respondWith(codableDate, nil)
+        }
+        customRouter.get("/customCoder2") { (middleware: UserMiddleware, middleware2: UserMiddleware, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("GET on /customCoder")
+            respondWith(codableDate, nil)
+        }
+        customRouter.get("/customCoder3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("GET on /customCoder")
+            respondWith(codableDate, nil)
+        }
+        customRouter.get("/customCoderArray1") { (middleware: UserMiddleware, respondWith: ([CodableDate]?, RequestError?) -> Void) in
+            print("GET on /customCoderArray")
+            respondWith([codableDate], nil)
+        }
+        customRouter.get("/customCoderArray2") { (middleware: UserMiddleware, middleware2: UserMiddleware, respondWith: ([CodableDate]?, RequestError?) -> Void) in
+            print("GET on /customCoderArray")
+            respondWith([codableDate], nil)
+        }
+        customRouter.get("/customCoderArray3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, respondWith: ([CodableDate]?, RequestError?) -> Void) in
+            print("GET on /customCoderArray")
+            respondWith([codableDate], nil)
+        }
+        customRouter.get("/customCoderTuple1") { (middleware: UserMiddleware, respondWith: ([(Int, CodableDate)]?, RequestError?) -> Void) in
+            print("GET on /customCoderTuple")
+            respondWith([(1, codableDate)], nil)
+        }
+        customRouter.get("/customCoderTuple2") { (middleware: UserMiddleware, middleware2: UserMiddleware, respondWith: ([(Int, CodableDate)]?, RequestError?) -> Void) in
+            print("GET on /customCoderTuple")
+            respondWith([(1, codableDate)], nil)
+        }
+        customRouter.get("/customCoderTuple3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, respondWith: ([(Int, CodableDate)]?, RequestError?) -> Void) in
+            print("GET on /customCoderTuple")
+            respondWith([(1, codableDate)], nil)
+        }
+        customRouter.get("/customCoderQuery1") { (middleware: UserMiddleware, query: SimpleQuery, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("GET on /customCoderQuery")
+            respondWith(codableDate, nil)
+        }
+        customRouter.get("/customCoderQuery2") { (middleware: UserMiddleware, middleware2: UserMiddleware, query: SimpleQuery, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("GET on /customCoderQuery")
+            respondWith(codableDate, nil)
+        }
+        customRouter.get("/customCoderQuery3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, query: SimpleQuery, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("GET on /customCoderQuery")
+            respondWith(codableDate, nil)
+        }
+        customRouter.get("/customCoderQueryArray1") { (middleware: UserMiddleware, query: SimpleQuery, respondWith: ([CodableDate]?, RequestError?) -> Void) in
+            print("GET on /customCoderQueryArray")
+            respondWith([codableDate], nil)
+        }
+        customRouter.get("/customCoderQueryArray2") { (middleware: UserMiddleware, middleware2: UserMiddleware, query: SimpleQuery, respondWith: ([CodableDate]?, RequestError?) -> Void) in
+            print("GET on /customCoderQueryArray")
+            respondWith([codableDate], nil)
+        }
+        customRouter.get("/customCoderQueryArray3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, query: SimpleQuery, respondWith: ([CodableDate]?, RequestError?) -> Void) in
+            print("GET on /customCoderQueryArray")
+            respondWith([codableDate], nil)
+        }
+        customRouter.post("/customCoder1") { (middleware: UserMiddleware, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("POST on /customCoder for date \(inDate)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.post("/customCoder2") { (middleware: UserMiddleware, middleware2: UserMiddleware, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("POST on /customCoder for date \(inDate)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.post("/customCoder3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("POST on /customCoder for date \(inDate)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.post("/customCoderId1") { (middleware: UserMiddleware, inDate: CodableDate, respondWith: (Int?, CodableDate?, RequestError?) -> Void) in
+            print("POST on /customCoderId for user \(inDate)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(1, codableDate, nil)
+        }
+        customRouter.post("/customCoderId2") { (middleware: UserMiddleware, middleware2: UserMiddleware, inDate: CodableDate, respondWith: (Int?, CodableDate?, RequestError?) -> Void) in
+            print("POST on /customCoderId for user \(inDate)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(1, codableDate, nil)
+        }
+        customRouter.post("/customCoderId3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, inDate: CodableDate, respondWith: (Int?, CodableDate?, RequestError?) -> Void) in
+            print("POST on /customCoderId for user \(inDate)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(1, codableDate, nil)
+        }
+        customRouter.put("/customCoder1") { (middleware: UserMiddleware, id: Int, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("PUT on /customCoder/\(id)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.put("/customCoder2") { (middleware: UserMiddleware, middleware2: UserMiddleware, id: Int, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("PUT on /customCoder/\(id)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.put("/customCoder3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, id: Int, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("PUT on /customCoder/\(id)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.patch("/customCoder1") { (middleware: UserMiddleware, id: Int, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("PATCH on /customCoder/\(id)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.patch("/customCoder2") { (middleware: UserMiddleware, middleware2: UserMiddleware, id: Int, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("PATCH on /customCoder/\(id)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        customRouter.patch("/customCoder3") { (middleware: UserMiddleware, middleware2: UserMiddleware, middleware3: UserMiddleware, id: Int, inDate: CodableDate, respondWith: (CodableDate?, RequestError?) -> Void) in
+            print("PATCH on /customCoder/\(id)")
+            XCTAssertEqual(inDate, codableDate)
+            respondWith(codableDate, nil)
+        }
+        
+        buildServerTest(customRouter, timeout: 30)
+            .request("get", path: "/customCoder1", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoder2", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoder3", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderArray1", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([codableDate], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderArray2", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([codableDate], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderArray3", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([codableDate], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderTuple1", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([[1: codableDate]], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderTuple2", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([[1: codableDate]], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderTuple3", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([[1: codableDate]], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderQuery1?string=hello", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderQuery2?string=hello", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderQuery3?string=hello", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderQueryArray1?string=hello", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([codableDate], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderQueryArray2?string=hello", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([codableDate], customDecoder: jsonDecoder)
+            
+            .request("get", path: "/customCoderQueryArray3?string=hello", headers: ["TestHeader": "Hello"])
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData([codableDate], customDecoder: jsonDecoder)
+            
+            .request("post", path: "/customCoder1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("post", path: "/customCoder2", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("post", path: "/customCoder3", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("post", path: "/customCoderId1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("post", path: "/customCoderId2", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("post", path: "/customCoderId3", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.created)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("put", path: "/customCoder1/1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("put", path: "/customCoder2/1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("put", path: "/customCoder3/1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("patch", path: "/customCoder1/1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("patch", path: "/customCoder2/1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
+            .request("patch", path: "/customCoder3/1", data: codableDate, headers: ["TestHeader": "Hello"], encoder: jsonEncoder)
+            .hasStatus(.OK)
+            .hasContentType(withPrefix: "application/json")
+            .hasData(codableDate, customDecoder: jsonDecoder)
+            
             .run()
     }
 }


### PR DESCRIPTION
## Description
This PR adds two fields to Router called encoders and decoders.
These contain a String to BodyEncoderGenerator/BodyDecoderGenerator dictionary.

We have also added a Read(as: Codable, decoder: BodyDecoder) function, which decodes the data from the routerRequest into a codable type using the given Decoder.

The Codable router uses the decoders dictionary to generate a decoder for the Content-type header and then use the new Read function to decode the request using that decoder.

The Codable router uses the Accepts header to select the best encoder from the Encoders dictionary and use that encoder to encode it's response. 

### Travis pass requirements

This requires a the Query Coders to be able to encode/decoder data which is in this (PR](https://github.com/IBM-Swift/KituraContracts/pull/28)

It also requires the addition of the BodyEncoder/BodyDecoder protocol which is currently being worked on this [branch](https://github.com/IBM-Swift/KituraContracts/tree/customCoder)

## Motivation and Context
This allows users to customize the JSON encoder and decoder in Codable routes and add their own Encoders/Decoders for encoding/decoding different Content-Type headers. 

This is a fix for issue #1298 
This follows on from the work in pull request [1221](https://github.com/IBM-Swift/Kitura/pull/1221) but is generalized for any custom encoder/decoder

## How Has This Been Tested?
This change affects all Codable and Type-Safe routes so tests have been added which use a custom JSONEncoder. The test suite has also been updated to allow custom encoders/decoders to be used.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
