### PR TITLE
Avoid copy in RouterResponse.send(str)

### DIFF
--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -440,13 +440,12 @@ public class RouterResponse {
             Log.warning("RouterResponse send(str:) invoked after end() for \(self.request.urlURL)")
             return self
         }
-        let utf8Length = str.utf8.count
-        let bufferLength = utf8Length + 1  // Add room for the NULL terminator
-        var utf8: [CChar] = [CChar](repeating: 0, count: bufferLength)
-        if str.getCString(&utf8, maxLength: bufferLength, encoding: .utf8) {
-            let rawBytes = UnsafeRawPointer(UnsafePointer(utf8))
-            buffer.append(bytes: rawBytes.assumingMemoryBound(to: UInt8.self), length: utf8Length)
-            state.invokedSend = true
+        let count = str.utf8.count
+        str.withCString {
+            $0.withMemoryRebound(to: UInt8.self, capacity: count) {
+                buffer.append(bytes: $0, length: count)
+                state.invokedSend = true
+            }
         }
         return self
     }


### PR DESCRIPTION
The code in `RouterReponse.send(_ str:)` does an unnecessary allocate and copy of the `String` into an intermediate buffer, before writing to the `BufferList`.  This is suboptimal on all Swift versions but especially Swift 5 where the native string backing is UTF-8, so writing into the `BufferList` can be optimised down to a straight `memcpy()`.

Performance testing of this change for "Hello World":

```
               | Throughput (req/s)      | CPU (%) | Mem (kb)     | Latency (ms)                   | good
Implementation | Average    | Max        | Average | Avg peak RSS | Average  | 99%      | Max      | iters
---------------|------------|------------|---------|--------------|----------|----------|----------|-------
      base_421 |    65371.8 |    67103.4 |    97.4 |        25718 |      1.9 |      5.6 |    200.0 |    10
    nocopy_421 |    67454.4 |    70337.9 |    97.5 |        25681 |      1.9 |      6.7 |    201.9 |    10
       base_50 |    68373.6 |    69623.3 |    97.8 |        28702 |      1.8 |      4.1 |    201.1 |    10
     nocopy_50 |    74002.8 |    76245.5 |    97.6 |        28655 |      1.7 |      6.1 |    200.2 |    10
```

Swift 4.2.1 throughput is **+3%**.
Swift 5 throughput is **+8%**.