### PR TITLE
Feat: Make request/response decoder/encoder public

### DIFF
--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -42,11 +42,11 @@ public class RouterRequest {
 
     /// The server request.
     let serverRequest: ServerRequest
-    
-    /// The Data decoder generator for the request content-type
-    let decoder: BodyDecoder?
 
     // MARK: Properties
+    
+    /// The BodyDecoder that will be used to decode Data into a Codable type.
+    public var decoder: BodyDecoder?
     
     /// The hostname of the request.
     public var hostname: String {

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -103,9 +103,13 @@ public class RouterResponse {
 
     private var lifecycle = Lifecycle()
 
-    private let encoders: [MediaType: () -> BodyEncoder]
+    /// A dictionary of MediaType to BodyEncoder.
+    /// When encoding a Codable type to data the BodyEncoder will be selected from this dictionary using the Accept header.
+    public var encoders: [MediaType: () -> BodyEncoder]
     
-    private let defaultResponseMediaType: MediaType
+    /// The MediaType that will be used to select a BodyEncoder
+    /// if there isn't as encoder for the Accept header/no Accept header is provided.
+    public var defaultResponseMediaType: MediaType
     
     // regex used to sanitize javascript identifiers
     fileprivate static let sanitizeJSIdentifierRegex: NSRegularExpression! = {


### PR DESCRIPTION
## Description
This pull request makes the encoders and decoder on the request/response public. This allows the user to set the encoder/decoder for a specific request/response either inside the route for Raw routing or using a Middleware with Codable routing.

## Motivation and Context
This change was requested so that you could create a JWT decoder that selects the public key for decryption based on a header in the request.

## How Has This Been Tested?
A test has been added that sets a custom encoder/decoder inside a Raw route to change the Date decoding strategy. 

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
