### PR TITLE
Use UTF8View to create Data

### DIFF
--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -115,7 +115,7 @@ public class RouterRequest {
         if let result = self._parsedURL {
             return result
         } else {
-            let result = URLParser(url: self.serverRequest.urlURL.absoluteString.data(using: .utf8)!, isConnect: false)
+            let result = URLParser(url: Data(self.serverRequest.urlURL.absoluteString.utf8), isConnect: false)
             self._parsedURL = result
             return result
         }

--- a/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
+++ b/Sources/Kitura/bodyParser/MultiPartBodyParser.swift
@@ -19,24 +19,13 @@ import LoggerAPI
 
 class MultiPartBodyParser: BodyParserProtocol {
     let boundaryData: Data
-    let endBoundaryData: Data
-    let newLineData: Data
-    let endHeaderData: Data
+    let endBoundaryData = Data("--".utf8)
+    let newLineData = Data("\r\n".utf8)
+    let endHeaderData = Data("\r\n\r\n".utf8)
 
     init(boundary: String) {
-        guard let boundaryData = String("--" + boundary).data(using: .utf8),
-            let endBoundaryData = "--".data(using: .utf8),
-            let newLineData = "\r\n".data(using: .utf8),
-            let endHeaderData = "\r\n\r\n".data(using: .utf8)
-            else {
-                Log.error("Error converting strings to data for multipart parsing")
-                exit(1)
-        }
-
-        self.boundaryData = boundaryData
-        self.endBoundaryData = endBoundaryData
-        self.newLineData = newLineData
-        self.endHeaderData = endHeaderData
+        let str = "--" + boundary
+        self.boundaryData = Data(str.utf8)
     }
 
     func parse(_ data: Data) -> ParsedBody? {

--- a/Sources/Kitura/contentType/ContentType.swift
+++ b/Sources/Kitura/contentType/ContentType.swift
@@ -40,15 +40,10 @@ public class ContentType {
 
     /// The following function loads the MIME types from an external file
     private init () {
-        let contentTypesData = contentTypesString.data(using: .utf8)
-        guard contentTypesData != nil else {
-            Log.error("Error parsing \(contentTypesString)")
-            return
-        }
+        let contentTypesData = Data(contentTypesString.utf8)
 
-        let jsonParseOptions = JSONSerialization.ReadingOptions.mutableContainers
-        let parsedObject = try? JSONSerialization.jsonObject(with: contentTypesData!,
-                                                             options: jsonParseOptions)
+        let parsedObject = try? JSONSerialization.jsonObject(with: contentTypesData,
+                                                             options: .mutableContainers)
 
         // MARK: Linux Foundation will return an Any instead of an AnyObject
         // Need to test if this breaks the Linux build.

--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -236,11 +236,11 @@ extension StaticFileServer {
                     partHeader += "Content-Range: bytes \(range.lowerBound)-\(range.upperBound)/\(fileSize)\r\n"
                     partHeader += (contentType == nil ? "" : "Content-Type: \(contentType!)\r\n")
                     partHeader += "\r\n"
-                    data.append(partHeader.data(using: .utf8)!)
+                    data.append(Data(partHeader.utf8))
                     data.append(fileData)
-                    data.append("\r\n".data(using: .utf8)!)
+                    data.append(Data("\r\n".utf8))
                 }
-                data.append("--\(boundary)--".data(using: .utf8)!)
+                data.append(Data("--\(boundary)--".utf8))
                 response.send(data: data)
                 response.statusCode = .partialContent
             }


### PR DESCRIPTION
A few places in Kitura we use `str.data(using: .utf8)` to create a `Data`. Currently in Swift 5 this is not optimised and goes via a UTF-16 `NSString`.

Instead, use the `Data` initializer which accepts a `Sequence`. This has a fastpath for UTF-8 already.