### PR TITLE
Remove dictionary mapping in tests

### DIFF
--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -300,12 +300,12 @@ class TestCodableRouter: KituraTest {
     }
 
     func testBasicGetIdentifiersArray() {
-        var intTuple = [(Int, User)]()
-        self.userStore.forEach { intTuple.append(($0.0, $0.1)) }
+        let intTuple: [(Int, User)] = [(1, User(id: 1, name: "Andy")), (2, User(id: 2, name: "Dave")), (3, User(id: 3, name: "Ian"))]
+        // expectedIntData = [["1": User(id: 1, name: "Andy")], ["2": User(id: 2, name: "Dave")], ["3": User(id: 3, name: "Ian")]]
         let expectedIntData: [[String: User]] = intTuple.map({ [$0.value: $1] })
         
-        var stringTuple = [(String, User)]()
-        self.userStore.forEach { stringTuple.append((String($0.0), $0.1)) }
+        let stringTuple: [(String, User)] = [("1", User(id: 1, name: "Andy")), ("2", User(id: 2, name: "Dave")), ("3", User(id: 3, name: "Ian"))]
+        // expectedStringData = [["1": User(id: 1, name: "Andy")], ["2": User(id: 2, name: "Dave")], ["3": User(id: 3, name: "Ian")]]
         let expectedStringData: [[String: User]] = stringTuple.map({ [$0.value: $1] })
         
         router.get("/int/users") { (respondWith: ([(Int, User)]?, RequestError?) -> Void) in

--- a/Tests/KituraTests/TestTypeSafeMiddleware.swift
+++ b/Tests/KituraTests/TestTypeSafeMiddleware.swift
@@ -289,15 +289,12 @@ class TestTypeSafeMiddleware: KituraTest {
     }
 
     func testSingleMiddlewareGetIdentifierCodableArray() {
-        // Expected tuples [[1: User(id: 1, name: "Andy")], [2: User(id: 2, name: "Dave")], [3: User(id: 3, name: "Ian")]]
-        var intTuple = [(Int, User)]()
-        self.userStore.forEach { intTuple.append(($0.0, $0.1)) }
+        let intTuple: [(Int, User)] = [(1, User(id: 1, name: "Andy")), (2, User(id: 2, name: "Dave")), (3, User(id: 3, name: "Ian"))]
+        // expectedIntData = [["1": User(id: 1, name: "Andy")], ["2": User(id: 2, name: "Dave")], ["3": User(id: 3, name: "Ian")]]
         let expectedIntData: [[String: User]] = intTuple.map({ [$0.value: $1] })
 
         router.get("/userMiddleware") { (middleware: UserMiddleware, respondWith: ([(Int, User)]?, RequestError?) -> Void) in
             print("GET Identifier Codable tuple on /userMiddleware - received header \(middleware.header)")
-            var intTuple = [(Int, User)]()
-            self.userStore.forEach { intTuple.append(($0.0, $0.1)) }
             respondWith(intTuple, nil)
         }
 
@@ -315,15 +312,12 @@ class TestTypeSafeMiddleware: KituraTest {
     }
 
     func testMultipleMiddlewareGetIdentifierCodableArray() {
-        // Expected tuples [[1: User(id: 1, name: "Andy")], [2: User(id: 2, name: "Dave")], [3: User(id: 3, name: "Ian")]]
-        var intTuple = [(Int, User)]()
-        self.userStore.forEach { intTuple.append(($0.0, $0.1)) }
+        let intTuple: [(Int, User)] = [(1, User(id: 1, name: "Andy")), (2, User(id: 2, name: "Dave")), (3, User(id: 3, name: "Ian"))]
+        // expectedIntData = [["1": User(id: 1, name: "Andy")], ["2": User(id: 2, name: "Dave")], ["3": User(id: 3, name: "Ian")]]
         let expectedIntData: [[String: User]] = intTuple.map({ [$0.value: $1] })
 
         router.get("/userMultiMiddleware") { (middleware: UserMiddleware, middleware2: UserMiddleware2, middleware3: UserMiddleware3, respondWith: ([(Int, User)]?, RequestError?) -> Void) in
             print("GET Identifier Codable on /userMultiMiddleware - received headers \(middleware.header), \(middleware2.header), \(middleware3.header)")
-            var intTuple = [(Int, User)]()
-            self.userStore.forEach { intTuple.append(($0.0, $0.1)) }
             respondWith(intTuple, nil)
         }
 


### PR DESCRIPTION
This PR Removes the mapping from a dictionary to an array when comparing results in tests. This is because the dictionary is unordered which causes the comparison to fail on Swift 5. They have been replaced with arrays of the expected values.