### PR TITLE
[DO NOT MERGE] Default to Kitura-NIO for networking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04 KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel"
+      env: DOCKER_IMAGE=ubuntu:16.04 KITURA_NET=1 SWIFT_TEST_ARGS="--parallel"
     - os: linux
       dist: trusty
       sudo: required
@@ -49,27 +49,27 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:18.04 KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel"
+      env: DOCKER_IMAGE=ubuntu:18.04 KITURA_NET=1 SWIFT_TEST_ARGS="--parallel"
     - os: osx
       osx_image: xcode9.2
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
+      env: SWIFT_SNAPSHOT=4.0.3 BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode9.4
       sudo: required
-      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true
+      env: SWIFT_SNAPSHOT=4.1.2 JAZZY_ELIGIBLE=true BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_TEST_ARGS="--parallel"
+      env: SWIFT_TEST_ARGS="--parallel" BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel" BREW_INSTALL_PACKAGES="libressl"
+      env: KITURA_NET=1 SWIFT_TEST_ARGS="--parallel"
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel --num-workers=16"
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel --num-workers=16" BREW_INSTALL_PACKAGES="libressl"
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: KITURA_NET=1 SWIFT_TEST_ARGS="--parallel"
+      env: KITURA_NET=1 SWIFT_TEST_ARGS="--parallel" BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode10.1
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: KITURA_NET=1 SWIFT_TEST_ARGS="--parallel" BREW_INSTALL_PACKAGES="libressl"
+      env: KITURA_NET=1 SWIFT_TEST_ARGS="--parallel"
     - os: osx
       osx_image: xcode10.1
       sudo: required

--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ import Foundation
 
 var kituraNetPackage: Package.Dependency
 
-if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
-} else {
+if ProcessInfo.processInfo.environment["KITURA_NET"] != nil {
     kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0")
+} else {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
 }
 
 let package = Package(

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -21,10 +21,10 @@ import Foundation
 
 var kituraNetPackage: Package.Dependency
 
-if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
-} else {
+if ProcessInfo.processInfo.environment["KITURA_NET"] != nil {
     kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0")
+} else {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
 }
 
 let package = Package(

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -21,10 +21,10 @@ import Foundation
 
 var kituraNetPackage: Package.Dependency
 
-if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
-} else {
+if ProcessInfo.processInfo.environment["KITURA_NET"] != nil {
     kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0")
+} else {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
 }
 
 let package = Package(

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -33,7 +33,7 @@ class TestServer: KituraTest {
 
     var httpPort = 8080
     let fastCgiPort = 9000
-    let useNIO = ProcessInfo.processInfo.environment["KITURA_NIO"] != nil
+    let useNIO = ProcessInfo.processInfo.environment["KITURA_NET"] == nil
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use Kitura-NIO as the default networking library for Kitura

## Description
We currently default to Kitura-net for networking and offer a switch to Kitura-NIO using the KITURA_NIO environment variable. This commit proposes defaulting to Kitura-NIO and switching to Kitura-net using the KITURA_NET environment variable.

## Motivation and Context
We'd like to have Kitura running over SwiftNIO by default. Kitura-net would be optional.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
