### PR TITLE
macos: install libressl when building with Kitura-NIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel"
+      env: KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel" BREW_INSTALL_PACKAGES="libressl"
     - os: osx
       osx_image: xcode10.1
       sudo: required


### PR DESCRIPTION
Ask `Package-Builder` to install libressl when using Kitura-NIO on macOS

## Description
`Package-Builder`  has been changed to not install libressl by default. It is installed only when asked for, using the `BREW_INSTALL_PACKAGES` env variable.

## Motivation and Context
See https://github.com/IBM-Swift/Package-Builder/pull/157

