### PR TITLE
Document standard Kitura responses in generated swagger

### DIFF
--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -36,10 +36,17 @@ enum SwaggerGenerationError: Swift.Error {
 
 // Container for Swagger response type.
 struct SwaggerResponseType {
+    // Indicates whether the response payload is optional
     var optional: Bool
+    // Indicates whether the response should be declared as an array type
     var array: Bool
-    var type: String
+    // The Swift type corresponding to the response type, or `nil` if there is no response payload
+    var type: Decodable.Type?
+    // The HTTP status code to associate with this response, or `nil` to define the 'default' response
+    var statusCode: HTTPStatusCode?
 }
+
+typealias SwaggerRequestError = String
 
 // Container for Swagger document information.
 struct SwaggerInfo: Encodable {
@@ -435,7 +442,10 @@ struct SwaggerDocument: Encodable {
     // - Parameter responseType: Either an array or a single response.
     // - Returns: SwaggerResponse.
     func buildResponse(description: String, responseType: SwaggerResponseType) -> SwaggerResponse {
-        let reference = SingleReference(ref: "#/definitions/\(responseType.type)")
+        guard let type = responseType.type else {
+            return SwaggerResponse(description: description, schema: nil)
+        }
+        let reference = SingleReference(ref: "#/definitions/\(type)")
         if responseType.array {
             return SwaggerResponse(description: description, schema: .array(ArrayReference(items: reference)))
         }
@@ -633,6 +643,23 @@ struct SwaggerDocument: Encodable {
         }
     }
 
+    /// Generates a standard description based on an HTTPStatusCode,
+    /// or nil which indicates that the response is user-defined (in
+    /// lieu of a capability of users describing their own responses)
+    static func responseDescription(for status: HTTPStatusCode?) -> String {
+        guard let status = status else {
+            return "A user-defined response."
+        }
+        switch status {
+        case .badRequest: return "An error occurred while decoding an input type."
+        case .created: return "The resource was successfully created."
+        case .unsupportedMediaType: return "The incoming content type cannot be handled."
+        case .unprocessableEntity: return "The incoming payload could not be decoded."
+        case .internalServerError: return "An unexpected error, such as a misconfiguration of the server."
+        default: return "A successful response."
+        }
+    }
+
     /// add a path into the OpenAPI (swagger) document
     ///
     /// - Parameter path: The API path to register.
@@ -657,12 +684,15 @@ struct SwaggerDocument: Encodable {
             }
             var responses = SwaggerResponses()
             if let responseTypes = responseList {
-                if method == "delete" {
-                    // special case for delete methods as they don't return codable objects, so a simple successful
-                    // response statement is sufficient.
-                    responses["200"] = SwaggerResponse(description: "successful response", schema: nil)
-                } else {
-                    responses["200"] = buildResponse(description: "successful response", responseType: responseTypes[0])
+                for responseType in responseTypes {
+                    // Response is keyed by String, as it may be non-numeric (eg: 'default')
+                    let responseCode: String
+                    if let statusCode = responseType.statusCode {
+                        responseCode = String(statusCode.rawValue)
+                    } else {
+                        responseCode = "default"
+                    }
+                    responses[responseCode] = buildResponse(description: SwaggerDocument.responseDescription(for: responseType.statusCode), responseType: responseType)
                 }
 
                 // handle the input parameter here: turn it into a parameters object.
@@ -1157,8 +1187,8 @@ extension Router {
     /// - Parameter outputtype: The output object type.
     public func registerGetRoute<O: Codable>(route: String, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: "\(O.self)"))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: O.self, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerRoute(route: route, method: "get", outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1169,8 +1199,8 @@ extension Router {
     /// - Parameter outputtype: The output object type.
     public func registerGetRoute<Id: Identifier, O: Codable>(route: String, id: Id.Type, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: "\(O.self)"))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: O.self, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerRoute(route: route, method: "get", id: Id.self, outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1182,8 +1212,9 @@ extension Router {
     /// - Parameter outputType: The output object type.
     public func registerGetRoute<Q: QueryParams, O: Codable>(route: String, queryParams: Q.Type, optionalQParam: Bool, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: "\(O.self)"))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: O.self, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .badRequest))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerRoute(route: route, method: "get", queryType: Q.self, allOptQParams: optionalQParam, outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1192,8 +1223,8 @@ extension Router {
     /// - Parameter route: The route to register.
     public func registerDeleteRoute(route: String) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: ""))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerDelete(route: route, responseTypes: responseTypes)
     }
 
@@ -1204,8 +1235,9 @@ extension Router {
     /// - Parameter optionalQParam: Flag to indicate that the query params are all optional.
     public func registerDeleteRoute<Q: QueryParams>(route: String, queryParams: Q.Type, optionalQParam: Bool) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: ""))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .badRequest))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerDelete(route: route, queryType: Q.self, allOptQParams: optionalQParam, responseTypes: responseTypes)
     }
 
