### PR TITLE
fix: StaticFileServer request path extraction (#1353)

### DIFF
--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -141,7 +141,7 @@ open class StaticFileServer: RouterMiddleware {
             return
         }
 
-        guard let requestPath = request.parsedURLPath.path else {
+        guard let requestPath = request.parsedURL.path else {
             return
         }
 

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -41,6 +41,12 @@ class TestStaticFileServer: KituraTest {
             ("testGetTraversedFile", testGetTraversedFile),
             ("testAbsolutePathFunction", testAbsolutePathFunction),
             ("testAbsoluteRootPath", testAbsoluteRootPath),
+            ("testSubRouterStaticFileServer", testSubRouterStaticFileServer),
+            ("testSubRouterSubFolderStaticFileServer", testSubRouterSubFolderStaticFileServer),
+            ("testSubRouterStaticFileServerRedirect", testSubRouterStaticFileServerRedirect),
+            ("testSubRouterSubFolderStaticFileServerRedirect", testSubRouterSubFolderStaticFileServerRedirect),
+            ("testParameterizedSubRouterSubFolderStaticFileServer", testParameterizedSubRouterSubFolderStaticFileServer),
+            ("testParameterizedSubRouterSubFolderStaticFileServerRedirect", testParameterizedSubRouterSubFolderStaticFileServerRedirect),
             ("testRangeRequests", testRangeRequests),
             ("testRangeRequestsWithLargeLastBytePos", testRangeRequestsWithLargeLastBytePos),
             ("testRangeRequestIsIgnoredOnOptionOff", testRangeRequestIsIgnoredOnOptionOff),
@@ -179,6 +185,12 @@ class TestStaticFileServer: KituraTest {
 
         options = StaticFileServer.Options(possibleExtensions: ["exe", "html"], cacheOptions: cacheOptions, acceptRanges: false)
         router.all("/tyui", middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/", options:options, customResponseHeadersSetter: HeaderSetter()))
+        
+        options = StaticFileServer.Options(serveIndexForDirectory: true, redirect: true, cacheOptions: cacheOptions)
+        router.route("/ghjk").all(middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/", options: options))
+        
+        options = StaticFileServer.Options(serveIndexForDirectory: true, redirect: true, cacheOptions: cacheOptions)
+        router.route("/opnm/:parameter").all(middleware: StaticFileServer(path: "./Tests/KituraTests/TestStaticFileServer/subfolder", options: options))
 
         return router
     }
@@ -256,8 +268,33 @@ class TestStaticFileServer: KituraTest {
     }
 
     let indexHtmlContents = "<!DOCTYPE html><html><body><b>Index</b></body></html>" // contents of index.html
+    let subfolderIndexHtmlContents = "<!DOCTYPE html><html><body><b>Sub Folder Index</b></body></html>" // contents of subfolder/index.html
     let indexHtmlCount = 54 // index.html file data length
 
+    func testSubRouterStaticFileServer() {
+        runGetResponseTest(path: "/ghjk/", expectedResponseText: indexHtmlContents + "\n")
+    }
+    
+    func testSubRouterSubFolderStaticFileServer() {
+        runGetResponseTest(path: "/ghjk/subfolder/", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
+    func testSubRouterStaticFileServerRedirect() {
+        runGetResponseTest(path: "/ghjk", expectedResponseText: indexHtmlContents + "\n")
+    }
+    
+    func testSubRouterSubFolderStaticFileServerRedirect() {
+        runGetResponseTest(path: "/ghjk/subfolder", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
+    func testParameterizedSubRouterSubFolderStaticFileServer() {
+        runGetResponseTest(path: "/opnm/xxxx/", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
+    func testParameterizedSubRouterSubFolderStaticFileServerRedirect() {
+        runGetResponseTest(path: "/opnm/xxxx", expectedResponseText: subfolderIndexHtmlContents + "\n")
+    }
+    
     func testRangeRequests() {
         let requestingBytes = 10
         performServerTest(router) { expectation in

--- a/Tests/KituraTests/TestStaticFileServer/subfolder/index.html
+++ b/Tests/KituraTests/TestStaticFileServer/subfolder/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body><b>Sub Folder Index</b></body></html>


### PR DESCRIPTION
* [Fix] StaticFileServer requestPath redirection bug 

StaticFileServer requestPath now extracted from request.parsedURL rather than request.parsedURLPath as this fixes redirection behaviour to trailing slash paths when the static file server is a middleware for a routed path.

Eg. router.get("/aaa/123", middleware: StaticFileServer(...)) -- GET /aaa/123/bbb would previously redirect to /bbb/ rather than /aaa/123/bbb/ as expected. Similar behaviour was experienced when router.route("/aaa/123").get(middleware: StaticFileServer(...))

* Add tests for static file server on a sub router.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
