### PR TITLE
Use an optimal way to get the UTF8 length

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -440,7 +440,7 @@ public class RouterResponse {
             Log.warning("RouterResponse send(str:) invoked after end() for \(self.request.urlURL)")
             return self
         }
-        let utf8Length = str.lengthOfBytes(using: .utf8)
+        let utf8Length = str.utf8.count
         let bufferLength = utf8Length + 1  // Add room for the NULL terminator
         var utf8: [CChar] = [CChar](repeating: 0, count: bufferLength)
         if str.getCString(&utf8, maxLength: bufferLength, encoding: .utf8) {


### PR DESCRIPTION
We currently use NSString.lengthOfBytes(using:) to calculate the length of the UTF8 bytes. A flamegraph analysis of Kitura against a simple HelloWorld benchmark proves this to be sub-optimal. Using the `String.utf8.count` instead bumps up performance by 12-14%.

