### PR TITLE
Support Swift 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-19-a
+      env: SWIFT_SNAPSHOT=4.2
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-19-a KITURA_NIO=1
+      env: SWIFT_SNAPSHOT=4.2 KITURA_NIO=1
     - os: osx
       osx_image: xcode9.2
       sudo: required

--- a/Sources/Kitura/DecodingError+Extensions.swift
+++ b/Sources/Kitura/DecodingError+Extensions.swift
@@ -38,7 +38,7 @@ extension DecodingError {
             return "The required key '\(prefixString)\(type.stringValue)' not found."
         case .dataCorrupted(let context):
             // Linux does not get to this state but sends an Error "The operation could not be completed" instead. Future proofing this though just in case.
-            #if !os(Linux) || swift(>=4.1.50)
+            #if !os(Linux) || compiler(>=4.2)
             if let nsError = context.underlyingError as NSError?, let detailedError = nsError.userInfo["NSDebugDescription"] as? String {
                 return "The JSON appears to be malformed. \(detailedError)"
             }

--- a/Sources/Kitura/DecodingError+Extensions.swift
+++ b/Sources/Kitura/DecodingError+Extensions.swift
@@ -38,7 +38,7 @@ extension DecodingError {
             return "The required key '\(prefixString)\(type.stringValue)' not found."
         case .dataCorrupted(let context):
             // Linux does not get to this state but sends an Error "The operation could not be completed" instead. Future proofing this though just in case.
-            #if !os(Linux) || compiler(>=4.2)
+            #if !os(Linux) || swift(>=4.1.50)
             if let nsError = context.underlyingError as NSError?, let detailedError = nsError.userInfo["NSDebugDescription"] as? String {
                 return "The JSON appears to be malformed. \(detailedError)"
             }

--- a/Sources/Kitura/DecodingError+Extensions.swift
+++ b/Sources/Kitura/DecodingError+Extensions.swift
@@ -38,13 +38,13 @@ extension DecodingError {
             return "The required key '\(prefixString)\(type.stringValue)' not found."
         case .dataCorrupted(let context):
             // Linux does not get to this state but sends an Error "The operation could not be completed" instead. Future proofing this though just in case.
-            #if os(Linux)
-            // Linux wants a force downcast, MacOS doesn't.
-            if let nsError = context.underlyingError as? NSError, let detailedError = nsError.userInfo["NSDebugDescription"] as? String {
+            #if !os(Linux) || swift(>=4.2)
+            if let nsError = context.underlyingError as NSError?, let detailedError = nsError.userInfo["NSDebugDescription"] as? String {
                 return "The JSON appears to be malformed. \(detailedError)"
             }
             #else
-            if let nsError = context.underlyingError as NSError?, let detailedError = nsError.userInfo["NSDebugDescription"] as? String {
+            // Linux (prior to 4.2) needs a conditional downcast
+            if let nsError = context.underlyingError as? NSError, let detailedError = nsError.userInfo["NSDebugDescription"] as? String {
                 return "The JSON appears to be malformed. \(detailedError)"
             }
             #endif

--- a/Sources/Kitura/DecodingError+Extensions.swift
+++ b/Sources/Kitura/DecodingError+Extensions.swift
@@ -38,7 +38,7 @@ extension DecodingError {
             return "The required key '\(prefixString)\(type.stringValue)' not found."
         case .dataCorrupted(let context):
             // Linux does not get to this state but sends an Error "The operation could not be completed" instead. Future proofing this though just in case.
-            #if !os(Linux) || swift(>=4.2)
+            #if !os(Linux) || swift(>=4.1.50)
             if let nsError = context.underlyingError as NSError?, let detailedError = nsError.userInfo["NSDebugDescription"] as? String {
                 return "The JSON appears to be malformed. \(detailedError)"
             }


### PR DESCRIPTION
Switches to the swift-4.2-RELEASE build (on Linux; macOS is already there as Travis has released an xcode10 GM image with the same name - `xcode10` - as the previous betas).

Also resolves a compilation warning since conditional cast of NSError to Error is no longer required on Linux.