### PR TITLE
backport: install libressl when building with Kitura-NIO(macOS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
     - os: osx
       osx_image: xcode10
       sudo: required
-      env: KITURA_NIO=1
+      env: KITURA_NIO=1 BREW_INSTALL_PACKAGES="libressl"
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git


### PR DESCRIPTION
Backport https://github.com/IBM-Swift/Kitura/commit/68e98937d62d792cee733726b9eb99d31319a3ec to the `kitura-2.6` branch

## Description
We changes `Package-Builder` to install brew packages by reading the value of a new environment variable called `BREW_INSTALL_PACKAGES` (see https://github.com/IBM-Swift/Package-Builder/pull/156 and https://github.com/IBM-Swift/Package-Builder/pull/157). The default installation of `libressl` on macOS was hence removed. A corresponding change was made to Kitura master. 

## Motivation and Context
Travis CI is failing to build the `kitura-2.6` branch in the NIO mode on macOS.
