### PR TITLE
[kitura-nio]Allow pfx files on Darwin

### DIFF
--- a/.swift-test-linux
+++ b/.swift-test-linux
@@ -1,0 +1,1 @@
+swift test -Xlinker -lz

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,8 @@ matrix:
       sudo: required
       env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-04-a
 
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install libressl ; fi
+
 script:
   - ./build.sh

--- a/Sources/Kitura/SSLConfig.swift
+++ b/Sources/Kitura/SSLConfig.swift
@@ -39,7 +39,6 @@ public struct SSLConfig {
 
         config = SSLService.Configuration(withCACertificateFilePath: caCertificateFilePath, usingCertificateFile: certificateFilePath, withKeyFile:keyFilePath, usingSelfSignedCerts: selfSigned, cipherSuite: cipherSuite)
     }
-    #endif // os(Linux)
 
     /// Initialize an `SSLService.Configuration` instance using a CA certificate directory.
     ///
@@ -55,6 +54,8 @@ public struct SSLConfig {
 
         config = SSLService.Configuration(withCACertificateDirectory:caCertificateDirPath, usingCertificateFile: certificateFilePath, withKeyFile: keyFilePath, usingSelfSignedCerts: selfSigned, cipherSuite: cipherSuite)
     }
+
+    #endif // os(Linux)
 
     //MARK: For MacOS
     /// Initialize an `SSLService.Configuration` instance using a certificate chain file.

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -42,16 +42,16 @@ class KituraTest: XCTestCase {
     static let sslConfig: SSLConfig = {
         let sslConfigDir = URL(fileURLWithPath: #file).appendingPathComponent("../SSLConfig")
 
-        //#if os(Linux)
+        #if os(Linux)
             let certificatePath = sslConfigDir.appendingPathComponent("certificate.pem").standardized.path
             let keyPath = sslConfigDir.appendingPathComponent("key.pem").standardized.path
             return SSLConfig(withCACertificateDirectory: nil, usingCertificateFile: certificatePath,
                               withKeyFile: keyPath, usingSelfSignedCerts: true)
-        //#else
-        //    let chainFilePath = sslConfigDir.appendingPathComponent("certificateChain.pfx").standardized.path
-        //    return SSLConfig(withChainFilePath: chainFilePath, withPassword: "kitura",
-        //                     usingSelfSignedCerts: true)
-        //#endif
+        #else
+            let chainFilePath = sslConfigDir.appendingPathComponent("certificateChain.pfx").standardized.path
+            return SSLConfig(withChainFilePath: chainFilePath, withPassword: "kitura",
+                             usingSelfSignedCerts: true)
+        #endif
     }()
 
     private static let initOnce: () = {


### PR DESCRIPTION
PR https://github.com/IBM-Swift/Kitura-NIO/pull/58 adds support for PKCS#12 formatted certificates in Kitura-NIO. Hence we can now allow SSL configuration through pfx files on Darwin