### PR TITLE
perf: only call addCookies() if there are cookies

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -174,7 +174,10 @@ public class RouterResponse {
         if  contentLength == nil {
             headers["Content-Length"] = String(content.count)
         }
-        addCookies()
+
+        if cookies.count > 0 {
+            addCookies()
+        }
 
         if  request.method != .head {
             try response.write(from: content)


### PR DESCRIPTION
## Description

Currently, RouterResponse.end() always calls addCookies() to add the
Set-Cookie header if required. The code does various pieces of work even
if there are no cookies, such as allocating an array and iterating over
an empty dictionary.

We can avoid all this unnecessary work by checking whether there are any
cookies before calling addCookies().

## Motivation and Context

I've recently been analysing Kitura performance, and the cost of `addCookies()` is significant.

## How Has This Been Tested?

Performance testing Kitura built in debug mode using simple HelloWorld app. Load was driven via wrk with 128 concurrent connections across 4 cores.

Ubuntu 14.04:

```
               | Throughput (req/s)      | CPU (%) | Mem (kb)     | Latency (ms)                   | good
Implementation | Average    | Max        | Average | Avg peak RSS | Average  | 99%      | Max      | iters
---------------|------------|------------|---------|--------------|----------|----------|----------|-------
             1 |    46283.1 |    49023.9 |    98.3 |        22813 |      2.7 |      6.3 |    202.9 |    19
             2 |    51124.1 |    54404.1 |    98.3 |        22407 |      2.5 |      7.5 |    201.5 |    18
```

Ubuntu 16.04:

```
               | Throughput (req/s)      | CPU (%) | Mem (kb)     | Latency (ms)                   | good
Implementation | Average    | Max        | Average | Avg peak RSS | Average  | 99%      | Max      | iters
---------------|------------|------------|---------|--------------|----------|----------|----------|-------
      Baseline |    61853.6 |    66361.4 |    98.4 |        12826 |      2.0 |      5.1 |    199.6 |    20
           New |    69601.2 |    72414.9 |    97.9 |        15394 |      1.8 |      5.0 |    201.6 |    20
```

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
