### PR TITLE
Maintain CI testing for 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ branches:
 # by .swift-version, unless SWIFT_SNAPSHOT is specified.
 matrix:
   include:
+    # Continue to test one permutation on Trusty (14.04)
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: required
-      services: docker
-      env: DOCKER_IMAGE=swift:4.0.3 SWIFT_SNAPSHOT=4.0.3
+      env: SWIFT_SNAPSHOT=4.0.3
     - os: linux
       dist: xenial
       sudo: required


### PR DESCRIPTION
As Swift.org builds for Ubuntu 14.04 are still being produced, and extended (paid) support is available past the imminent end-of-life date, I'm restoring one build permutation so that we maintain coverage for the core Kitura dependencies.

Similar coverage will be maintained in Kitura-Sample.