### PR TITLE
FileResourceServer must be explicitly enabled when initializing Router

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -95,7 +95,7 @@ public class Router {
     public init(mergeParameters: Bool = false, enableWelcomePage: Bool = true) {
         self.swagger = SwaggerDocument()
         self.mergeParameters = mergeParameters
-        fileResourceServer = enableWelcomePage ? FileResourceServer() : nil
+        self.fileResourceServer = enableWelcomePage ? FileResourceServer() : nil
 
         Log.verbose("Router initialized")
     }
@@ -608,7 +608,7 @@ extension Router : ServerDelegate {
             return
         }
 
-        if  urlPath.hasPrefix(kituraResourcePrefix), let fileResourceServer = fileResourceServer {
+        if  let fileResourceServer = fileResourceServer, urlPath.hasPrefix(kituraResourcePrefix) {
             let resource = String(urlPath[kituraResourcePrefix.endIndex...])
             fileResourceServer.sendIfFound(resource: resource, usingResponse: response)
         } else {
@@ -630,7 +630,7 @@ extension Router : ServerDelegate {
     /// - Parameter response: The `RouterResponse` object used to respond to the
     ///                     HTTP request.
     private func sendDefaultResponse(request: RouterRequest, response: RouterResponse) {
-        if request.parsedURLPath.path == "/", let fileResourceServer = fileResourceServer {
+        if let fileResourceServer = fileResourceServer, request.parsedURLPath.path == "/" {
             fileResourceServer.sendIfFound(resource: "index.html", usingResponse: response)
         } else {
             do {

--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -88,14 +88,14 @@ public class Router {
     /// ```
     /// - Parameter mergeParameters: Optional parameter to specify if the router should be able to access parameters
     ///                                 from its parent router. Defaults to `false` if not specified.
-    /// - Parameter useResourceServer: Optional parameter to start and use the
+    /// - Parameter enableWelcomePage: Optional parameter to start and use the
     ///                                FileResourceServer to serve the default
     ///                                "Welcome to Kitura" page and related
     ///                                assets.
-    public init(mergeParameters: Bool = false, useResourceServer: Bool = false) {
+    public init(mergeParameters: Bool = false, enableWelcomePage: Bool = true) {
         self.swagger = SwaggerDocument()
         self.mergeParameters = mergeParameters
-        fileResourceServer = useResourceServer ? FileResourceServer() : nil
+        fileResourceServer = enableWelcomePage ? FileResourceServer() : nil
 
         Log.verbose("Router initialized")
     }

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -34,7 +34,7 @@ class TestStaticFileServer: KituraTest {
             ("testGetWithWhiteSpaces", testGetWithWhiteSpaces),
             ("testGetWithSpecialCharacters", testGetWithSpecialCharacters),
             ("testGetWithSpecialCharactersEncoded", testGetWithSpecialCharactersEncoded),
-            ("testNoResourcesByDefault", testNoResourcesByDefault),
+            ("testWelcomePageCanBeDisabled", testWelcomePageCanBeDisabled),
             ("testGetKituraResource", testGetKituraResource),
             ("testGetDefaultResponse", testGetDefaultResponse),
             ("testGetMissingKituraResource", testGetMissingKituraResource),
@@ -58,7 +58,7 @@ class TestStaticFileServer: KituraTest {
     }
 
     let router = TestStaticFileServer.setupRouter()
-    let routerWithResources = TestStaticFileServer.setupRouter(useResourceServer: true)
+    let routerWithoutWelcome = TestStaticFileServer.setupRouter(enableWelcomePage: false)
 
     func testFileServer() {
         performServerTest(router, asyncTasks: { expectation in
@@ -161,8 +161,8 @@ class TestStaticFileServer: KituraTest {
         })
     }
 
-    static func setupRouter(useResourceServer: Bool = false) -> Router {
-        let router = Router(useResourceServer: useResourceServer)
+    static func setupRouter(enableWelcomePage: Bool = true) -> Router {
+        let router = Router(enableWelcomePage: enableWelcomePage)
 
         // The route below ensures that the static file server does not prevent all routes being walked
         router.all("/", middleware: StaticFileServer())
@@ -230,16 +230,16 @@ class TestStaticFileServer: KituraTest {
         runGetResponseTest(path: "/qwer/index%2B%40%2C.html", expectedResponseText: "<!DOCTYPE html><html><body><b>Index with plus at comma</b></body></html>\n")
     }
 
-    func testNoResourcesByDefault() {
-        runGetResponseTest(path: "/", expectedStatusCode: HTTPStatusCode.notFound)
+    func testWelcomePageCanBeDisabled() {
+        runGetResponseTest(path: "/", expectedStatusCode: HTTPStatusCode.notFound, withRouter: routerWithoutWelcome)
     }
 
     func testGetKituraResource() {
-        runGetResponseTest(path: "/@@Kitura-router@@/", withRouter: routerWithResources)
+        runGetResponseTest(path: "/@@Kitura-router@@/")
     }
 
     func testGetDefaultResponse() {
-        runGetResponseTest(path: "/", withRouter: routerWithResources)
+        runGetResponseTest(path: "/")
     }
 
     func testGetMissingKituraResource() {

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -163,6 +163,7 @@ class TestStaticFileServer: KituraTest {
 
     static func setupRouter(useResourceServer: Bool = false) -> Router {
         let router = Router(useResourceServer: useResourceServer)
+
         // The route below ensures that the static file server does not prevent all routes being walked
         router.all("/", middleware: StaticFileServer())
 
@@ -191,7 +192,7 @@ class TestStaticFileServer: KituraTest {
     }
 
     private typealias BodyChecker =  (String) -> Void
-private func runGetResponseTest(path: String, expectedResponseText: String? = nil,
+    private func runGetResponseTest(path: String, expectedResponseText: String? = nil,
                                     expectedStatusCode: HTTPStatusCode = HTTPStatusCode.OK,
                                     bodyChecker: BodyChecker? = nil,
                                     withRouter: Router? = nil) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a redo of #1343 based on feedback in that thread. Whereas the code in that PR implicitly disabled the FileResourceServer for a Router if that Router had any elements/handlers, this PR changes Router to add a new optional `withResourceServer` parameter to its initializer which only starts the FileResourceServer if explicitly set to `true`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@djones6 recommended this approach rather than the one I had chosen in the original PR, and I like his idea better than mine too.  As stated there, this may break expected functionality with the Kitura CLI tool.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As with the other PR, existing tests testing the FileResourceServer functionality have been tweaked, and a new test has been added to ensure the functionality is not present by default.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