@@ -1215,8 +1247,8 @@ extension Router {
     /// - Parameter id: The id type.
     public func registerDeleteRoute<Id: Identifier>(route: String, id: Id.Type ) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: ""))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerDelete(route: route, id: Id.self, responseTypes: responseTypes)
     }
 
@@ -1227,8 +1259,10 @@ extension Router {
     /// - Parameter outputType: The output object type.
     public func registerPostRoute<I: Codable, O: Codable>(route: String, inputType: I.Type, outputType: O.Type) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "\(O.self)"))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: O.self, statusCode: .created))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unsupportedMediaType))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .internalServerError))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unprocessableEntity))
         registerRoute(route: route, method: "post", inputType: I.self, outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1240,8 +1274,10 @@ extension Router {
     /// - Parameter outputType: The output object type.
     public func registerPostRoute<I: Codable, Id: Identifier, O: Codable>(route: String, id: Id.Type, inputType: I.Type, outputType: O.Type) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "\(O.self)"))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: O.self, statusCode: .created))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unsupportedMediaType))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .internalServerError))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unprocessableEntity))
         registerRoute(route: route, method: "post", id: Id.self, inputType: I.self, outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1253,8 +1289,13 @@ extension Router {
     /// - Parameter outputType: The output object type.
     public func registerPutRoute<Id: Identifier, I: Codable, O: Codable>(route: String, id: Id.Type, inputType: I.Type, outputType: O.Type) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "\(O.self)"))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: O.self, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unsupportedMediaType))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .internalServerError))
+        // There are two cases where an unprocessableEntity can be returned:
+        // 1. If we cannot decode the input type from the request,
+        // 2. If we cannot decode the Identifier value supplied (for example, a missing or non-numeric value is supplied for a numeric Identifier)
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unprocessableEntity))
         registerRoute(route: route, method: "put", id: Id.self, inputType: I.self, outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1266,8 +1307,13 @@ extension Router {
     /// - Parameter outputType: The output object type.
     public func registerPatchRoute<Id: Identifier, I: Codable, O: Codable>(route: String, id: Id.Type, inputType: I.Type, outputType: O.Type) {
         var responseTypes = [SwaggerResponseType]()
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "\(O.self)"))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: "RequestError"))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: O.self, statusCode: .OK))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unsupportedMediaType))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .internalServerError))
+        // There are two cases where an unprocessableEntity can be returned:
+        // 1. If we cannot decode the input type from the request,
+        // 2. If we cannot decode the Identifier value supplied (for example, a missing or non-numeric value is supplied for a numeric Identifier)
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .unprocessableEntity))
         registerRoute(route: route, method: "patch", id: Id.self, inputType: I.self, outputType: O.self, responseTypes: responseTypes)
     }
 }

--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -46,8 +46,6 @@ struct SwaggerResponseType {
     var statusCode: HTTPStatusCode?
 }
 
-typealias SwaggerRequestError = String
-
 // Container for Swagger document information.
 struct SwaggerInfo: Encodable {
     var version: String
@@ -1188,7 +1186,6 @@ extension Router {
     public func registerGetRoute<O: Codable>(route: String, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
         responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: O.self, statusCode: .OK))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerRoute(route: route, method: "get", outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1200,7 +1197,6 @@ extension Router {
     public func registerGetRoute<Id: Identifier, O: Codable>(route: String, id: Id.Type, outputType: O.Type, outputIsArray: Bool = false) {
         var responseTypes = [SwaggerResponseType]()
         responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: O.self, statusCode: .OK))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerRoute(route: route, method: "get", id: Id.self, outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1214,7 +1210,6 @@ extension Router {
         var responseTypes = [SwaggerResponseType]()
         responseTypes.append(SwaggerResponseType(optional: true, array: outputIsArray, type: O.self, statusCode: .OK))
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .badRequest))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerRoute(route: route, method: "get", queryType: Q.self, allOptQParams: optionalQParam, outputType: O.self, responseTypes: responseTypes)
     }
 
@@ -1224,7 +1219,6 @@ extension Router {
     public func registerDeleteRoute(route: String) {
         var responseTypes = [SwaggerResponseType]()
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .OK))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerDelete(route: route, responseTypes: responseTypes)
     }
 
