### PR TITLE
Allow users to switch to using the NIO port of KituraNet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      services: docker
+      env: DOCKER_IMAGE=ubuntu:16.04 KITURA_NIO=1
+    - os: linux
+      dist: trusty
+      sudo: required
       env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-19-a
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
       dist: trusty
       sudo: required
       env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-19-a
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-19-a KITURA_NIO=1
     - os: osx
       osx_image: xcode9.2
       sudo: required
@@ -46,6 +50,13 @@ matrix:
       osx_image: xcode10
       sudo: required
       env: SWIFT_SNAPSHOT=4.2
+    - os: osx
+      osx_image: xcode10
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.2 KITURA_NIO=1
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install libressl ; fi
 
 script:
   - ./build.sh

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,15 @@
  **/
 
 import PackageDescription
+import Foundation
+
+var kituraNetPackage: Package.Dependency
+
+if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
+} else {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0")
+}
 
 let package = Package(
     name: "Kitura",
@@ -29,7 +38,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
+        kituraNetPackage,
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.1.0")

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -o verbose
 
 if [ -n "${DOCKER_IMAGE}" ]; then
     docker pull ${DOCKER_IMAGE}
-    docker run --env SWIFT_SNAPSHOT -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
+    docker run --env SWIFT_SNAPSHOT --env KITURA_NIO -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
 else
     git clone https://github.com/IBM-Swift/Package-Builder.git
     ./Package-Builder/build-package.sh -projectDir $(pwd)

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -o verbose
 
 if [ -n "${DOCKER_IMAGE}" ]; then
     docker pull ${DOCKER_IMAGE}
-    docker run --env SWIFT_SNAPSHOT --env KITURA_NIO -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
+    docker run --env SWIFT_SNAPSHOT --env KITURA_NIO -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config && cd $TRAVIS_BUILD_DIR && ./build.sh"
 else
     git clone https://github.com/IBM-Swift/Package-Builder.git
     ./Package-Builder/build-package.sh -projectDir $(pwd)


### PR DESCRIPTION
We recently renamed the erstwhile KituraNIO package to KituraNet. So, we now have a `KituraNet` and a `SwiftNIO-based KituraNet`. This pull request allows Kitura users to switch to using the latter using only an environment variable named `KITURA_NIO`.

## Description
The core of the change is only to the Swift package manifest file. In the building phase of the Kitura application, if an environment variable named `KITURA_NIO` is set, the Swift package manager switches to using the NIO-based KituraNet found [here](https://github.com/IBM-Swift/KituraNIO). The other changes in this pull request are in the Tests and mostly around two limitations of the NIO-based port - [a bind issue ](https://github.com/IBM-Swift/KituraNIO/issues/2)and the absence of a FastCGI implementation. 

To enable the use of the `SwiftNIO-based KituraNet` we use:
`export KITURA_NIO=1`

To switch back to using stock KituraNet in the same environment:
`unset KITURA_NIO`

## Motivation and Context
Support for a NIO-based networking package was available until now only on a branch named `kitura-nio`. This pull request makes it available on the master branch.