### PR TITLE
Improve type handling for id params in generated swagger

### DIFF
--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -53,7 +53,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Single) typed middleware request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
@@ -88,7 +88,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Single) typed middleware request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
@@ -123,7 +123,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Single) typed middleware request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
@@ -163,7 +163,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) typed middleware request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
@@ -198,7 +198,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) typed middleware request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
@@ -233,7 +233,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) typed middleware request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
@@ -276,7 +276,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received GET (singular with identifier and middleware) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -318,7 +318,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received GET (singular with identifier and middleware) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -360,7 +360,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received GET (singular with identifier and middleware) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -404,7 +404,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, @escaping IdentifierCodableArrayResultClosure<Id, O>) -> Void
     ) {
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) with identifier typed middleware request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
@@ -439,7 +439,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, @escaping IdentifierCodableArrayResultClosure<Id, O>) -> Void
     ) {
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) with identifier typed middleware request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
@@ -474,7 +474,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, @escaping IdentifierCodableArrayResultClosure<Id, O>) -> Void
     ) {
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) with identifier typed middleware request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
@@ -517,7 +517,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, Q, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -564,7 +564,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, Q, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -611,7 +611,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, Q, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -663,7 +663,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -709,7 +709,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -755,7 +755,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -800,7 +800,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE (plural with middleware) type-safe request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
@@ -833,7 +833,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE (plural with middleware) type-safe request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
@@ -866,7 +866,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE (plural with middleware) type-safe request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
@@ -907,7 +907,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerDeleteRoute(route: route, id: true)
+        registerDeleteRoute(route: route, id: Id.self)
         delete(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received DELETE (singular with middleware) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -947,7 +947,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerDeleteRoute(route: route, id: true)
+        registerDeleteRoute(route: route, id: Id.self)
         delete(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received DELETE (singular with middleware) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -987,7 +987,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerDeleteRoute(route: route, id: true)
+        registerDeleteRoute(route: route, id: Id.self)
         delete(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received DELETE (singular with middleware) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -1032,7 +1032,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, Q, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -1076,7 +1076,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, Q, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -1120,7 +1120,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, Q, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -1170,7 +1170,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, I, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -1211,7 +1211,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, I, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -1252,7 +1252,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, I, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -1295,7 +1295,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, I, @escaping IdentifierCodableResultClosure<Id, O>) -> Void
     ) {
-        registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -1333,7 +1333,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, I, @escaping IdentifierCodableResultClosure<Id, O>) -> Void
     ) {
-        registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -1371,7 +1371,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, I, @escaping IdentifierCodableResultClosure<Id, O>) -> Void
     ) {
-        registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -1415,7 +1415,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPutRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPutRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
@@ -1457,7 +1457,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPutRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPutRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
@@ -1499,7 +1499,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPutRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPutRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
@@ -1551,7 +1551,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPatchRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPatchRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
@@ -1599,7 +1599,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPatchRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPatchRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
@@ -1647,7 +1647,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPatchRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPatchRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -357,7 +357,7 @@ extension Router {
 
     // POST
     fileprivate func postSafely<I: Codable, O: Codable>(_ route: String, handler: @escaping CodableClosure<I, O>) {
-        registerPostRoute(route: route, id: false, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -370,7 +370,7 @@ extension Router {
 
     // POST
     fileprivate func postSafelyWithId<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
-        registerPostRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPostRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
             guard let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response) else {
@@ -386,7 +386,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPutRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPutRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         put(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
@@ -404,7 +404,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerPatchRoute(route: route, id: true, inputtype: I.self, outputtype: O.self)
+        registerPatchRoute(route: route, id: Id.self, inputtype: I.self, outputtype: O.self)
         patch(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
@@ -419,7 +419,7 @@ extension Router {
 
     // Get single
     fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping SimpleCodableClosure<O>) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (single no-identifier) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
@@ -428,7 +428,7 @@ extension Router {
 
     // Get array
     fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
@@ -437,7 +437,7 @@ extension Router {
     
     // Get array of (Id, Codable) tuples
     fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")
             handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
@@ -446,7 +446,7 @@ extension Router {
 
     // Get w/Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -463,7 +463,7 @@ extension Router {
 
     // Get w/Query Parameters with CodableResultClosure
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -481,7 +481,7 @@ extension Router {
 
     // Get w/Optional Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -502,7 +502,7 @@ extension Router {
 
     // Get w/Optional Query Parameters with CodableResultClosure
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, id: false, outputtype: O.self)
+        registerGetRoute(route: route, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -526,7 +526,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerGetRoute(route: route, id: true, outputtype: O.self)
+        registerGetRoute(route: route, id: Id.self, outputtype: O.self)
         get(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received GET (singular with identifier) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -539,7 +539,7 @@ extension Router {
 
     // DELETE
     fileprivate func deleteSafely(_ route: String, handler: @escaping NonCodableClosure) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE (plural) type-safe request")
             handler(CodableHelpers.constructResultHandler(response: response, completion: next))
@@ -551,7 +551,7 @@ extension Router {
         if parameterIsPresent(in: route) {
             return
         }
-        registerDeleteRoute(route: route, id: true)
+        registerDeleteRoute(route: route, id: Id.self)
         delete(join(path: route, with: ":id")) { request, response, next in
             Log.verbose("Received DELETE (singular) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
@@ -564,7 +564,7 @@ extension Router {
 
     // DELETE w/Query Parameters
     fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q, @escaping ResultClosure) -> Void) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -581,7 +581,7 @@ extension Router {
 
     // DELETE w/Optional Query Parameters
     fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q?, @escaping ResultClosure) -> Void) {
-        registerDeleteRoute(route: route, id: false)
+        registerDeleteRoute(route: route)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -111,7 +111,11 @@ class TestSwaggerGeneration: KituraTest {
         completion(nil, nil, nil)
     }
 
-    func putSingleAppleHandler(id: Int, posted: Apple, completion: (Apple?, RequestError?) -> Void ) -> Void {
+    func putSingleAppleHandlerStringId(id: String, posted: Apple, completion: (Apple?, RequestError?) -> Void ) -> Void {
+        completion(nil, nil)
+    }
+
+    func putSingleAppleHandlerIntId(id: Int, posted: Apple, completion: (Apple?, RequestError?) -> Void ) -> Void {
         completion(nil, nil)
     }
 
@@ -392,7 +396,8 @@ class TestSwaggerGeneration: KituraTest {
                 XCTAssertTrue(paths["/me/getid/{id}"] != nil, "path /me/getid/{id} is missing")
                 XCTAssertTrue(paths["/me/patch/{id}"] != nil, "path /me/patch/{id} is missing")
                 XCTAssertTrue(paths["/me/pear"] != nil, "path /me/pear is missing")
-                XCTAssertTrue(paths["/me/put/{id}"] != nil, "path /me/put/{id} is missing")
+                XCTAssertTrue(paths["/me/puts/{id}"] != nil, "path /me/puts/{id} is missing")
+                XCTAssertTrue(paths["/me/puti/{id}"] != nil, "path /me/puti/{id} is missing")
             } else {
                 XCTFail("paths is missing")
             }
@@ -419,69 +424,69 @@ class TestSwaggerGeneration: KituraTest {
             // test for paths section
             if let paths = dict["paths"] as? [String: Any] {
                 // test for path contents
-                if let path = paths["/me/put/{id}"] as? [String: Any] {
+                if let path = paths["/me/puts/{id}"] as? [String: Any] {
                     // test for put method
                     if let put = path["put"] as? [String: Any] {
                         // test for parameters section
                         if let parameters = put["parameters"] as? [[String: Any]] {
-                            XCTAssertTrue(parameters.count == 2, "path /me/put/{id}: put parameters.count is incorrect")
+                            XCTAssertTrue(parameters.count == 2, "path /me/puts{id}: put parameters.count is incorrect")
                             // test for 1st parameter block
                             let p1 = parameters[0]
                             if let inval = p1["in"] as? String {
-                                XCTAssertTrue(inval == "path", "path /me/put/{id}: put parameters in value is incorrect")
+                                XCTAssertTrue(inval == "path", "path /me/puts/{id}: put parameters in value is incorrect")
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters in value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters in value is missing")
                             }
                             if let name = p1["name"] as? String {
-                                XCTAssertTrue(name == "id", "path /me/put/{id}: put parameters name value is incorrect")
+                                XCTAssertTrue(name == "id", "path /me/puts/{id}: put parameters name value is incorrect")
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters name value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters name value is missing")
                             }
                             if let required = p1["required"] as? Bool {
-                                XCTAssertTrue(required == true, "path /me/put/{id}: put parameters required value is incorrect")
+                                XCTAssertTrue(required == true, "path /me/puts/{id}: put parameters required value is incorrect")
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters required value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters required value is missing")
                             }
                             if let type = p1["type"] as? String {
-                                XCTAssertTrue(type == "integer", "path /me/put/{id}: put parameters type value is incorrect")
+                                XCTAssertTrue(type == "string", "path /me/puts/{id}: put parameters type value is incorrect")
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters type value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters type value is missing")
                             }
 
                             // test for 2nd parameter block
                             let p2 = parameters[1]
                             if let inval = p2["in"] as? String {
-                                XCTAssertTrue(inval == "body", "path /me/put/{id}: put parameters in value is incorrect")
+                                XCTAssertTrue(inval == "body", "path /me/puts/{id}: put parameters in value is incorrect")
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters in value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters in value is missing")
                             }
                             if let name = p2["name"] as? String {
-                                XCTAssertTrue(name == "input", "path /me/put/{id}: put parameters name value is incorrect")
+                                XCTAssertTrue(name == "input", "path /me/puts/{id}: put parameters name value is incorrect")
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters name value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters name value is missing")
                             }
                             if let required = p2["required"] as? Bool {
-                                XCTAssertTrue(required == true, "path /me/put/{id}: put parameters required value is incorrect")
+                                XCTAssertTrue(required == true, "path /me/puts/{id}: put parameters required value is incorrect")
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters required value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters required value is missing")
                             }
                             if let schema = p2["schema"] as? [String: String] {
                                 if let ref = schema["$ref"] {
-                                    XCTAssertTrue(ref == "#/definitions/Apple", "path /me/put/{id}: put parameters schema ref is incorrect")
+                                    XCTAssertTrue(ref == "#/definitions/Apple", "path /me/puts/{id}: put parameters schema ref is incorrect")
                                 } else {
-                                    XCTFail("path /me/put/{id}: put parameters schema ref is missing")
+                                    XCTFail("path /me/puts/{id}: put parameters schema ref is missing")
                                 }
                             } else {
-                                XCTFail("path /me/put/{id}: put parameters schema value is missing")
+                                XCTFail("path /me/puts/{id}: put parameters schema value is missing")
                             }
                         } else {
-                            XCTFail("path /me/put/{id}: put parameters are missing")
+                            XCTFail("path /me/puts/{id}: put parameters are missing")
                         }
                     } else {
-                        XCTFail("path /me/put/{id}: put method is missing")
+                        XCTFail("path /me/puts/{id}: put method is missing")
                     }
                 } else {
-                    XCTFail("path /me/put/{id} is missing")
+                    XCTFail("path /me/puts/{id} is missing")
                 }
             } else {
                 XCTFail("paths is missing")
@@ -509,52 +514,52 @@ class TestSwaggerGeneration: KituraTest {
             // test for paths section
             if let paths = dict["paths"] as? [String: Any] {
                 // test for path contents
-                if let path = paths["/me/put/{id}"] as? [String: Any] {
+                if let path = paths["/me/puts/{id}"] as? [String: Any] {
                     // test for put method
                     if let put = path["put"] as? [String: Any] {
                         // test for produces block
                         if let produces = put["produces"] as? [String] {
-                            XCTAssertTrue(produces.contains("application/json"), "path /me/put/{id}: put produces does not contain application/json")
-                            XCTAssertTrue(produces.count == 1, "path /me/put/{id}: put produces.count is incorrect")
+                            XCTAssertTrue(produces.contains("application/json"), "path /me/puts/{id}: put produces does not contain application/json")
+                            XCTAssertTrue(produces.count == 1, "path /me/puts/{id}: put produces.count is incorrect")
                         } else {
-                            XCTFail("path /me/put/{id}: put produces is missing")
+                            XCTFail("path /me/puts/{id}: put produces is missing")
                         }
                         // test for consumes block
                         if let consumes = put["consumes"] as? [String] {
-                            XCTAssertTrue(consumes.contains("application/json"), "path /me/put/{id}: put consumes does not contain application/json")
-                            XCTAssertTrue(consumes.count == 1, "path /me/put/{id}: put consumes.count is incorrect")
+                            XCTAssertTrue(consumes.contains("application/json"), "path /me/puts/{id}: put consumes does not contain application/json")
+                            XCTAssertTrue(consumes.count == 1, "path /me/puts/{id}: put consumes.count is incorrect")
                         } else {
-                            XCTFail("path /me/put/{id}: put consumes is missing")
+                            XCTFail("path /me/puts/{id}: put consumes is missing")
                         }
                         // test for responses block
                         if let responses = put["responses"] as? [String: Any] {
                             if let twohundred = responses["200"] as? [String: Any] {
                                 if let description = twohundred["description"] as? String {
-                                    XCTAssertTrue(description == "successful response", "path /me/put/{id}: put responses 200 description is incorrect")
+                                    XCTAssertTrue(description == "successful response", "path /me/puts/{id}: put responses 200 description is incorrect")
                                 } else {
-                                    XCTFail("path /me/put/{id}: put 200 response does not contain a description")
+                                    XCTFail("path /me/puts/{id}: put 200 response does not contain a description")
                                 }
                                 if let schema = twohundred["schema"] as? [String: Any] {
                                     if let ref = schema["$ref"] as? String {
-                                        XCTAssertTrue(ref == "#/definitions/Apple", "path /me/put/{id}: put responses 200 schema is incorrect")
+                                        XCTAssertTrue(ref == "#/definitions/Apple", "path /me/puts/{id}: put responses 200 schema is incorrect")
                                     } else {
-                                        XCTFail("path /me/put/{id}: put 200 response schema is missing")
+                                        XCTFail("path /me/puts/{id}: put 200 response schema is missing")
                                     }
                                 } else {
-                                    XCTFail("path /me/put/{id}: put 200 response does not contain a schema")
+                                    XCTFail("path /me/puts/{id}: put 200 response does not contain a schema")
                                 }
                             } else {
-                                XCTFail("path /me/put/{id}: put 200 response is missing")
+                                XCTFail("path /me/puts/{id}: put 200 response is missing")
                             }
-                            XCTAssertTrue(responses.count == 1, "path /me/put/{id}: put responses.count is incorrect")
+                            XCTAssertTrue(responses.count == 1, "path /me/puts/{id}: put responses.count is incorrect")
                         } else {
-                            XCTFail("path /me/put/{id}: put responses is missing")
+                            XCTFail("path /me/puts/{id}: put responses is missing")
                         }
                     } else {
-                        XCTFail("path /me/put/{id}: put method is missing")
+                        XCTFail("path /me/puts/{id}: put method is missing")
                     }
                 } else {
-                    XCTFail("path /me/put/{id} is missing")
+                    XCTFail("path /me/puts/{id} is missing")
                 }
             } else {
                 XCTFail("paths is missing")
@@ -628,6 +633,69 @@ class TestSwaggerGeneration: KituraTest {
         }
     }
 
+    func pathContentAssertions4(json: String?) {
+        if let jsonString = json {
+            guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+            guard let dict = json as? [String: Any] else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+
+            // test for paths section
+            if let paths = dict["paths"] as? [String: Any] {
+                // test for path contents
+                if let path = paths["/me/puti/{id}"] as? [String: Any] {
+                    // test for put method
+                    if let put = path["put"] as? [String: Any] {
+                        // test for parameters section
+                        if let parameters = put["parameters"] as? [[String: Any]] {
+                            XCTAssertTrue(parameters.count == 2, "path /me/puti{id}: put parameters.count is incorrect")
+                            // test for 1st parameter block
+                            let p1 = parameters[0]
+                            if let inval = p1["in"] as? String {
+                                XCTAssertTrue(inval == "path", "path /me/puti/{id}: put parameters in value is incorrect")
+                            } else {
+                                XCTFail("path /me/puti/{id}: put parameters in value is missing")
+                            }
+                            if let name = p1["name"] as? String {
+                                XCTAssertTrue(name == "id", "path /me/puti/{id}: put parameters name value is incorrect")
+                            } else {
+                                XCTFail("path /me/puti/{id}: put parameters name value is missing")
+                            }
+                            if let required = p1["required"] as? Bool {
+                                XCTAssertTrue(required == true, "path /me/puti/{id}: put parameters required value is incorrect")
+                            } else {
+                                XCTFail("path /me/puti/{id}: put parameters required value is missing")
+                            }
+                            if let type = p1["type"] as? String {
+                                XCTAssertTrue(type == "integer", "path /me/puti/{id}: put parameters type value is incorrect")
+                            } else {
+                                XCTFail("path /me/puti/{id}: put parameters type value is missing")
+                            }
+                        } else {
+                            XCTFail("path /me/puti/{id}: put parameters are missing")
+                        }
+                    } else {
+                        XCTFail("path /me/puti/{id}: put method is missing")
+                    }
+                } else {
+                    XCTFail("path /me/puti/{id} is missing")
+                }
+            } else {
+                XCTFail("paths is missing")
+            }
+        } else {
+            XCTFail("got unexpected nil from router.swaggerJSON")
+        }
+    }
+
     func testSwaggerGeneration() {
         // test correct values returned from JsonApiDoc property
         let router = Router()
@@ -644,7 +712,8 @@ class TestSwaggerGeneration: KituraTest {
         router.post("/me/post", handler: postAppleHandler)
         router.post("/me/postid", handler: postSingleAppleHandler)
 
-        router.put("/me/put", handler: putSingleAppleHandler)
+        router.put("/me/puts", handler: putSingleAppleHandlerStringId)
+        router.put("/me/puti", handler: putSingleAppleHandlerIntId)
 
         setupServerAndExpectations(router: router, expectStart: true, expectStop: true, expectFail: false)
 
@@ -661,6 +730,7 @@ class TestSwaggerGeneration: KituraTest {
         pathContentAssertions1(json: router.swaggerJSON)
         pathContentAssertions2(json: router.swaggerJSON)
         pathContentAssertions3(json: router.swaggerJSON)
+        pathContentAssertions4(json: router.swaggerJSON)
 
         requestQueue.async() {
             Kitura.stop()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Reworking of the handling of the id parameter, to permit both Int and String types rather than hard-coding `integer`.

This is code from @nhardman in #1304 which I have split into smaller PRs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This adds new Swagger generation tests for both String and Int type identifiers.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
