### PR TITLE
Support for query parameters in generated swagger

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
-        .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.0.0")
+        .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -517,7 +517,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, Q, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -564,7 +564,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, Q, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -611,7 +611,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, Q, @escaping CodableResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -663,7 +663,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -709,7 +709,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -755,7 +755,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -1032,7 +1032,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, Q, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route)
+        registerDeleteRoute(route: route, queryparams: Q.self, optionalQParam: false)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -1076,7 +1076,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, Q, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route)
+        registerDeleteRoute(route: route, queryparams: Q.self, optionalQParam: false)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -1120,7 +1120,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, Q, @escaping ResultClosure) -> Void
     ) {
-        registerDeleteRoute(route: route)
+        registerDeleteRoute(route: route, queryparams: Q.self, optionalQParam: false)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -446,7 +446,7 @@ extension Router {
 
     // Get w/Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -463,7 +463,7 @@ extension Router {
 
     // Get w/Query Parameters with CodableResultClosure
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -481,7 +481,7 @@ extension Router {
 
     // Get w/Optional Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -502,7 +502,7 @@ extension Router {
 
     // Get w/Optional Query Parameters with CodableResultClosure
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -564,7 +564,7 @@ extension Router {
 
     // DELETE w/Query Parameters
     fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q, @escaping ResultClosure) -> Void) {
-        registerDeleteRoute(route: route)
+        registerDeleteRoute(route: route, queryparams: Q.self)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -581,7 +581,7 @@ extension Router {
 
     // DELETE w/Optional Query Parameters
     fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q?, @escaping ResultClosure) -> Void) {
-        registerDeleteRoute(route: route)
+        registerDeleteRoute(route: route, queryparams: Q.self)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -446,7 +446,7 @@ extension Router {
 
     // Get w/Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -463,7 +463,7 @@ extension Router {
 
     // Get w/Query Parameters with CodableResultClosure
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: false, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -481,7 +481,7 @@ extension Router {
 
     // Get w/Optional Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: true, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -502,7 +502,7 @@ extension Router {
 
     // Get w/Optional Query Parameters with CodableResultClosure
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, queryparams: Q.self, outputtype: O.self)
+        registerGetRoute(route: route, queryparams: Q.self, optionalQParam: true, outputtype: O.self)
         get(route) { request, response, next in
             Log.verbose("Received GET (singular) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -564,7 +564,7 @@ extension Router {
 
     // DELETE w/Query Parameters
     fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q, @escaping ResultClosure) -> Void) {
-        registerDeleteRoute(route: route, queryparams: Q.self)
+        registerDeleteRoute(route: route, queryparams: Q.self, optionalQParam: false)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -581,7 +581,7 @@ extension Router {
 
     // DELETE w/Optional Query Parameters
     fileprivate func deleteSafely<Q: QueryParams>(_ route: String, handler: @escaping (Q?, @escaping ResultClosure) -> Void) {
-        registerDeleteRoute(route: route, queryparams: Q.self)
+        registerDeleteRoute(route: route, queryparams: Q.self, optionalQParam: true)
         delete(route) { request, response, next in
             Log.verbose("Received DELETE type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -27,7 +27,62 @@ extension String {
     }
 }
 
+struct QueryStringParam: QueryParams {
+    public let stringField: String
+}
+
+struct QueryIntFieldParam: QueryParams {
+    public let intField: Int32
+}
+
+struct QueryIntFieldOptionalParam: QueryParams {
+    public let intField: Int?
+}
+
+struct QueryIntFieldArrayParam: QueryParams {
+    public let intField: [Int32]
+}
+
+struct QueryThreeParams: QueryParams {
+    public let intArrayField: [Int32]?
+    public let intField: Int32
+    public let stringField: String
+}
+
 // handler to use in the tests
+func getQueryUglifruitHandler1(query: QueryStringParam, completion: (Uglifruit?, RequestError?) -> Void ) -> Void {
+    let ugli = Uglifruit(auth: "hi", colour: "red", flavour: "tangy", test: nil)
+    completion(ugli, nil)
+}
+
+func getQueryUglifruitHandler2(query: QueryIntFieldParam, completion: (Uglifruit?, RequestError?) -> Void ) -> Void {
+    let ugli = Uglifruit(auth: "hi", colour: "red", flavour: "tangy", test: nil)
+    completion(ugli, nil)
+}
+
+func getQueryUglifruitHandler3(query: QueryIntFieldOptionalParam, completion: (Uglifruit?, RequestError?) -> Void ) -> Void {
+    let ugli = Uglifruit(auth: "hi", colour: "red", flavour: "tangy", test: nil)
+    completion(ugli, nil)
+}
+
+func getQueryUglifruitHandler4(query: QueryIntFieldArrayParam, completion: (Uglifruit?, RequestError?) -> Void ) -> Void {
+    let ugli = Uglifruit(auth: "hi", colour: "red", flavour: "tangy", test: nil)
+    completion(ugli, nil)
+}
+
+func getQueryUglifruitHandler5(query: QueryThreeParams, completion: (Uglifruit?, RequestError?) -> Void ) -> Void {
+    let ugli = Uglifruit(auth: "hi", colour: "red", flavour: "tangy", test: nil)
+    completion(ugli, nil)
+}
+
+func deleteQueryUglifruitHandler1(query: QueryIntFieldParam, completion: (RequestError?) -> Void) {
+    completion(nil)
+}
+
+func deleteQueryUglifruitHandler2(query: QueryIntFieldParam?, completion: (RequestError?) -> Void) {
+    completion(nil)
+}
+
 func deleteHandler(completion: (RequestError?) -> Void ) -> Void {
     completion(nil)
 }
@@ -79,6 +134,7 @@ class TestSwaggerGeneration: KituraTest {
             ("testSwaggerDefinitions", testSwaggerDefinitions),
             ("testSwaggerSections", testSwaggerSections),
             ("testSwaggerContent", testSwaggerContent),
+            ("testSwaggerQueryParams", testSwaggerQueryParams),
         ]
     }
 
@@ -94,6 +150,13 @@ class TestSwaggerGeneration: KituraTest {
         router.get("/me/getarray", handler: getArrayAppleHandler)
         router.get("/me/getarray", handler: getSingleArrayAppleHandler)
         router.get("/me/getid", handler: getSingleAppleHandler)
+        router.get("/me/getugli1", handler: getQueryUglifruitHandler1)
+        router.get("/me/getugli2", handler: getQueryUglifruitHandler2)
+        router.get("/me/getugli3", handler: getQueryUglifruitHandler3)
+        router.get("/me/getugli4", handler: getQueryUglifruitHandler4)
+        router.get("/me/getugli5", handler: getQueryUglifruitHandler5)
+        router.delete("/me/delugli1", handler: deleteQueryUglifruitHandler1)
+        router.delete("/me/delugli2", handler: deleteQueryUglifruitHandler2)
 
         router.patch("/me/patch", handler: patchSingleAppleHandler)
 
@@ -514,6 +577,268 @@ class TestSwaggerGeneration: KituraTest {
         }
     }
 
+    func pathGetQueryParams1(paths: [String: Any]) {
+        // test for path contents
+        if let path = paths["/me/getugli1"] as? [String: Any] {
+            // test for put method
+            if let get = path["get"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = get["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 1, "path /me/getugli1: query parameters.count is incorrect")
+                    // test for 1st parameter block
+                    let param = parameters[0]
+                    if let inval = param["in"] as? String {
+                        XCTAssertTrue(inval == "query", "path /me/getugli1: query param 'in' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli1: query parameters 'in' value is missing")
+                    }
+                    if let name = param["name"] as? String {
+                        XCTAssertTrue(name == "stringField", "path /me/getugli1: query param 'name' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli1: query parameters 'name' value is missing")
+                    }
+                    if let required = param["required"] as? Bool {
+                        XCTAssertTrue(required, "path /me/getugli1: query param 'required' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli1: query parameters 'required' value is missing")
+                    }
+                    if let type = param["type"] as? String {
+                        XCTAssertTrue(type == "string", "path /me/getugli1: query param 'type' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli1: query parameters 'type' value is missing")
+                    }
+                } else {
+                    XCTFail("path /me/getugli1: query parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/getugli1: get method is missing")
+            }
+        } else {
+            XCTFail("path /me/getugli1 is missing")
+        }
+    }
+
+    func pathGetQueryParams2(paths: [String: Any]) {
+        // test for path contents
+        if let path = paths["/me/getugli2"] as? [String: Any] {
+            // test for put method
+            if let get = path["get"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = get["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 1, "path /me/getugli2: query parameters.count is incorrect")
+                    // test for 1st parameter block
+                    let param = parameters[0]
+                    if let inval = param["in"] as? String {
+                        XCTAssertTrue(inval == "query", "path /me/getugli2: query param 'in' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli2: query parameters 'in' value is missing")
+                    }
+                    if let name = param["name"] as? String {
+                        XCTAssertTrue(name == "intField", "path /me/getugli2: query param 'name' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli2: query parameters 'name' value is missing")
+                    }
+                    if let format = param["format"] as? String {
+                        XCTAssertTrue(format == "int32", "path /me/getugli2: query param 'format' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli2: query parameters 'format' value is missing")
+                    }
+                    if let required = param["required"] as? Bool {
+                        XCTAssertTrue(required, "path /me/getugli2: query param 'required' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli2: query parameters 'required' value is missing")
+                    }
+                    if let type = param["type"] as? String {
+                        XCTAssertTrue(type == "integer", "path /me/getugli2: query param 'type' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli2: query parameters 'type' value is missing")
+                    }
+                } else {
+                    XCTFail("path /me/getugli2: query parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/getugli2: get method is missing")
+            }
+        } else {
+            XCTFail("path /me/getugli2 is missing")
+        }
+    }
+
+    func pathGetQueryParams3(paths: [String: Any]) {
+        // test for path contents
+        if let path = paths["/me/getugli3"] as? [String: Any] {
+            // test for put method
+            if let get = path["get"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = get["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 1, "path /me/getugli3: query parameters.count is incorrect")
+                    // test for 1st parameter block
+                    let param = parameters[0]
+                    if let inval = param["in"] as? String {
+                        XCTAssertTrue(inval == "query", "path /me/getugli3: query param 'in' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli3: query parameters 'in' value is missing")
+                    }
+                    if let name = param["name"] as? String {
+                        XCTAssertTrue(name == "intField", "path /me/getugli3: query param 'name' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli3: query parameters 'name' value is missing")
+                    }
+                    if let required = param["required"] as? Bool {
+                        XCTAssertFalse(required, "path /me/getugli3: query param 'required' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli3: query parameters 'required' value is missing")
+                    }
+                    if let type = param["type"] as? String {
+                        XCTAssertTrue(type == "integer", "path /me/getugli3: query param 'type' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli3: query parameters 'type' value is missing")
+                    }
+                    XCTAssertTrue(param["format"] == nil, "path /me/getugli3: query parameters 'format' value is found when it should not exist")
+                } else {
+                    XCTFail("path /me/getugli3: query parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/getugli3: get method is missing")
+            }
+        } else {
+            XCTFail("path /me/getugli3 is missing")
+        }
+    }
+
+    func pathGetQueryParams4(paths: [String: Any]) {
+        // test for path contents
+        if let path = paths["/me/getugli4"] as? [String: Any] {
+            // test for put method
+            if let get = path["get"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = get["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 1, "path /me/getugli4: query parameters.count is incorrect")
+                    // test for 1st parameter block
+                    let param = parameters[0]
+                    if let inval = param["in"] as? String {
+                        XCTAssertTrue(inval == "query", "path /me/getugli4: query param 'in' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli4: query parameters 'in' value is missing")
+                    }
+                    if let name = param["name"] as? String {
+                        XCTAssertTrue(name == "intField", "path /me/getugli4: query param 'name' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli4: query parameters 'name' value is missing")
+                    }
+                    if let items = param["items"] as? [String: Any] {
+                        if let type = items["type"] as? String {
+                            XCTAssertTrue(type == "integer", "path /me/getugli4: query param 'items[type]' value is incorrect")
+                        } else {
+                            XCTFail("path /me/getugli4: query parameters 'items[type]' value is missing")
+                        }
+                        if let format = items["format"] as? String {
+                            XCTAssertTrue(format == "int32", "path /me/getugli4: query param 'items[format]' value is incorrect")
+                        } else {
+                            XCTFail("path /me/getugli4: query parameters 'items[format]' value is missing")
+                        }
+                    } else {
+                        XCTFail("path /me/getugli4: query parameters 'items' value is missing")
+                    }
+                    if let collectionFormat = param["collectionFormat"] as? String {
+                        XCTAssertTrue(collectionFormat == "csv", "path /me/getugli4: query param 'collectionFormat' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli4: query parameters 'collectionFormat' value is missing")
+                    }
+                    if let required = param["required"] as? Bool {
+                        XCTAssertTrue(required, "path /me/getugli4: query param 'required' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli4: query parameters 'required' value is missing")
+                    }
+                    if let type = param["type"] as? String {
+                        XCTAssertTrue(type == "array", "path /me/getugli4: query param 'type' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli4: query parameters 'type' value is missing")
+                    }
+                } else {
+                    XCTFail("path /me/getugli4: query parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/getugli4: get method is missing")
+            }
+        } else {
+            XCTFail("path /me/getugli4 is missing")
+        }
+    }
+
+    func pathGetQueryParams5(paths: [String: Any]) {
+        if let path = paths["/me/getugli5"] as? [String: Any] {
+            // test for put method
+            if let get = path["get"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = get["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 3, "path /me/getugli5: get parameters.count is incorrect")
+                    // test for 1st parameter block
+                    let param = parameters[0]
+                    if let inval = param["in"] as? String {
+                        XCTAssertTrue(inval == "query", "path /me/getugli5: get parameters 'in' value is incorrect")
+                    } else {
+                        XCTFail("path /me/getugli5: get parameters 'in' value is missing")
+                    }
+                } else {
+                    XCTFail("path /me/getugli5: get parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/getugli5: get method is missing")
+            }
+        } else {
+            XCTFail("path /me/getugli5 is missing")
+        }
+    }
+
+    func pathDeleteQueryParams(paths: [String: Any]) {
+        if let path = paths["/me/delugli1"] as? [String: Any] {
+            // test for put method
+            if let delete = path["delete"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = delete["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 1, "path /me/delugli1: get parameters.count is incorrect")
+                    // test for 1st parameter block
+                    let param = parameters[0]
+                    if let inval = param["in"] as? String {
+                        XCTAssertTrue(inval == "query", "path /me/delugli1: delete parameters 'in' value is incorrect")
+                    } else {
+                        XCTFail("path /me/delugli1: delete parameters 'in' value is missing")
+                    }
+                } else {
+                    XCTFail("path /me/delugli1: delete parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/delugli1: delete method is missing")
+            }
+        } else {
+            XCTFail("path /me/delugli1 is missing")
+        }
+
+        if let path = paths["/me/delugli2"] as? [String: Any] {
+            // test for put method
+            if let delete = path["delete"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = delete["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 1, "path /me/delugli2: get parameters.count is incorrect")
+                    // test for 1st parameter block
+                    let param = parameters[0]
+                    if let inval = param["in"] as? String {
+                        XCTAssertTrue(inval == "query", "path /me/delugli2: delete parameters 'in' value is incorrect")
+                    } else {
+                        XCTFail("path /me/delugli2: delete parameters 'in' value is missing")
+                    }
+                } else {
+                    XCTFail("path /me/delugli2: delete parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/delugli2: delete method is missing")
+            }
+        } else {
+            XCTFail("path /me/delugli2 is missing")
+        }
+    }
+
     func testSwaggerSections() {
         // test correct values returned from JsonApiDoc property
         setupServerAndExpectations(router: router, expectStart: true, expectStop: true, expectFail: false)
@@ -583,6 +908,53 @@ class TestSwaggerGeneration: KituraTest {
                 pathContentAssertions2(paths: paths)
                 pathContentAssertions3(paths: paths)
                 pathContentAssertions4(paths: paths)
+            } else {
+                XCTFail("paths is missing")
+            }
+        } else {
+            XCTFail("got unexpected nil from router.swaggerJSON")
+        }
+
+        requestQueue.async() {
+            Kitura.stop()
+        }
+
+        waitForExpectations(timeout: 10) { error in
+            XCTAssertNil(error)
+        }
+    }
+
+    func testSwaggerQueryParams() {
+        // test correct values returned from JsonApiDoc property
+        setupServerAndExpectations(router: router, expectStart: true, expectStop: true, expectFail: false)
+
+        let requestQueue = DispatchQueue(label: "Request queue")
+        requestQueue.async() {
+            Kitura.start()
+        }
+
+        if let jsonString = router.swaggerJSON {
+            guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+            guard let dict = json as? [String: Any] else {
+                XCTFail("got unexpected nil from router.swaggerJSON")
+                return
+            }
+
+            // test for paths section
+            if let paths = dict["paths"] as? [String: Any] {
+                pathGetQueryParams1(paths: paths)
+                pathGetQueryParams2(paths: paths)
+                pathGetQueryParams3(paths: paths)
+                pathGetQueryParams4(paths: paths)
+                pathGetQueryParams5(paths: paths)
+                pathDeleteQueryParams(paths: paths)
             } else {
                 XCTFail("paths is missing")
             }

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -75,11 +75,20 @@ func getQueryUglifruitHandler5(query: QueryThreeParams, completion: (Uglifruit?,
     completion(ugli, nil)
 }
 
+func getQueryUglifruitHandler6(query: QueryThreeParams?, completion: (Uglifruit?, RequestError?) -> Void ) -> Void {
+    let ugli = Uglifruit(auth: "hi", colour: "red", flavour: "tangy", test: nil)
+    completion(ugli, nil)
+}
+
 func deleteQueryUglifruitHandler1(query: QueryIntFieldParam, completion: (RequestError?) -> Void) {
     completion(nil)
 }
 
 func deleteQueryUglifruitHandler2(query: QueryIntFieldParam?, completion: (RequestError?) -> Void) {
+    completion(nil)
+}
+
+func deleteQueryUglifruitHandler3(query: QueryThreeParams?, completion: (RequestError?) -> Void) {
     completion(nil)
 }
 
@@ -155,8 +164,10 @@ class TestSwaggerGeneration: KituraTest {
         router.get("/me/getugli3", handler: getQueryUglifruitHandler3)
         router.get("/me/getugli4", handler: getQueryUglifruitHandler4)
         router.get("/me/getugli5", handler: getQueryUglifruitHandler5)
+        router.get("/me/getugli6", handler: getQueryUglifruitHandler6)
         router.delete("/me/delugli1", handler: deleteQueryUglifruitHandler1)
         router.delete("/me/delugli2", handler: deleteQueryUglifruitHandler2)
+        router.delete("/me/delugli3", handler: deleteQueryUglifruitHandler3)
 
         router.patch("/me/patch", handler: patchSingleAppleHandler)
 
@@ -792,6 +803,7 @@ class TestSwaggerGeneration: KituraTest {
     }
 
     func pathDeleteQueryParams(paths: [String: Any]) {
+        // Confirm that query params are created for deletes.
         if let path = paths["/me/delugli1"] as? [String: Any] {
             // test for put method
             if let delete = path["delete"] as? [String: Any] {
@@ -836,6 +848,60 @@ class TestSwaggerGeneration: KituraTest {
             }
         } else {
             XCTFail("path /me/delugli2 is missing")
+        }
+    }
+
+    func pathOptionalQueryParams(paths: [String: Any]) {
+        // Ensure that an optional query param causes all fields in the query
+        // params to be optional.
+        if let path = paths["/me/getugli6"] as? [String: Any] {
+            // test for put method
+            if let get = path["get"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = get["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 3, "path /me/getugli6: get parameters.count is incorrect")
+                    // test for 1st parameter block
+                    for i in 0 ... 2 {
+                        let param = parameters[i]
+                        if let required = param["required"] as? Bool {
+                            XCTAssertTrue(required == false, "path /me/getugli6 get parameter[\(i)] 'required' value is incorrect")
+                        } else {
+                            XCTFail("path /me/getugli6: get parameters[\(i)] 'required' value is missing")
+                        }
+                    }
+                } else {
+                    XCTFail("path /me/getugli6: get parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/getugli6: get method is missing")
+            }
+        } else {
+            XCTFail("path /me/getugli6 is missing")
+        }
+
+        if let path = paths["/me/delugli3"] as? [String: Any] {
+            // test for put method
+            if let get = path["delete"] as? [String: Any] {
+                // test for parameters section
+                if let parameters = get["parameters"] as? [[String: Any]] {
+                    XCTAssertTrue(parameters.count == 3, "path /me/delugli3: delete parameters.count is incorrect")
+                    // test for 1st parameter block
+                    for i in 0 ... 2 {
+                        let param = parameters[i]
+                        if let required = param["required"] as? Bool {
+                            XCTAssertTrue(required == false, "path /me/delugli3 delete parameter[\(i)] 'required' value is incorrect")
+                        } else {
+                            XCTFail("path /me/delugli3: delete parameters[\(i)] 'required' value is missing")
+                        }
+                    }
+                } else {
+                    XCTFail("path /me/delugli3: delete parameters are missing")
+                }
+            } else {
+                XCTFail("path /me/delugli3: delete method is missing")
+            }
+        } else {
+            XCTFail("path /me/delugli3 is missing")
         }
     }
 
@@ -954,6 +1020,7 @@ class TestSwaggerGeneration: KituraTest {
                 pathGetQueryParams3(paths: paths)
                 pathGetQueryParams4(paths: paths)
                 pathGetQueryParams5(paths: paths)
+                pathOptionalQueryParams(paths: paths)
                 pathDeleteQueryParams(paths: paths)
             } else {
                 XCTFail("paths is missing")

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -458,21 +458,13 @@ class TestSwaggerGeneration: KituraTest {
         if let path = paths["/me/pear"] as? [String: Any] {
             // test for delete method
             if let delete = path["delete"] as? [String: Any] {
-                if let parameters = delete["parameters"] as? [[String: Any]] {
-                    XCTAssertTrue(parameters.count == 0, "path /me/pear: delete parameters.count is incorrect")
-                } else {
-                    XCTFail("path /me/pear: delete parameters are missing")
-                }
+                XCTAssertTrue(delete["parameters"] == nil, "path /me/pear: delete parameters found when they should not exist")
             } else {
                 XCTFail("path /me/pear: delete method is missing")
             }
             // test for get method
             if let get = path["get"] as? [String: Any] {
-                if let parameters = get["parameters"] as? [[String: Any]] {
-                    XCTAssertTrue(parameters.count == 0, "path /me/pear: get parameters.count is incorrect")
-                } else {
-                    XCTFail("path /me/pear: get parameters are missing")
-                }
+                XCTAssertTrue(get["parameters"] == nil, "path /me/pear: get parameters found when they should not exist")
             } else {
                 XCTFail("path /me/pear: get method is missing")
             }


### PR DESCRIPTION
This PR adds support for representing query parameters in generated swagger.

It also changes the definition of the `parameters` for a `SwaggerMethod`  from `SwaggerParameters` to `[SwaggerParameter]?`, which means it can be omitted from the document rather than the generated swagger containing an empty array when no parameters are present.  The existing tests have been modified accordingly.

This is @nhardman's code and is the feature part of PR #1304, from which I have separately extracted and delivered some fixes for identifier types (#1316) and testcase refactoring (#1320).

There are some issues I'm aware of (such as `queryparams` rather than `queryParams`, and a spurious change of `idType` to `idtype`), but this code builds and passes the tests (which include new tests for this feature).

Some of the tidying up will be addressed in https://github.com/IBM-Swift/Kitura/commit/b344a2b5abc3bb40225f77d585f0e23ea8a65d13 (follow-on PR).