### PR TITLE
tests: Remove force-unwraps

### DIFF
--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -524,8 +524,10 @@ class TestStaticFileServer: KituraTest {
                 XCTAssertNotNil(response)
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK)
                 XCTAssertNotNil(response?.headers["Last-Modified"]?.first)
-                XCTAssertNotNil(response?.headers["eTag"]?.first)
-                let eTag = response!.headers["eTag"]!.first!
+                guard let eTag = response?.headers["eTag"]?.first else {
+                    XCTFail("eTag header was missing")
+                    return expectation.fulfill()
+                }
 
                 // if ETag is the same then partial content (206) should be served
                 self.performRequest("get", path: "/qwer/index.html", callback: { response in
@@ -559,9 +561,11 @@ class TestStaticFileServer: KituraTest {
             self.performRequest("get", path: "/qwer/index.html", callback: { response in
                 XCTAssertNotNil(response)
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK)
-                XCTAssertNotNil(response?.headers["Last-Modified"]?.first)
+                guard let lastModified = response?.headers["Last-Modified"]?.first else {
+                    XCTFail("Last-Modified header was missing")
+                    return expectation.fulfill()
+                }
                 XCTAssertNotNil(response?.headers["eTag"]?.first)
-                let lastModified = response!.headers["Last-Modified"]!.first!
 
                 // if Last-Modified is the same then partial content (206) should be served
                 self.performRequest("get", path: "/qwer/index.html", callback: { response in


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Several tests that rely on `StaticFileServer` currently fail when running under Xcode.  Two of these tests contain force-unwraps that cause a crash instead of test failure.

This PR removes the force-unwraps from these tests, so that the test suite can be run to completion.  It does not fix the underlying problem that the path to the resources for the StaticFileServer in the tests is invalid when running under Xcode (see #1427).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests should not crash, even if they are failing for some reason.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
