### PR TITLE
Fix crash when empty MediaType is passed in request

### DIFF
--- a/Sources/Kitura/contentType/MediaType.swift
+++ b/Sources/Kitura/contentType/MediaType.swift
@@ -88,7 +88,8 @@ public struct MediaType: CustomStringConvertible, Equatable, Hashable {
         let mimeComponents = mimeType
             .lowercased()
             .split(separator: "/", maxSplits: 1)
-        guard let topLevelType = TopLevelType(rawValue: String(mimeComponents[0])) else {
+        guard !mimeComponents.isEmpty,
+          let topLevelType = TopLevelType(rawValue: String(mimeComponents[0])) else {
             return nil
         }
         self.topLevelType = topLevelType

--- a/Tests/KituraTests/TestMediaType.swift
+++ b/Tests/KituraTests/TestMediaType.swift
@@ -99,4 +99,8 @@ class TestMediaType: KituraTest {
     func testInvalidMediaType() {
         XCTAssertNil(MediaType(contentTypeHeader: "incorrect/html; charset=banana"))
     }
+
+    func testEmptyMediaType() {
+        XCTAssertNil(MediaType(contentTypeHeader: ""))
+    }
 }


### PR DESCRIPTION
## Description
I've been testing my Kitura server and crashed it with:
```
curl -X "POST" "[ENDPOINT_URL]" \
     -H 'Content-Type: ' \
     -d $'{}'
```

## Motivation and Context
It fixes server crash

## How Has This Been Tested?
Just send a request with empty Content-Type.

## Checklist:
- [ ] If applicable, I have updated the documentation accordingly.
- [X] If applicable, I have added tests to cover my changes.