### PR TITLE
Made the routingHelper functions publicly available

### DIFF
--- a/Sources/Kitura/Router.swift
+++ b/Sources/Kitura/Router.swift
@@ -100,7 +100,7 @@ public class Router {
         Log.verbose("Router initialized")
     }
 
-    func routingHelper(_ method: RouterMethod, pattern: String?, handler: [RouterHandler]) -> Router {
+    public func routingHelper(_ method: RouterMethod, pattern: String?, handler: [RouterHandler]) -> Router {
         elements.append(RouterElement(method: method,
                                       pattern: pattern,
                                       handler: handler,
@@ -108,7 +108,7 @@ public class Router {
         return self
     }
 
-    func routingHelper(_ method: RouterMethod, pattern: String?, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
+    public func routingHelper(_ method: RouterMethod, pattern: String?, allowPartialMatch: Bool = true, middleware: [RouterMiddleware]) -> Router {
         elements.append(RouterElement(method: method,
                                       pattern: pattern,
                                       middleware: middleware,


### PR DESCRIPTION
## Description
By making the current two implemented `routingHelper()` functions in the router publicly available it allows a bit more abstraction by the user in terms of implementing generics if desired, by leveraging the use of the already public `RouterMethod` struct:

Instead of `router.get('endpoint', handler:)` I can now alternatively call `router.routingHelper(.get, 'endpoint', handler:)` if desired.

## How Has This Been Tested?
`-`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.