### PR TITLE
tests: Use ephemeral ports in Kitura tests

### DIFF
--- a/.swift-test-parallel
+++ b/.swift-test-parallel
@@ -1,0 +1,1 @@
+swift test --parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,15 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: CUSTOM_TEST_SCRIPT=.swift-test-parallel
+    - os: linux
+      dist: trusty
+      sudo: required
       env: KITURA_NIO=1
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: KITURA_NIO=1 CUSTOM_TEST_SCRIPT=.swift-test-parallel
     - os: linux
       dist: trusty
       sudo: required
@@ -66,7 +74,15 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
+      env: CUSTOM_TEST_SCRIPT=.swift-test-parallel
+    - os: osx
+      osx_image: xcode10
+      sudo: required
       env: KITURA_NIO=1
+    - os: osx
+      osx_image: xcode10
+      sudo: required
+      env: KITURA_NIO=1 CUSTOM_TEST_SCRIPT=.swift-test-parallel
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-    - os: linux
-      dist: trusty
-      sudo: required
       env: CUSTOM_TEST_SCRIPT=.swift-test-parallel
-    - os: linux
-      dist: trusty
-      sudo: required
-      env: KITURA_NIO=1
     - os: linux
       dist: trusty
       sudo: required
@@ -71,14 +64,7 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
-    - os: osx
-      osx_image: xcode10
-      sudo: required
       env: CUSTOM_TEST_SCRIPT=.swift-test-parallel
-    - os: osx
-      osx_image: xcode10
-      sudo: required
-      env: KITURA_NIO=1
     - os: osx
       osx_image: xcode10
       sudo: required

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -31,7 +31,7 @@ class TestServer: KituraTest {
         ]
     }
 
-    let httpPort = 8080
+    var httpPort = 8080
     let fastCgiPort = 9000
     let useNIO = ProcessInfo.processInfo.environment["KITURA_NIO"] != nil
 
@@ -42,7 +42,7 @@ class TestServer: KituraTest {
 
     private func setupServerAndExpectations(expectStart: Bool, expectStop: Bool, expectFail: Bool, httpPort: Int?=nil, fastCgiPort: Int?=nil) {
         let router = Router()
-        let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? self.httpPort, with: router)
+        let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? 0, with: router)
         let fastCgiServer = useNIO ? FastCGIServer() : Kitura.addFastCGIServer(onPort: fastCgiPort ?? self.fastCgiPort, with: router)
 
         if expectStart {
@@ -164,7 +164,7 @@ class TestServer: KituraTest {
     }
 
     func testServerRestart() {
-        let port = httpPort
+        var port = httpPort
         let path = "/testServerRestart"
         let body = "Server is running."
 
@@ -174,7 +174,7 @@ class TestServer: KituraTest {
             next()
         }
 
-        let server = Kitura.addHTTPServer(onPort: port, with: router)
+        let server = Kitura.addHTTPServer(onPort: 0, with: router)
         server.sslConfig = KituraTest.sslConfig.config
 
         let stopped = DispatchSemaphore(value: 0)
@@ -183,6 +183,7 @@ class TestServer: KituraTest {
         }
 
         Kitura.start()
+        port = server.port!
         testResponse(port: port, path: path, expectedBody: body)
         Kitura.stop(unregister: false)
         stopped.wait()
@@ -191,6 +192,7 @@ class TestServer: KituraTest {
         testResponse(port: port, path: path, expectedBody: nil, expectedStatus: nil)
 
         Kitura.start()
+        port = server.port!
         testResponse(port: port, path: path, expectedBody: body)
         Kitura.stop() // default for unregister is true
 


### PR DESCRIPTION
Provide an option to run Kitura tests in parallel (`swift test --parallel`) supported by the use of ephemeral ports.

## Description
Kitura tests that fire up a server have the latter listening at a default port of 8080. This stops us from running the tests in parallel because port collisions happen. If we bind the servers to ephemeral ports, it is possible to run the tests in parallel. This pull requests adds support to optionally use ephemeral ports (through the `USE_EPHEMERAL_PORTS` compiler flag). It also adds some travis CI tests that use ephemeral ports and the run in parallel.

## Motivation and Context
Adds an option to run tests in parallel, showcases the use of ephemeral ports, with both KituraNet and KituraNIO

## How Has This Been Tested?
The following test scenarios have been added to travis.yml
1.  Parallel tests(ephemeral ports) with KituraNet on Linux
2.  Parallel tests(ephemeral ports) with KituraNet on macOS
3.  Parallel tests(ephemeral ports) with KituraNIO on Linux
4.  Parallel tests(ephemeral ports) with KituraNIO on macOS