@@ -1237,7 +1231,6 @@ extension Router {
         var responseTypes = [SwaggerResponseType]()
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .OK))
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .badRequest))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerDelete(route: route, queryType: Q.self, allOptQParams: optionalQParam, responseTypes: responseTypes)
     }
 
@@ -1248,7 +1241,6 @@ extension Router {
     public func registerDeleteRoute<Id: Identifier>(route: String, id: Id.Type ) {
         var responseTypes = [SwaggerResponseType]()
         responseTypes.append(SwaggerResponseType(optional: true, array: false, type: nil, statusCode: .OK))
-        responseTypes.append(SwaggerResponseType(optional: true, array: false, type: SwaggerRequestError.self, statusCode: nil))
         registerDelete(route: route, id: Id.self, responseTypes: responseTypes)
     }
 

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -465,7 +465,7 @@ class TestSwaggerGeneration: KituraTest {
                 if let responses = put["responses"] as? [String: Any] {
                     if let twohundred = responses["200"] as? [String: Any] {
                         if let description = twohundred["description"] as? String {
-                            XCTAssertTrue(description == "successful response", "path /me/puts/{id}: put responses 200 description is incorrect")
+                            XCTAssertTrue(description == SwaggerDocument.responseDescription(for: HTTPStatusCode(rawValue: 200)), "path /me/puts/{id}: put responses 200 description is incorrect")
                         } else {
                             XCTFail("path /me/puts/{id}: put 200 response does not contain a description")
                         }
@@ -481,7 +481,11 @@ class TestSwaggerGeneration: KituraTest {
                     } else {
                         XCTFail("path /me/puts/{id}: put 200 response is missing")
                     }
-                    XCTAssertTrue(responses.count == 1, "path /me/puts/{id}: put responses.count is incorrect")
+                    // There should be _at least_ two responses:
+                    // A successful (OK) response and an error
+                    // (unprocessableEntity). Other errors may
+                    // also be enumerated.
+                    XCTAssertGreaterThan(responses.count, 1, "path /me/puts/{id}: put responses.count is incorrect")
                 } else {
                     XCTFail("path /me/puts/{id}: put responses is missing")
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves Kitura's generated OpenAPI document with a more accurate status code for responses based on the method:
- GET, PUT, PATCH and DELETE respond with `200: OK`,
- POST responds with `201: Created`,
- POST and PUT can respond with `415: Unsupported Media Type` or `422: Unprocessable Entity` if the content-type / payload are not acceptable or decodable,
- Routes that consume query params can respond with `400: Bad Request` if the query params cannot be decoded,
- Routes that consume body data (PUT and POST) can respond with `500: Internal Server Error` if BodyParser was erroneously used to consume the body data.

I added default descriptions for each of these response types and associated them with their respective routes,  and removed the (unused) attempt at representing a RequestError (which did not make sense).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kitura currently cannot programatically generate an accurate description of each possible response from a route handler, as there is no way to determine this at handler registration time. 

SwaggerGenerator currently generates a generic "200" response for every registered route with the description "successful response", but we can do better than this by at least documenting the default status code(s) we may return.

There are other desirable improvements in this area that this PR does **not** address:
- overriding the default status code via the RequestError type in success (2xx) cases: we need to think about how Kitura's API would the user communicate this information,
- customizing the response description(s),
- specifying additional unsuccessful response codes and their associated payload.

The existing code had the beginnings of a response type for the RequestError, however the code currently only produces a response entry for the _first_ SwaggerResponse registered.  Also, there are failings with the current implementation of RequestError that makes it incompatible with OpenAPI:

1. There's no way to determine the status code that should be associated with the RequestError ,
2. The RequestError type does not have a strongly defined on-the-wire representation (body). We allow arbitrary JSON to be sent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I updated existing tests accordingly.
I have tested with a sample project and validated the generated document using Swagger UI.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
