### PR TITLE
Use ephemeral ports for FastCGI testing

### DIFF
--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -32,7 +32,6 @@ class TestServer: KituraTest {
     }
 
     var httpPort = 8080
-    let fastCgiPort = 9000
     let useNIO = ProcessInfo.processInfo.environment["KITURA_NIO"] != nil
 
     override func setUp() {
@@ -43,7 +42,7 @@ class TestServer: KituraTest {
     private func setupServerAndExpectations(expectStart: Bool, expectStop: Bool, expectFail: Bool, httpPort: Int?=nil, fastCgiPort: Int?=nil) {
         let router = Router()
         let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? 0, with: router)
-        let fastCgiServer = useNIO ? FastCGIServer() : Kitura.addFastCGIServer(onPort: fastCgiPort ?? self.fastCgiPort, with: router)
+        let fastCgiServer = useNIO ? FastCGIServer() : Kitura.addFastCGIServer(onPort: fastCgiPort ?? 0, with: router)
 
         if expectStart {
             let httpStarted = expectation(description: "HTTPServer started()")


### PR DESCRIPTION
Recently we have seen some CI failures (example [here](https://travis-ci.org/IBM-Swift/Kitura/jobs/486165105)) like this:

```
[VERBOSE] [Kitura.swift:143 start()] Starting a FastCGI Server on port 9000...
/home/travis/build/IBM-Swift/Kitura/Tests/KituraTests/TestServer.swift:116: error: TestServer.testServerStartStop : failed - Error code: -9992(0x-2708), Address already in use
[ERROR] [Kitura.swift:147 start()] Error listening on port 9000: Error code: -9992(0x-2708), Address already in use. Use server.failed(callback:) to handle
```

I suspect this is because the FastCGI testing is not using ephemeral ports so when we do `swift test --parallel` we can get collisions on those tests.

Change the tests so it specifies port `0` and hence uses ephemeral ports.