### PR TITLE
Don't enable FileResourceServer if handlers exist on the router.

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -47,7 +47,7 @@ public class Router {
     fileprivate let kituraResourcePrefix = "/@@Kitura-router@@/"
 
     /// Helper for serving file resources
-    fileprivate let fileResourceServer = FileResourceServer()
+    fileprivate lazy var fileResourceServer = FileResourceServer()
 
     /// Flag to enable/disable access to parent router's params
     private let mergeParameters: Bool
@@ -603,7 +603,7 @@ extension Router : ServerDelegate {
             return
         }
 
-        if  urlPath.hasPrefix(kituraResourcePrefix) {
+        if  elements.isEmpty && urlPath.hasPrefix(kituraResourcePrefix) {
             let resource = String(urlPath[kituraResourcePrefix.endIndex...])
             fileResourceServer.sendIfFound(resource: resource, usingResponse: response)
         } else {
@@ -625,7 +625,7 @@ extension Router : ServerDelegate {
     /// - Parameter response: The `RouterResponse` object used to respond to the
     ///                     HTTP request.
     private func sendDefaultResponse(request: RouterRequest, response: RouterResponse) {
-        if request.parsedURLPath.path == "/" {
+        if elements.isEmpty && request.parsedURLPath.path == "/" {
             fileResourceServer.sendIfFound(resource: "index.html", usingResponse: response)
         } else {
             do {

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -39,6 +39,7 @@ class TestStaticFileServer: KituraTest {
             ("testGetMissingKituraResource", testGetMissingKituraResource),
             ("testGetTraversedFileKituraResource", testGetTraversedFileKituraResource),
             ("testGetTraversedFile", testGetTraversedFile),
+            ("testNoResourceWhenHandlerPresent", testNoResourceWhenHandlerPresent),
             ("testAbsolutePathFunction", testAbsolutePathFunction),
             ("testAbsoluteRootPath", testAbsoluteRootPath),
             ("testRangeRequests", testRangeRequests),
@@ -192,8 +193,9 @@ class TestStaticFileServer: KituraTest {
     private typealias BodyChecker =  (String) -> Void
     private func runGetResponseTest(path: String, expectedResponseText: String? = nil,
                                     expectedStatusCode: HTTPStatusCode = HTTPStatusCode.OK,
-                                    bodyChecker: BodyChecker? = nil) {
-        performServerTest(router) { expectation in
+                                    bodyChecker: BodyChecker? = nil,
+                                    useBlankRouter: Bool = false) {
+        performServerTest(useBlankRouter ? Router() : router) { expectation in
             self.performRequest("get", path: path, callback: { response in
                 guard let response = response else {
                     XCTFail("ClientRequest response object was nil")
@@ -228,23 +230,27 @@ class TestStaticFileServer: KituraTest {
     }
 
     func testGetKituraResource() {
-        runGetResponseTest(path: "/@@Kitura-router@@/")
+        runGetResponseTest(path: "/@@Kitura-router@@/", useBlankRouter: true)
     }
 
     func testGetDefaultResponse() {
-        runGetResponseTest(path: "/", expectedStatusCode: HTTPStatusCode.OK)
+        runGetResponseTest(path: "/", expectedStatusCode: HTTPStatusCode.OK, useBlankRouter: true)
     }
 
     func testGetMissingKituraResource() {
-        runGetResponseTest(path: "/@@Kitura-router@@/missing.file", expectedStatusCode: HTTPStatusCode.notFound)
+        runGetResponseTest(path: "/@@Kitura-router@@/missing.file", expectedStatusCode: HTTPStatusCode.notFound, useBlankRouter: true)
     }
 
     func testGetTraversedFileKituraResource() {
-        runGetResponseTest(path: "/@@Kitura-router@@/../../../Tests/KituraTests/TestStaticFileServer.swift", expectedStatusCode: HTTPStatusCode.notFound)
+        runGetResponseTest(path: "/@@Kitura-router@@/../../../Tests/KituraTests/TestStaticFileServer.swift", expectedStatusCode: HTTPStatusCode.notFound, useBlankRouter: true)
     }
 
     func testGetTraversedFile() {
-        runGetResponseTest(path: "../Tests/KituraTests/TestStaticFileServer.swift", expectedStatusCode: HTTPStatusCode.notFound)
+        runGetResponseTest(path: "../Tests/KituraTests/TestStaticFileServer.swift", expectedStatusCode: HTTPStatusCode.notFound, useBlankRouter: true)
+    }
+
+    func testNoResourceWhenHandlerPresent() {
+        runGetResponseTest(path: "/@@Kitura-router@@/", expectedStatusCode: HTTPStatusCode.notFound)
     }
 
     func testAbsolutePathFunction() {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

> nocturnal [7:02 PM]
> I’m just now noticing FileResourceServer. It’s… interesting.
> 
> nocturnal [7:05 PM]
> So every Kitura project has a built-in static file server, and you can’t disable it. Nor can you can’t change the path prefix that triggers it, or the directory of files it serves, so it can’t be leveraged to do something useful.
> 
> ianpartridge [4 days ago]
> Yes, this is what serves up the default splash page. I agree it should be possible to disable this.

Accordingly, these changes implicitly disable FileResourceServer if the Router instance has any elements; e.g., if `.get()` or any of its friends have been used to attach a handler to a route.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Probably the biggest reason is that it's unexpected behavior for Kitura to be able to serve files when it hasn't explicitly been instructed to do so. (This is largely why I engineered this to automatically disable the FileResourceServer functionality if any handlers exist rather than adding a resourceServerEnabled property or something like that that would require users to change their code to get behavior that they're probably already expecting.)
- Not initializing FileResourceServer when not needed is theoretically a performance and memory usage improvement, though the former may be offset by new checks to see if there are no elements on the router.
- Not being able to disable FileResourceServer is arguably a security risk, though fortunately the code seems to be smart enough to not let you back out of the base resource directory on the file system.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
One new test case has been added to ensure that resources are no longer served when the router has elements/handlers. Existing test cases which were testing FileResourceServer were modified to do so with an "empty" Router instance.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

## Other Notes:
- To avoid duplication of code and code purpose, it may be desirable for the FileResourceServer to be replaced with a StaticFileServer, though this PR makes no attempt to go down that road yet.
- I can't believe I've been working with Kitura for like a year now and just noticed this a couple days ago. I'm such a n00b.