### PR TITLE
Changed redirect test to local redirect

### DIFF
--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -547,11 +547,11 @@ class TestResponse: KituraTest {
 
     func testRedirect() {
         performServerTest(router) { expectation in
-            self.performRequest("get", path: "/redir", callback: {response in
+            self.performRequest("get", path: "/redirect", callback: {response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 do {
                     let body = try response?.readString()
-                    XCTAssertNotNil(body?.range(of: "ibm"), "response does not contain IBM")
+                    XCTAssertEqual(body, "redirected to new route")
                 } catch {
                     XCTFail("Error reading body")
                 }
@@ -1198,14 +1198,23 @@ class TestResponse: KituraTest {
             next()
         }
 
-        router.get("/redir") { _, response, next in
+        router.get("/redirect") { _, response, next in
             do {
-                try response.redirect("http://www.ibm.com")
+                try response.redirect("/redirected")
             } catch {
                 XCTFail("Error sending response. Error=\(error.localizedDescription)")
             }
 
             next()
+        }
+        
+        router.get("/redirected") { _, response, next in
+            do {
+                try response.send("redirected to new route").end()
+            } catch {
+                XCTFail("Error sending response. Error=\(error.localizedDescription)")
+                next()
+            }
         }
 
         // Error handling example


### PR DESCRIPTION
## Description
The redirect test in Kitura used to redirect to IBM.com and then search the result for the text IBM. If it found it then it would pass. This caused the tests to fail if IBM.com did not respond. 

This change adds a new route "redirected" and makes the test redirect to this local route instead and check for the correct response.