### PR TITLE
Cache URLParser objects for reuse

### DIFF
--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -110,12 +110,15 @@ public class RouterRequest {
     private var _parsedURL: URLParser?
     internal let parsedURLPath: URLParser
 
+    private static var urlParsers: [String: URLParser] = [:]
+
     /// The parsed URL.
     public private(set) lazy var parsedURL: URLParser = { [unowned self] in
         if let result = self._parsedURL {
             return result
         } else {
-            let result = URLParser(url: self.serverRequest.urlURL.absoluteString.data(using: .utf8)!, isConnect: false)
+            let urlString = self.serverRequest.urlURL.absoluteString
+            let result = RouterRequest.urlParsers[urlString] ?? URLParser(url: urlString.data(using: .utf8)!, isConnect: false)
             self._parsedURL = result
             return result
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Cache URLParser objects for reuse

## Description
<!--- Describe your changes in detail -->
URLParser objects are created once in every RouterRequest. Their creation involves a conversion of String representation of a URL to Data followed by a parsing step. Typically, a webservice consists of a limited number of routes, and hence a limited number of target URLs. It may hence make sense to cache the URLParser objects against the String representations of the URLs. Since we are talking about a limited number of URLs here, the possibility of a leak is negligible. 

## Motivation and Context
Caching can lead to a significant performance gain in certain workloads.

## How Has This Been Tested?
Tested on Linux and macOS