### PR TITLE
Support array response types in generated swagger

### DIFF
--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -108,7 +108,7 @@ extension Router {
      ### Usage Example: ###
      In this example, `MySession` is a struct that conforms to the `TypeSafeMiddleware` protocol and specifies an optional `User`, where `User` conforms to Codable.
      ```swift
-     router.get("/user") { (session: MySession, middle2: Middle2, middle3: Middle3, rrespondWith: (User?, RequestError?) -> Void) in
+     router.get("/user") { (session: MySession, middle2: Middle2, middle3: Middle3, respondWith: (User?, RequestError?) -> Void) in
         guard let user: User = session.user else {
             return respondWith(nil, .notFound)
         }
@@ -163,7 +163,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputType: O.self)
+        registerGetRoute(route: route, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) typed middleware request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
@@ -198,7 +198,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputType: O.self)
+        registerGetRoute(route: route, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) typed middleware request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
@@ -233,7 +233,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, outputType: O.self)
+        registerGetRoute(route: route, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) typed middleware request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
@@ -404,7 +404,9 @@ extension Router {
         _ route: String,
         handler: @escaping (T, @escaping IdentifierCodableArrayResultClosure<Id, O>) -> Void
     ) {
-        registerGetRoute(route: route, id: Id.self, outputType: O.self)
+        // FIXME: The ID is returned in a tuple, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
+        registerGetRoute(route: route, id: Id.self, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) with identifier typed middleware request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
@@ -439,7 +441,9 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, @escaping IdentifierCodableArrayResultClosure<Id, O>) -> Void
     ) {
-        registerGetRoute(route: route, id: Id.self, outputType: O.self)
+        // FIXME: The ID is returned in a tuple, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
+        registerGetRoute(route: route, id: Id.self, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) with identifier typed middleware request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
@@ -459,7 +463,7 @@ extension Router {
      ### Usage Example: ###
      In this example, `MySession` is a struct that conforms to the `TypeSafeMiddleware` protocol and specifies an [(Int, User)] dictionary, where `User` conforms to Codable.
      ```swift
-     router.get("/user") { (session: MySession, middle2: Middle2, middle3: Middle3, rrespondWith: ([(Int, User)]?, RequestError?) -> Void) in
+     router.get("/user") { (session: MySession, middle2: Middle2, middle3: Middle3, respondWith: ([(Int, User)]?, RequestError?) -> Void) in
         guard let users: [(Int, User)] = session.users else {
             return respondWith(nil, .notFound)
         }
@@ -474,7 +478,9 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, @escaping IdentifierCodableArrayResultClosure<Id, O>) -> Void
     ) {
-        registerGetRoute(route: route, id: Id.self, outputType: O.self)
+        // FIXME: The ID is returned in a tuple, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
+        registerGetRoute(route: route, id: Id.self, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET(Array) with identifier typed middleware request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
@@ -663,7 +669,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self)
+        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -709,7 +715,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self)
+        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -755,7 +761,7 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, Q, @escaping CodableArrayResultClosure<O>) -> Void
     ) {
-        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self)
+        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with middleware and Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -853,7 +859,7 @@ extension Router {
      ### Usage Example: ###
      In this example, `MySession` is a struct that conforms to the `TypeSafeMiddleware` protocol and specifies an optional `User`, where `User` conforms to Codable.
      ```swift
-     router.delete("/user") { (session: MySession, middle2: Middle2, middle3: Middle3, rrespondWith: (RequestError?) -> Void) in
+     router.delete("/user") { (session: MySession, middle2: Middle2, middle3: Middle3, respondWith: (RequestError?) -> Void) in
         session.user: User? = nil
         respondWith(nil)
      }
@@ -1295,6 +1301,8 @@ extension Router {
         _ route: String,
         handler: @escaping (T, I, @escaping IdentifierCodableResultClosure<Id, O>) -> Void
     ) {
+        // FIXME: The ID is returned in the Location header, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
         registerPostRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
@@ -1333,6 +1341,8 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, I, @escaping IdentifierCodableResultClosure<Id, O>) -> Void
     ) {
+        // FIXME: The ID is returned in the Location header, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
         registerPostRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
@@ -1371,6 +1381,8 @@ extension Router {
         _ route: String,
         handler: @escaping (T1, T2, T3, I, @escaping IdentifierCodableResultClosure<Id, O>) -> Void
     ) {
+        // FIXME: The ID is returned in the Location header, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
         registerPostRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -370,6 +370,8 @@ extension Router {
 
     // POST
     fileprivate func postSafelyWithId<I: Codable, Id: Identifier, O: Codable>(_ route: String, handler: @escaping CodableIdentifierClosure<I, Id, O>) {
+        // FIXME: The ID is returned in the Location header, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
         registerPostRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
         post(route) { request, response, next in
             Log.verbose("Received POST type-safe request")
@@ -437,6 +439,8 @@ extension Router {
     
     // Get array of (Id, Codable) tuples
     fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
+        // FIXME: The ID is returned in a tuple, it is not an input parameter
+        // https://github.com/IBM-Swift/Kitura/issues/1336
         registerGetRoute(route: route, id: Id.self, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -428,7 +428,7 @@ extension Router {
 
     // Get array
     fileprivate func getSafely<O: Codable>(_ route: String, handler: @escaping CodableArrayClosure<O>) {
-        registerGetRoute(route: route, outputType: O.self)
+        registerGetRoute(route: route, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request")
             handler(CodableHelpers.constructOutResultHandler(response: response, completion: next))
@@ -437,7 +437,7 @@ extension Router {
     
     // Get array of (Id, Codable) tuples
     fileprivate func getSafely<Id: Identifier, O: Codable>(_ route: String, handler: @escaping IdentifierCodableArrayClosure<Id, O>) {
-        registerGetRoute(route: route, id: Id.self, outputType: O.self)
+        registerGetRoute(route: route, id: Id.self, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural with identifier) type-safe request")
             handler(CodableHelpers.constructTupleArrayOutResultHandler(response: response, completion: next))
@@ -446,7 +446,7 @@ extension Router {
 
     // Get w/Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self)
+        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: false, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")
@@ -481,7 +481,7 @@ extension Router {
 
     // Get w/Optional Query Parameters
     fileprivate func getSafely<Q: QueryParams, O: Codable>(_ route: String, handler: @escaping (Q?, @escaping CodableArrayResultClosure<O>) -> Void) {
-        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: true, outputType: O.self)
+        registerGetRoute(route: route, queryParams: Q.self, optionalQParam: true, outputType: O.self, outputIsArray: true)
         get(route) { request, response, next in
             Log.verbose("Received GET (plural) type-safe request with Query Parameters")
             Log.verbose("Query Parameters: \(request.queryParameters)")

--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -1102,9 +1102,9 @@ extension Router {
     ///
     /// - Parameter route: The route to register.
     /// - Parameter outputtype: The output object type.
-    public func registerGetRoute<O: Codable>(route: String, outputType: O.Type) {
+    public func registerGetRoute<O: Codable>(route: String, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "\(O.self)"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: "\(O.self)"))
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
         registerRoute(route: route, method: "get", outputType: O.self, responseTypes: responseTypes)
     }
@@ -1114,9 +1114,9 @@ extension Router {
     /// - Parameter route: The route to register.
     /// - Parameter id: The id type.
     /// - Parameter outputtype: The output object type.
-    public func registerGetRoute<Id: Identifier, O: Codable>(route: String, id: Id.Type, outputType: O.Type) {
+    public func registerGetRoute<Id: Identifier, O: Codable>(route: String, id: Id.Type, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "\(O.self)"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: "\(O.self)"))
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
         registerRoute(route: route, method: "get", id: Id.self, outputType: O.self, responseTypes: responseTypes)
     }
@@ -1127,9 +1127,9 @@ extension Router {
     /// - Parameter queryParams: The query parameters.
     /// - Parameter optionalQParam: Flag to indicate that the query params are all optional.
     /// - Parameter outputType: The output object type.
-    public func registerGetRoute<Q: QueryParams, O: Codable>(route: String, queryParams: Q.Type, optionalQParam: Bool, outputType: O.Type) {
+    public func registerGetRoute<Q: QueryParams, O: Codable>(route: String, queryParams: Q.Type, optionalQParam: Bool, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "\(O.self)"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: "\(O.self)"))
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
         registerRoute(route: route, method: "get", queryType: Q.self, allOptQParams: optionalQParam, outputType: O.self, responseTypes: responseTypes)
     }

--- a/Tests/KituraTests/Models/Banana.swift
+++ b/Tests/KituraTests/Models/Banana.swift
@@ -1,0 +1,21 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public struct Banana: Codable {
+    let id: String?
+    let name: String
+    let colour: FruitColour
+}

--- a/Tests/KituraTests/Models/FruitColour.swift
+++ b/Tests/KituraTests/Models/FruitColour.swift
@@ -1,0 +1,30 @@
+/*
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Why doesn't this work?
+//public enum FruitColour: String, Codable {
+//    case yellow, green, red, purple, orange
+//}
+
+public struct FruitColour: Codable {
+    let colour: String
+
+    static let yellow = FruitColour(colour: "yellow")
+    static let green = FruitColour(colour: "green")
+    static let red = FruitColour(colour: "red")
+    static let purple = FruitColour(colour: "purple")
+    static let orange = FruitColour(colour: "orange")
+}

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -112,7 +112,7 @@ func getSingleAppleHandler(id: Int, completion: (Apple?, RequestError?) -> Void)
     completion(nil, nil)
 }
 
-func getSingleArrayAppleHandler(completion: ([(Int, Apple)]?, RequestError?) -> Void) -> Void {
+func getTupleArrayAppleHandler(completion: ([(Int, Apple)]?, RequestError?) -> Void) -> Void {
     completion(nil, nil)
 }
 
@@ -136,28 +136,37 @@ func patchSingleAppleHandler(id: Int, posted: Apple, completion: (Apple?, Reques
     completion(nil, nil)
 }
 
+// A route that has an input type (Banana) that is never used as an output type
+func postBananaHandler(posted: Banana, completion: (Apple?, RequestError?) -> Void) -> Void {
+    completion(nil, nil)
+}
+
 class TestSwaggerGeneration: KituraTest {
 
     static var allTests: [(String, (TestSwaggerGeneration) -> () throws -> Void)] {
         return [
+            ("testSwaggerVersion", testSwaggerVersion),
+            ("testBasePath", testBasePath),
+            ("testSchemes", testSchemes),
+            ("testInfo", testInfo),
             ("testSwaggerDefinitions", testSwaggerDefinitions),
-            ("testSwaggerSections", testSwaggerSections),
             ("testSwaggerContent", testSwaggerContent),
             ("testSwaggerQueryParams", testSwaggerQueryParams),
+            ("testArrayReturnTypes", testArrayReturnTypes),
+            ("testInputTypesModelled", testInputTypesModelled),
+            ("testNestedTypesModelled", testNestedTypesModelled),
         ]
     }
 
-    let httpPort = 8080
     let router = Router()
 
     override func setUp() {
         super.setUp()
-        stopServer() // stop common server so we can run these tests
         router.delete("/me/pear", handler: deleteHandler)
         router.get("/me/pear", handler: getPearHandler)
         router.get("/me/apple", handler: getAppleHandler)
-        router.get("/me/getarray", handler: getArrayAppleHandler)
-        router.get("/me/getarray", handler: getSingleArrayAppleHandler)
+        router.get("/me/getArray", handler: getArrayAppleHandler)
+        router.get("/me/getTupleArray", handler: getTupleArrayAppleHandler)
         router.get("/me/getid", handler: getSingleAppleHandler)
         router.get("/me/getugli1", handler: getQueryUglifruitHandler1)
         router.get("/me/getugli2", handler: getQueryUglifruitHandler2)
@@ -176,50 +185,16 @@ class TestSwaggerGeneration: KituraTest {
 
         router.put("/me/puts", handler: putSingleAppleHandlerStringId)
         router.put("/me/puti", handler: putSingleAppleHandlerIntId)
-    }
 
-    private func setupServerAndExpectations(router: Router, expectStart: Bool, expectStop: Bool, expectFail: Bool, httpPort: Int?=nil) {
-        let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? self.httpPort, with: router)
-
-        if expectStart {
-            let httpStarted = expectation(description: "HTTPServer started()")
-
-            httpServer.started {
-                httpStarted.fulfill()
-            }
-        } else {
-            httpServer.started {
-                XCTFail("httpServer.started should not have been called")
-            }
-        }
-
-        if expectStop {
-            let httpStopped = expectation(description: "HTTPServer stopped()")
-
-            httpServer.stopped {
-                httpStopped.fulfill()
-            }
-        }
-
-        if expectFail {
-            let httpFailed = expectation(description: "HTTPServer failed()")
-
-            httpServer.failed { error in
-                httpFailed.fulfill()
-            }
-        } else {
-            httpServer.failed { error in
-                XCTFail("\(error)")
-            }
-        }
+        router.post("/banana", handler: postBananaHandler)
     }
 
     func pathAssertions(paths: [String: Any]) {
         // test for path existence
         XCTAssertTrue(paths["/me/post"] != nil, "path /me/post is missing")
-        XCTAssertTrue(paths["/me/getarray/{id}"] != nil, "path /me/getarray/{id} is missing")
+        XCTAssertTrue(paths["/me/getTupleArray/{id}"] != nil, "path /me/getTupleArray/{id} is missing")
         XCTAssertTrue(paths["/me/postid/{id}"] != nil, "path /me/postid/{id} is missing")
-        XCTAssertTrue(paths["/me/getarray"] != nil, "path /me/getarray is missing")
+        XCTAssertTrue(paths["/me/getArray"] != nil, "path /me/getArray is missing")
         XCTAssertTrue(paths["/me/apple"] != nil, "path /me/apple is missing")
         XCTAssertTrue(paths["/me/getid/{id}"] != nil, "path /me/getid/{id} is missing")
         XCTAssertTrue(paths["/me/patch/{id}"] != nil, "path /me/patch/{id} is missing")
@@ -337,6 +312,47 @@ class TestSwaggerGeneration: KituraTest {
         }
     }
 
+    // Check that a type that only appears as an input type is defined
+    func bananaDefinitionsAssertions(definitions: [String: Any]) {
+        guard let model = definitions["Banana"] as? [String: Any] else {
+            return XCTFail("Banana model is missing")
+        }
+        if let type = model["type"] as? String {
+            XCTAssertTrue(type == "object", "model Banana: type is incorrect")
+        } else {
+            XCTFail("Model Banana: type is missing")
+        }
+
+        if let required = model["required"] as? [String] {
+            XCTAssertTrue(required.contains("name"), "model Banana: required does not contain 'name'")
+            XCTAssertTrue(required.contains("colour"), "model Banana: required does not contain 'colour'")
+            XCTAssertEqual(required.count, 2, "model Apple: required.count is incorrect")
+        } else {
+            XCTFail("model Banana: required is missing")
+        }
+    }
+
+    // Check that a nested type is correctly referenced and defined in the swagger
+    func nestedModelDefinitionsAssertions(definitions: [String: Any]) {
+        guard let banana = definitions["Banana"] as? [String: Any] else {
+            return XCTFail("Banana model is missing")
+        }
+        if let properties = banana["properties"] as? [String: Any] {
+            if let colour = properties["colour"] as? [String: Any] {
+                if let typeRef = colour["$ref"] as? String {
+                    XCTAssertTrue(typeRef == "#/definitions/FruitColour", "model Banana: property 'colour' has incorrect type reference")
+                } else {
+                    XCTFail("model Banana: property 'colour' has missing type reference")
+                }
+            } else {
+                XCTFail("model Banana: property 'colour' is missing")
+            }
+        }
+        guard let fruitColour = definitions["FruitColour"] as? [String: Any] else {
+            return XCTFail("FruitColour model is missing")
+        }
+    }
+
     func uglifruitDefinitionsAssertions(definitions: [String: Any]) {
         if let model = definitions["Uglifruit"] as? [String: Any] {
             if let type = model["type"] as? String {
@@ -346,51 +362,6 @@ class TestSwaggerGeneration: KituraTest {
             }
 
             XCTAssertTrue(model["required"] == nil, "model uglifruit: required should not be here")
-        }
-    }
-
-    func sectionsAssertions(dict: [String: Any]) {
-        // test for swagger version
-        if let swagger = dict["swagger"] as? String {
-            XCTAssertTrue(swagger == "2.0", "swagger version is incorrect")
-        } else {
-            XCTFail("swagger version is missing")
-        }
-
-        // test for basePath
-        if let basepath = dict["basePath"] as? String {
-            XCTAssertTrue(basepath == "/", "basePath is incorrect")
-        } else {
-            XCTFail("basePath is missing")
-        }
-
-        // test for schemes section
-        if let schemes = dict["schemes"] as? [String] {
-            XCTAssertTrue(schemes.contains("http"), "schemes does not contain http")
-            XCTAssertTrue(schemes.count == 1, "schemes.count is incorrect")
-        } else {
-            XCTFail("schemes is missing")
-        }
-
-        // test for info section
-        if let info = dict["info"] as? [String: String] {
-            if let title = info["title"] {
-                XCTAssertTrue(title == "Kitura Project", "title is incorrect")
-            } else {
-                XCTFail("title is missing")
-            }
-
-            if let desc = info["description"] {
-                XCTAssertTrue(desc == "Generated by Kitura", "description is incorrect")
-            } else {
-                XCTFail("description is missing")
-            }
-
-            if let version = info["version"] {
-                XCTAssertTrue(version == "1.0", "version is incorrect")
-            } else {
-                XCTFail("version is missing")
-            }
         }
     }
 
@@ -905,183 +876,219 @@ class TestSwaggerGeneration: KituraTest {
         }
     }
 
-    func testSwaggerSections() {
-        // test correct values returned from JsonApiDoc property
-        setupServerAndExpectations(router: router, expectStart: true, expectStop: true, expectFail: false)
-
-        let requestQueue = DispatchQueue(label: "Request queue")
-        requestQueue.async() {
-            Kitura.start()
+    //
+    // Helper for converting the router's swaggerJSON string to JSON dictionary
+    //
+    private func getSwaggerDictionary() -> [String: Any]? {
+        guard let jsonString = router.swaggerJSON else {
+            XCTFail("Router.swaggerJSON unexpectedly nil")
+            return nil
         }
+        print(jsonString)
+        guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
+            XCTFail("Unable to convert swaggerJSON to data")
+            return nil
+        }
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            XCTFail("Unable to deserialize swaggerJSON data")
+            return nil
+        }
+        guard let dict = json as? [String: Any] else {
+            XCTFail("Deserialized JSON was not a [String: Any] dictionary")
+            return nil
+        }
+        return dict
+    }
 
-        if let jsonString = router.swaggerJSON {
-            guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let dict = json as? [String: Any] else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-
-            // test for document sections
-            sectionsAssertions(dict: dict)
+    //
+    // Test that our swagger document contains the swagger version.
+    //
+    func testSwaggerVersion() {
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
+        }
+        if let swagger = dict["swagger"] as? String {
+            XCTAssertTrue(swagger == "2.0", "swagger version is incorrect")
         } else {
-            XCTFail("got unexpected nil from router.swaggerJSON")
-        }
-
-        requestQueue.async() {
-            Kitura.stop()
-        }
-
-        waitForExpectations(timeout: 10) { error in
-            XCTAssertNil(error)
+            XCTFail("swagger version is missing")
         }
     }
 
+    //
+    // Test that our swagger document defines the basePath.
+    //
+    func testBasePath() {
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
+        }
+        if let basepath = dict["basePath"] as? String {
+            XCTAssertTrue(basepath == "/", "basePath is incorrect")
+        } else {
+            XCTFail("basePath is missing")
+        }
+    }
+
+    //
+    // Test that our swagger document defines the expected schemes.
+    //
+    func testSchemes() {
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
+        }
+        if let schemes = dict["schemes"] as? [String] {
+            XCTAssertTrue(schemes.contains("http"), "schemes does not contain http")
+            XCTAssertTrue(schemes.count == 1, "schemes.count is incorrect")
+        } else {
+            XCTFail("schemes is missing")
+        }
+    }
+
+    //
+    // Test that our swagger document defines the info section.
+    //
+    func testInfo() {
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
+        }
+        if let info = dict["info"] as? [String: String] {
+            if let title = info["title"] {
+                XCTAssertTrue(title == "Kitura Project", "title is incorrect")
+            } else {
+                XCTFail("title is missing")
+            }
+
+            if let desc = info["description"] {
+                XCTAssertTrue(desc == "Generated by Kitura", "description is incorrect")
+            } else {
+                XCTFail("description is missing")
+            }
+
+            if let version = info["version"] {
+                XCTAssertTrue(version == "1.0", "version is incorrect")
+            } else {
+                XCTFail("version is missing")
+            }
+        }
+    }
+
+    //
+    // Test that our swagger document contains the expected paths
+    // and that the paths' structure is as expected.
+    //
     func testSwaggerContent() {
-        // test correct values returned from JsonApiDoc property
-        setupServerAndExpectations(router: router, expectStart: true, expectStop: true, expectFail: false)
-
-        let requestQueue = DispatchQueue(label: "Request queue")
-        requestQueue.async() {
-            Kitura.start()
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
         }
-
-
-        if let jsonString = router.swaggerJSON {
-            guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let dict = json as? [String: Any] else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            
-            // test for paths section
-            if let paths = dict["paths"] as? [String: Any] {
-                pathAssertions(paths: paths)
-                pathContentAssertions1(paths: paths)
-                pathContentAssertions2(paths: paths)
-                pathContentAssertions3(paths: paths)
-                pathContentAssertions4(paths: paths)
-            } else {
-                XCTFail("paths is missing")
-            }
+        if let paths = dict["paths"] as? [String: Any] {
+            pathAssertions(paths: paths)
+            pathContentAssertions1(paths: paths)
+            pathContentAssertions2(paths: paths)
+            pathContentAssertions3(paths: paths)
+            pathContentAssertions4(paths: paths)
         } else {
-            XCTFail("got unexpected nil from router.swaggerJSON")
-        }
-
-        requestQueue.async() {
-            Kitura.stop()
-        }
-
-        waitForExpectations(timeout: 10) { error in
-            XCTAssertNil(error)
+            XCTFail("paths is missing")
         }
     }
 
+    //
+    // Test that query parameters are correctly represented.
+    //
     func testSwaggerQueryParams() {
-        // test correct values returned from JsonApiDoc property
-        setupServerAndExpectations(router: router, expectStart: true, expectStop: true, expectFail: false)
-
-        let requestQueue = DispatchQueue(label: "Request queue")
-        requestQueue.async() {
-            Kitura.start()
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
         }
-
-        if let jsonString = router.swaggerJSON {
-            guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let dict = json as? [String: Any] else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-
-            // test for paths section
-            if let paths = dict["paths"] as? [String: Any] {
-                pathGetQueryParams1(paths: paths)
-                pathGetQueryParams2(paths: paths)
-                pathGetQueryParams3(paths: paths)
-                pathGetQueryParams4(paths: paths)
-                pathGetQueryParams5(paths: paths)
-                pathOptionalQueryParams(paths: paths)
-                pathDeleteQueryParams(paths: paths)
-            } else {
-                XCTFail("paths is missing")
-            }
+        if let paths = dict["paths"] as? [String: Any] {
+            pathGetQueryParams1(paths: paths)
+            pathGetQueryParams2(paths: paths)
+            pathGetQueryParams3(paths: paths)
+            pathGetQueryParams4(paths: paths)
+            pathGetQueryParams5(paths: paths)
+            pathOptionalQueryParams(paths: paths)
+            pathDeleteQueryParams(paths: paths)
         } else {
-            XCTFail("got unexpected nil from router.swaggerJSON")
-        }
-
-        requestQueue.async() {
-            Kitura.stop()
-        }
-
-        waitForExpectations(timeout: 10) { error in
-            XCTAssertNil(error)
+            XCTFail("paths is missing")
         }
     }
 
+    //
+    // Test that our swagger document contains the expected model definitions.
+    //
     func testSwaggerDefinitions() {
-        // test correct values returned from JsonApiDoc property
-        setupServerAndExpectations(router: router, expectStart: true, expectStop: true, expectFail: false)
-
-        let requestQueue = DispatchQueue(label: "Request queue")
-        requestQueue.async() {
-            Kitura.start()
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
         }
-
-        if let jsonString = router.swaggerJSON {
-            guard let data = jsonString.data(using: String.Encoding.utf8, allowLossyConversion: false) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-            guard let dict = json as? [String: Any] else {
-                XCTFail("got unexpected nil from router.swaggerJSON")
-                return
-            }
-
-            // test for document sections
-            sectionsAssertions(dict: dict)
-
-            // test for definitions section
-            if let definitions = dict["definitions"] as? [String: Any] {
-                appleDefinitionsAssertions(definitions: definitions)
-                pearDefinitionsAssertions(definitions: definitions)
-                uglifruitDefinitionsAssertions(definitions: definitions)
-            } else {
-                XCTFail("definitions section is missing")
-            }
+        if let definitions = dict["definitions"] as? [String: Any] {
+            appleDefinitionsAssertions(definitions: definitions)
+            pearDefinitionsAssertions(definitions: definitions)
+            uglifruitDefinitionsAssertions(definitions: definitions)
         } else {
-            XCTFail("got unexpected nil from router.swaggerJSON")
-        }
-
-        requestQueue.async() {
-            Kitura.stop()
-        }
-
-        waitForExpectations(timeout: 10) { error in
-            XCTAssertNil(error)
+            XCTFail("definitions section is missing")
         }
     }
+
+    //
+    // Test that array return types are correctly represented.
+    //
+    func testArrayReturnTypes() {
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
+        }
+        guard let paths = dict["paths"] as? [String: Any] else {
+            return XCTFail("Paths section is missing")
+        }
+        let tupleArrayPath = "/me/getTupleArray/{id}"
+        guard let path = paths[tupleArrayPath] as? [String: Any] else {
+            return XCTFail("Path \(tupleArrayPath) is missing")
+        }
+        guard let get = path["get"] as? [String: Any] else {
+            return XCTFail("Path \(tupleArrayPath): GET method missing")
+        }
+        guard let responses = get["responses"] as? [String: Any] else {
+            return XCTFail("Path \(tupleArrayPath): GET responses missing")
+        }
+        guard let okResponse = responses["200"] as? [String: Any] else {
+            return XCTFail("Path \(tupleArrayPath): GET response 200 missing")
+        }
+        guard let okSchema = okResponse["schema"] as? [String: Any] else {
+            return XCTFail("Path \(tupleArrayPath): GET schema missing")
+        }
+        guard let okReturnType = okSchema["type"] as? String else {
+            return XCTFail("Path \(tupleArrayPath): GET schema type missing")
+        }
+        XCTAssertEqual(okReturnType, "array", "Return type for GET on path \(tupleArrayPath) should be 'array', but was \(okReturnType)")
+        guard let returnItems = okSchema["items"] as? [String: Any] else {
+            return XCTFail("Path \(tupleArrayPath): GET schema items missing")
+        }
+        // TODO: Check content of items
+    }
+
+    //
+    // Test that input types that do not also appear as output types are
+    // correctly modelled.
+    //
+    func testInputTypesModelled() {
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
+        }
+        guard let definitions = dict["definitions"] as? [String: Any] else {
+            return XCTFail("Definitions section is missing")
+        }
+        bananaDefinitionsAssertions(definitions: definitions)
+    }
+
+    //
+    // Test that types that do not appear directly as top-level input or output parameters,
+    // but are referenced by such top-level types, are modelled in the swagger.
+    //
+    func testNestedTypesModelled() {
+        guard let dict = getSwaggerDictionary() else {
+            return XCTFail("Unable to get swagger dictionary")
+        }
+        guard let definitions = dict["definitions"] as? [String: Any] else {
+            return XCTFail("Definitions section is missing")
+        }
+        nestedModelDefinitionsAssertions(definitions: definitions)
+    }
+
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The swagger document generated by `SwaggerGenerator` does not currently represent array return types (such as those from a GET), although the plumbing is in place for it to do this.

This PR resolves this by adding an `outputIsArray: Bool = false` parameter to `registerGetRoute` and setting this to `true` from each route that has an array-type result handler.

I added tests:
- A test that array return types are declared as `"type": "array"`,
- A test that types that are only used as input types are modelled (covering the fix in #1331),
- A test that nested types (that are referenced by input or output types, but are not top-level types) are modelled.

Also, in the process of adding tests I found some redundant code for starting/stopping an instance of Kitura which is not necessary for testing the SwaggerGenerator (yet - it may become necessary once the swagger represents ports / protocols accurately).  I propose this is re-added when it becomes relevant.

Finally, I refactored some the monolithic 'testSections' into smaller tests, and pulled some common bootstrapping code out into a helper function.

Update: while creating the tests, I discovered that we do not handle the returning of Identifier types correctly (see https://github.com/IBM-Swift/Kitura/issues/1336).  I've added comments to the relevant routes but this is out of scope for this PR.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
