### PR TITLE
[Fix] StaticFileServer request path extraction

### DIFF
--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -141,7 +141,7 @@ open class StaticFileServer: RouterMiddleware {
             return
         }
 
-        guard let requestPath = request.parsedURLPath.path else {
+        guard let requestPath = request.parsedURL.path else {
             return
         }
 

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -42,6 +42,12 @@ class TestStaticFileServer: KituraTest {
             ("testGetTraversedFile", testGetTraversedFile),
             ("testAbsolutePathFunction", testAbsolutePathFunction),
             ("testAbsoluteRootPath", testAbsoluteRootPath),
+            ("testSubRouterStaticFileServer", testSubRouterStaticFileServer),
+            ("testSubRouterSubFolderStaticFileServer", testSubRouterSubFolderStaticFileServer),
+            ("testSubRouterStaticFileServerRedirect", testSubRouterStaticFileServerRedirect),
+            ("testSubRouterSubFolderStaticFileServerRedirect", testSubRouterSubFolderStaticFileServerRedirect),
+            ("testParameterizedSubRouterSubFolderStaticFileServer", testParameterizedSubRouterSubFolderStaticFileServer),
+            ("testParameterizedSubRouterSubFolderStaticFileServerRedirect", testParameterizedSubRouterSubFolderStaticFileServerRedirect),
             ("testRangeRequests", testRangeRequests),
             ("testRangeRequestsWithLargeLastBytePos", testRangeRequestsWithLargeLastBytePos),
             ("testRangeRequestIsIgnoredOnOptionOff", testRangeRequestIsIgnoredOnOptionOff),
@@ -181,6 +187,12 @@ class TestStaticFileServer: KituraTest {
 
         options = StaticFileServer.Options(possibleExtensions: ["exe", "html"], cacheOptions: cacheOptions, acceptRanges: false)
         router.all("/tyui", middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/", options:options, customResponseHeadersSetter: HeaderSetter()))
+        
+        options = StaticFileServer.Options(serveIndexForDirectory: true, redirect: true, cacheOptions: cacheOptions)
+        router.route("/ghjk").all(middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/", options: options))
+        
+        options = StaticFileServer.Options(serveIndexForDirectory: true, redirect: true, cacheOptions: cacheOptions)
+        router.route("/opnm/:parameter").all(middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/subfolder", options: options))
 
         return router
     }
@@ -263,8 +275,33 @@ class TestStaticFileServer: KituraTest {
     }
 
     let indexHtmlContents = "<!DOCTYPE html><html><body><b>Index</b></body></html>" // contents of index.html
+    let subfolderIndexHtmlContents = "<!DOCTYPE html><html><body><b>Sub Folder Index</b></body></html>" // contents of subfolder/index.html
     let indexHtmlCount = 54 // index.html file data length
 
+    func testSubRouterStaticFileServer() {
+        runGetResponseTest(path: "/ghjk/", expectedResponseText: indexHtmlContents + "\n")
+    }
+    
+    func testSubRouterSubFolderStaticFileServer() {
+        runGetResponseTest(path: "/ghjk/subfolder/", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
+    func testSubRouterStaticFileServerRedirect() {
+        runGetResponseTest(path: "/ghjk", expectedResponseText: indexHtmlContents + "\n")
+    }
+    
+    func testSubRouterSubFolderStaticFileServerRedirect() {
+        runGetResponseTest(path: "/ghjk/subfolder", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
+    func testParameterizedSubRouterSubFolderStaticFileServer() {
+        runGetResponseTest(path: "/opnm/xxxx/", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
+    func testParameterizedSubRouterSubFolderStaticFileServerRedirect() {
+        runGetResponseTest(path: "/opnm/xxxx", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
     func testRangeRequests() {
         let requestingBytes = 10
         performServerTest(router) { expectation in

--- a/Tests/KituraTests/TestStaticFileServer/subfolder/index.html
+++ b/Tests/KituraTests/TestStaticFileServer/subfolder/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body><b>Sub Folder Index</b></body></html>


### PR DESCRIPTION
## Context and Description
When StaticFileServer was added as a middleware, and it was added not to the root router but to a sub-router, and it had redirect folders to trailing slash turned on (default setting) then its redirection would be incorrect.

### Environment Details
Reproduced Swift 4.0.3 & 4.2; MacOS and Linux


### Steps to Reproduce
1) Setup a simple Kitura app with a router
2) Add a sample HTML file relative to the project at ./src/users/user_id/settings/index.html
3) Add a StaticFileServer to a sub-router of the main router

router.route("/users/:user_id").get(middleware: StaticFileServer(path: "./src/users/user_id/"))

4) HTTP GET /users/me/settings

### Expected vs. Actual Behaviour
Expected to happen... 

- Redirect issued to /users/me/settings/ and then the html file loaded

Actually happened... 

- Redirect issued to /settings/ which does not exist (404)

### Fix
Extract path of request from "request.parsedURL" instead of "request.parsedURLPath" as this takes into account the whole request path.
