### PR TITLE
Avoid NSString functions in query params

### DIFF
--- a/Sources/Kitura/RouteRegex.swift
+++ b/Sources/Kitura/RouteRegex.swift
@@ -65,11 +65,11 @@ public class RouteRegex {
         var keys = [String]()
         var nonKeyIndex = 0
 
-        let paths = pattern.components(separatedBy: "/")
+        let paths = pattern.split(separator: "/")
 
         for path in paths {
             (regexStr, keys, nonKeyIndex) =
-                handlePath(path, regexStr: regexStr, keys: keys, nonKeyIndex: nonKeyIndex)
+                handlePath(String(path), regexStr: regexStr, keys: keys, nonKeyIndex: nonKeyIndex)
         }
 
         if allowPartialMatch {

--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -72,17 +72,15 @@ extension Substring {
         // substring from index
         var value = self[self.index(after: index)...]
 
-        //let valueReplacingPlus = value.replacingOccurrences(of: "+", with: " ")
         // Faster way to replace '+' with ' ' that does not involve conversion to NSString
         value.replaceCharacters("+", with: " ")
 
-// TEMPORARY - evaluate benefit of removing this NSString method
-        let decodedValue = value.removingPercentEncoding
-        //let decodedValue: Substring? = nil
-        if decodedValue == nil {
+        // Note: Foundation processing function
+        guard let decodedValue = value.removingPercentEncoding else {
             Log.warning("Unable to decode query parameter \(key) (coded value: \(value)")
+            return (key: key, value: value)
         }
-        return (key: key, value: decodedValue != nil ? Substring(decodedValue!) : value)
+        return (key: key, value: Substring(decodedValue))
     }
 
     /// Finds and replaces all occurrences of a character with the provided substring

--- a/Sources/Kitura/String+Extensions.swift
+++ b/Sources/Kitura/String+Extensions.swift
@@ -64,9 +64,15 @@ extension Substring {
     /// with corresponding "key" and "value" values, with the value being URL
     /// unencoded.
     var keyAndDecodedValue: (key: Substring, value: Substring?) {
+        #if swift(>=4.2)
         guard let index = self.firstIndex(of: "=") else {
             return (key: self, value: nil)
         }
+        #else
+        guard let index = self.index(of: "=") else {
+            return (key: self, value: nil)
+        }
+        #endif
         // substring up to index
         let key = self[..<index]
         // substring from index
@@ -88,9 +94,15 @@ extension Substring {
     @inline(__always)
     private mutating func replaceCharacters(_ src: Character, with dst: Substring) {
         repeat {
+            #if swift(>=4.2)
             guard let startIndex = self.firstIndex(of: src) else {
                 break
             }
+            #else
+            guard let startIndex = self.index(of: src) else {
+                break
+            }
+            #endif
             self.replaceSubrange(startIndex...startIndex, with: dst)
         } while true
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces the use of `String.components` with `String.split` when processing the query parameters string, and replaces the use of `String.replacingOccurrences` with a new function that uses `String.replaceSubrange` instead.

I did attempt to replace the `removingPercentEncoding()` function with a version using only stdlib functions, however I could not get this to outperform the Foundation implementation consistently on Mac and Linux.  For reference, the implementation I came up with (based on CoreFoundation) was:
https://github.com/IBM-Swift/Kitura/compare/ef0e241de858e96e4165b4d4250b16627288488a...177d74eb010261ee194b40f2b2203d00243f0d88

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoids bridging to NSString.  (see #1388)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
