### PR TITLE
Fix: Add locking for Kitura servers

### DIFF
--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -170,12 +170,12 @@ public class Kitura {
             Log.verbose("Stopping HTTP Server on port \(port)...")
             server.stop()
         }
-        
+
         for (server, port) in fastCGIServersAndPorts {
             Log.verbose("Stopping FastCGI Server on port \(port)...")
             server.stop()
         }
-        
+
         if unregister {
             httpServersAndPorts.removeAll()
             fastCGIServersAndPorts.removeAll()
@@ -184,7 +184,6 @@ public class Kitura {
     }
 
     typealias Port = Int
-    
     private static let serverLock = NSLock()
     internal private(set) static var httpServersAndPorts = [(server: HTTPServer, port: Port)]()
     internal private(set) static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port)]()

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -185,7 +185,7 @@ public class Kitura {
 
     typealias Port = Int
     
-    static private let serverLock = NSLock()
+    private static let serverLock = NSLock()
     internal private(set) static var httpServersAndPorts = [(server: HTTPServer, port: Port)]()
     internal private(set) static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port)]()
 }

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -170,10 +170,12 @@ public class Kitura {
             Log.verbose("Stopping HTTP Server on port \(port)...")
             server.stop()
         }
+        
         for (server, port) in fastCGIServersAndPorts {
             Log.verbose("Stopping FastCGI Server on port \(port)...")
             server.stop()
         }
+        
         if unregister {
             httpServersAndPorts.removeAll()
             fastCGIServersAndPorts.removeAll()


### PR DESCRIPTION
This pull request uses NSLock() to make accessing the static httpServerAndPosts and fastCGIServersAndPorts atomic. 
This makes the creation and deletion of Kitura servers thread safe are requested in issue #1368 
This has been tested by running:
```
KITURA_NIO=1 swift test --sanitize=thread
```
Which used to report 1 warning and now reports none.