### PR TITLE
Support Unix domain sockets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=4.0.3
+      env: SWIFT_SNAPSHOT=4.0.3 SWIFT_TEST_ARGS="-Xswiftc -DSKIP_UNIX_SOCKETS"
     - os: linux
       dist: xenial
       sudo: required

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ var kituraNetPackage: Package.Dependency
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
     kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.0.0")
 } else {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0")
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0")
 }
 
 let package = Package(

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.1.0")

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.1.0")

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -64,13 +64,48 @@ public class Kitura {
                                     withSSL sslConfig: SSLConfig?=nil,
                                     keepAlive keepAliveState: KeepAliveState = .unlimited,
                                     allowPortReuse: Bool = false) -> HTTPServer {
+        return Kitura._addHTTPServer(onPort: port, with: delegate, withSSL: sslConfig, keepAlive: keepAliveState, allowPortReuse: allowPortReuse)
+    }
+
+    /// Add an HTTPServer on a Unix domain socket path with a delegate.
+    ///
+    /// The server is only registered with the framework, it does not start listening
+    /// on the Unix socket until `Kitura.run()` or `Kitura.start()` are called.
+    ///
+    ///### Usage Example: ###
+    ///```swift
+    /// let router = Router()
+    /// Kitura.addHTTPServer(onUnixDomainSocket: "/tmp/mySocket", with: router)
+    ///```
+    /// - Parameter onUnixDomainSocket: The path of the Unix domain socket to listen on.
+    /// - Parameter with: The `ServerDelegate` to use.
+    /// - Parameter withSSL: The `sslConfig` to use.
+    /// - Parameter keepAlive: The maximum number of additional requests to permit per Keep-Alive connection. Defaults to `.unlimited`. If set to `.disabled`, Keep-Alive will not be permitted.
+    /// - Returns: The created `HTTPServer`.
+    @discardableResult
+    public class func addHTTPServer(onUnixDomainSocket socketPath: String,
+                                    with delegate: ServerDelegate,
+                                    withSSL sslConfig: SSLConfig?=nil,
+                                    keepAlive keepAliveState: KeepAliveState = .unlimited) -> HTTPServer {
+        return Kitura._addHTTPServer(onUnixDomainSocket: socketPath, with: delegate, withSSL: sslConfig, keepAlive: keepAliveState)
+    }
+
+    private class func _addHTTPServer(onPort port: Int? = nil, onUnixDomainSocket socketPath: String? = nil,
+                                    with delegate: ServerDelegate,
+                                    withSSL sslConfig: SSLConfig?=nil,
+                                    keepAlive keepAliveState: KeepAliveState = .unlimited,
+                                    allowPortReuse: Bool = false) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config
         server.keepAliveState = keepAliveState
         server.allowPortReuse = allowPortReuse
         serverLock.lock()
-        httpServersAndPorts.append((server: server, port: port))
+        if let port = port {
+            httpServersAndPorts.append((server: server, port: port))
+        } else if let socketPath = socketPath {
+            httpServersAndUnixSocketPaths.append((server: server, socketPath: socketPath))
+        }
         serverLock.unlock()
         return server
     }
@@ -139,6 +174,14 @@ public class Kitura {
                 Log.error("Error listening on port \(port): \(error). Use server.failed(callback:) to handle")
             }
         }
+        for (server, path) in httpServersAndUnixSocketPaths {
+            Log.verbose("Starting an HTTP Server on path \(path)...")
+            do {
+                try server.listen(unixDomainSocketPath: path)
+            } catch {
+                Log.error("Error listening on path \(path): \(error). Use server.failed(callback:) to handle")
+            }
+        }
         for (server, port) in fastCGIServersAndPorts {
             Log.verbose("Starting a FastCGI Server on port \(port)...")
             do {
@@ -171,6 +214,11 @@ public class Kitura {
             server.stop()
         }
 
+        for (server, path) in httpServersAndUnixSocketPaths {
+            Log.verbose("Stopping HTTP Server on path \(path)...")
+            server.stop()
+        }
+
         for (server, port) in fastCGIServersAndPorts {
             Log.verbose("Stopping FastCGI Server on port \(port)...")
             server.stop()
@@ -178,6 +226,7 @@ public class Kitura {
 
         if unregister {
             httpServersAndPorts.removeAll()
+            httpServersAndUnixSocketPaths.removeAll()
             fastCGIServersAndPorts.removeAll()
         }
         serverLock.unlock()
@@ -186,5 +235,6 @@ public class Kitura {
     typealias Port = Int
     internal static let serverLock = NSLock()
     internal private(set) static var httpServersAndPorts = [(server: HTTPServer, port: Port)]()
+    internal private(set) static var httpServersAndUnixSocketPaths = [(server: HTTPServer, socketPath: String)]()
     internal private(set) static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port)]()
 }

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -22,22 +22,51 @@ import Kitura
 import Foundation
 import Dispatch
 
+// The type of transport to use when communicating with the server.
 enum SSLOption {
+    // Tests will be performed over both HTTP and HTTPS.
     case both
+    // Only HTTP will be tested.
     case httpOnly
+    // Only HTTPS will be tested.
     case httpsOnly
+}
+
+// The type of socket to use when connecting to the server.
+enum SocketTypeOption {
+    // Both inet and unix sockets will be tested, in turn
+    case both
+    // Only inet sockets will be tested
+    case inet
+    // Only unix sockets will be tested
+    case unix
 }
 
 class KituraTest: XCTestCase {
 
-    static let httpPort = 8080
-    static let httpsPort = 8443
+    // A singleton Kitura server listening on HTTP on an INET socket
+    static private(set) var httpInetServer: HTTPServer?
+    // A singleton Kitura server listening on HTTPS on an INET socket
+    static private(set) var httpsInetServer: HTTPServer?
+    // A singleton Kitura server listening on HTTP on a Unix socket
+    static private(set) var httpUnixServer: HTTPServer?
+    // A singleton Kitura server listening on HTTPS on a Unix socket
+    static private(set) var httpsUnixServer: HTTPServer?
 
-    static private(set) var httpServer: HTTPServer? 
-    static private(set) var httpsServer: HTTPServer?
-
+    // The port of the server returned by startServer().
     private(set) var port = -1
+    // Whether the server used by doPerformServerTest should use SSL.
     private(set) var useSSL = false
+    // The socket file path of the server returned by startUnixSocketServer().
+    private(set) var socketFilePath: String? = nil
+    // Whether the server used by doPerformServerTest should use a Unix domain socket.
+    private(set) var useUnixSocket = false
+
+    /// The types of listeners we currently support.
+    private enum ListenerType {
+        case inet(Int)
+        case unix(String)
+    }
 
     static let sslConfig: SSLConfig = {
         let sslConfigDir = URL(fileURLWithPath: #file).appendingPathComponent("../SSLConfig")
@@ -63,41 +92,61 @@ class KituraTest: XCTestCase {
         KituraTest.initOnce
     }
 
-    func buildServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
+    func buildServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, socketTypeOption: SocketTypeOption = SocketTypeOption.both, timeout: TimeInterval = 10,
                            line: Int = #line) -> RequestTestBuilder {
-        return ServerTestBuilder(test: self, router: router, sslOption: sslOption, timeout: timeout, line: line)
+        return ServerTestBuilder(test: self, router: router, sslOption: sslOption, socketTypeOption: socketTypeOption, timeout: timeout, line: line)
     }
 
-    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
+    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, socketTypeOption: SocketTypeOption = SocketTypeOption.both, timeout: TimeInterval = 10,
                            line: Int = #line, asyncTasks: (XCTestExpectation) -> Void...) {
-        performServerTest(router, sslOption: sslOption, timeout: timeout, line: line, asyncTasks: asyncTasks)
+        performServerTest(router, sslOption: sslOption, socketTypeOption: socketTypeOption, timeout: timeout, line: line, asyncTasks: asyncTasks)
     }
 
-    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, timeout: TimeInterval = 10,
+    func performServerTest(_ router: ServerDelegate, sslOption: SSLOption = SSLOption.both, socketTypeOption: SocketTypeOption = SocketTypeOption.both, timeout: TimeInterval = 10,
                            line: Int = #line, asyncTasks: [(XCTestExpectation) -> Void]) {
         if sslOption != SSLOption.httpsOnly {
-            self.port = KituraTest.httpPort
             self.useSSL = false
-            doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
+            if socketTypeOption != SocketTypeOption.unix {
+                self.useUnixSocket = false
+                doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
+            }
+            setUp()
+            if socketTypeOption != SocketTypeOption.inet {
+                self.useUnixSocket = true
+                doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
+            }
         }
         
         // Call setUp to start at a known state (ideally, this should have been written as a separate test)
         setUp()
 
         if sslOption != SSLOption.httpOnly {
-            self.port = KituraTest.httpsPort
             self.useSSL = true
-            doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
+            if socketTypeOption != SocketTypeOption.unix {
+                self.useUnixSocket = false
+                doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
+            }
+            setUp()
+            if socketTypeOption != SocketTypeOption.inet {
+                self.useUnixSocket = true
+                doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
+            }
         }
     }
 
     func doPerformServerTest(router: ServerDelegate, timeout: TimeInterval, line: Int, asyncTasks: [(XCTestExpectation) -> Void]) {
 
-        guard let port = startServer(router: router) else {
-            XCTFail("Error starting server. useSSL:\(useSSL)")
-            return
+        if useUnixSocket {
+            guard let socketPath = startUnixSocketServer(router: router) else {
+                return XCTFail("Error starting server. useSSL:\(useSSL), useUnixSocket:\(useUnixSocket)")
+            }
+            XCTAssertEqual(socketPath, self.socketFilePath, "Server is listening on the wrong path")
+        } else {
+            guard let port = startServer(router: router) else {
+                return XCTFail("Error starting server. useSSL:\(useSSL), useUnixSocket:\(useUnixSocket)")
+            }
+            self.port = port
         }
-        self.port = port
         let requestQueue = DispatchQueue(label: "Request queue")
         for (index, asyncTask) in asyncTasks.enumerated() {
             let expectation = self.expectation(line: line, index: index)
@@ -114,12 +163,12 @@ class KituraTest: XCTestCase {
 
     private func startServer(router: ServerDelegate) -> Int? {
         if useSSL {
-            if let server = KituraTest.httpsServer {
+            if let server = KituraTest.httpsInetServer {
                 server.delegate = router
                 return server.port
             }
         } else {
-            if let server = KituraTest.httpServer {
+            if let server = KituraTest.httpInetServer {
                 server.delegate = router
                 return server.port
             }
@@ -135,9 +184,9 @@ class KituraTest: XCTestCase {
             try server.listen(on: 0)
 
             if useSSL {
-                KituraTest.httpsServer = server
+                KituraTest.httpsInetServer = server
             } else {
-                KituraTest.httpServer = server
+                KituraTest.httpInetServer = server
             }
             return server.port
         } catch {
@@ -146,20 +195,80 @@ class KituraTest: XCTestCase {
         }
     }
 
-    func stopServer() {
-        KituraTest.httpServer?.stop()
-        KituraTest.httpServer = nil
+    private func startUnixSocketServer(router: ServerDelegate) -> String? {
+        if useSSL {
+            if let server = KituraTest.httpsUnixServer {
+                server.delegate = router
+                guard let listenPath = server.unixDomainSocketPath else {
+                    XCTFail("Unix socket path missing")
+                    return nil
+                }
+                self.socketFilePath = listenPath
+                return server.unixDomainSocketPath
+            }
+        } else {
+            if let server = KituraTest.httpUnixServer {
+                server.delegate = router
+                guard let listenPath = server.unixDomainSocketPath else {
+                    XCTFail("Unix socket path missing")
+                    return nil
+                }
+                self.socketFilePath = listenPath
+                return server.unixDomainSocketPath
+            }
+        }
+        let server = HTTP.createServer()
+        server.delegate = router
+        if useSSL {
+            server.sslConfig = KituraTest.sslConfig.config
+        }
 
-        KituraTest.httpsServer?.stop()
-        KituraTest.httpsServer = nil
+        // Create a temporary path for Unix domain socket
+        let socketPath = uniqueTemporaryFilePath()
+        self.socketFilePath = socketPath
+
+        do {
+            try server.listen(unixDomainSocketPath: socketPath)
+
+            if useSSL {
+                KituraTest.httpsUnixServer = server
+            } else {
+                KituraTest.httpUnixServer = server
+            }
+            return server.unixDomainSocketPath
+        } catch {
+            XCTFail("Error starting server: \(error)")
+            return nil
+        }
     }
 
-    func performRequest(_ method: String, path: String, port: Int? = nil, useSSL: Bool? = nil,
+    func stopServer() {
+        KituraTest.httpInetServer?.stop()
+        KituraTest.httpInetServer = nil
+
+        KituraTest.httpsInetServer?.stop()
+        KituraTest.httpsInetServer = nil
+
+        KituraTest.httpUnixServer?.stop()
+        KituraTest.httpUnixServer = nil
+
+        KituraTest.httpsUnixServer?.stop()
+        KituraTest.httpsUnixServer = nil
+
+        // Clean up temporary file for Unix domain socket
+        if let socketFilePath = socketFilePath {
+            removeTemporaryFilePath(socketFilePath)
+        }
+    }
+
+    func performRequest(_ method: String, path: String, port: Int? = nil, socketPath: String? = nil, useSSL: Bool? = nil, useUnixSocket: Bool? = nil,
                         callback: @escaping ClientRequest.Callback, headers: [String: String]? = nil,
                         requestModifier: ((ClientRequest) -> Void)? = nil) {
 
         let port = port ?? self.port
+        let socketPath = socketPath ?? self.socketFilePath
         let useSSL = useSSL ?? self.useSSL
+        let useUnixSocket = useUnixSocket ?? self.useUnixSocket
 
         var allHeaders = [String: String]()
         if  let headers = headers {
@@ -173,13 +282,17 @@ class KituraTest: XCTestCase {
 
         let schema = useSSL ? "https" : "http"
         var options: [ClientRequest.Options] =
-            [.method(method), .schema(schema), .hostname("localhost"), .port(UInt16(port).toInt16()), .path(path),
-             .headers(allHeaders)]
+            [.method(method), .schema(schema), .hostname("localhost"), .path(path), .headers(allHeaders)]
         if useSSL {
             options.append(.disableSSLVerification)
         }
-
-        let req = HTTP.request(options, callback: callback)
+        let req: ClientRequest
+        if useUnixSocket {
+            req = HTTP.request(options, unixDomainSocketPath: socketPath, callback: callback)
+        } else {
+            options.append(.port(UInt16(port).toInt16()))
+            req = HTTP.request(options, callback: callback)
+        }
         if let requestModifier = requestModifier {
             requestModifier(req)
         }
@@ -188,6 +301,34 @@ class KituraTest: XCTestCase {
 
     func expectation(line: Int, index: Int) -> XCTestExpectation {
         return self.expectation(description: "\(type(of: self)):\(line)[\(index)](ssl:\(useSSL))")
+    }
+
+    // Generates a unique temporary file path suitable for use as a Unix domain socket.
+    // On Linux, a path is returned within /tmp
+    // On MacOS, a path is returned within /var/folders
+    func uniqueTemporaryFilePath() -> String {
+        #if os(Linux)
+        let temporaryDirectory = "/tmp"
+        #else
+        var temporaryDirectory: String
+        if #available(OSX 10.12, *) {
+            temporaryDirectory = FileManager.default.temporaryDirectory.path
+        } else {
+            temporaryDirectory = "/tmp"
+        }
+        #endif
+        return temporaryDirectory + "/" + String(ProcessInfo.processInfo.globallyUniqueString.prefix(20))
+    }
+
+    // Delete a temporary file path.
+    func removeTemporaryFilePath(_ path: String) {
+        let fileURL = URL(fileURLWithPath: path)
+        let fm = FileManager.default
+        do {
+            try fm.removeItem(at: fileURL)
+        } catch {
+            XCTFail("Unable to remove \(path): \(error.localizedDescription)")
+        }
     }
 }
 

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -110,11 +110,13 @@ class KituraTest: XCTestCase {
                 self.useUnixSocket = false
                 doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
             }
+#if !SKIP_UNIX_SOCKETS
             setUp()
             if socketTypeOption != SocketTypeOption.inet {
                 self.useUnixSocket = true
                 doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
             }
+#endif
         }
         
         // Call setUp to start at a known state (ideally, this should have been written as a separate test)
@@ -126,11 +128,13 @@ class KituraTest: XCTestCase {
                 self.useUnixSocket = false
                 doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
             }
+#if !SKIP_UNIX_SOCKETS
             setUp()
             if socketTypeOption != SocketTypeOption.inet {
                 self.useUnixSocket = true
                 doPerformServerTest(router: router, timeout: timeout, line: line, asyncTasks: asyncTasks)
             }
+#endif
         }
     }
 

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016-2019
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,14 +136,14 @@ class KituraTest: XCTestCase {
 
     func doPerformServerTest(router: ServerDelegate, timeout: TimeInterval, line: Int, asyncTasks: [(XCTestExpectation) -> Void]) {
 
-        if useUnixSocket {
+        if self.useUnixSocket {
             guard let socketPath = startUnixSocketServer(router: router) else {
-                return XCTFail("Error starting server. useSSL:\(useSSL), useUnixSocket:\(useUnixSocket)")
+                return XCTFail("Error starting server. useSSL:\(self.useSSL), useUnixSocket:\(self.useUnixSocket)")
             }
             XCTAssertEqual(socketPath, self.socketFilePath, "Server is listening on the wrong path")
         } else {
             guard let port = startServer(router: router) else {
-                return XCTFail("Error starting server. useSSL:\(useSSL), useUnixSocket:\(useUnixSocket)")
+                return XCTFail("Error starting server. useSSL:\(self.useSSL), useUnixSocket:\(self.useUnixSocket)")
             }
             self.port = port
         }
@@ -317,7 +317,7 @@ class KituraTest: XCTestCase {
             temporaryDirectory = "/tmp"
         }
         #endif
-        return temporaryDirectory + "/" + String(ProcessInfo.processInfo.globallyUniqueString.prefix(20))
+        return temporaryDirectory + "/KituraTest." + String(ProcessInfo.processInfo.globallyUniqueString.prefix(20))
     }
 
     // Delete a temporary file path.

--- a/Tests/KituraTests/KituraTestBuilder.swift
+++ b/Tests/KituraTests/KituraTestBuilder.swift
@@ -119,15 +119,17 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
     let test: KituraTest
     let router: ServerDelegate
     let sslOption: SSLOption
+    let socketTypeOption: SocketTypeOption
     let timeout: TimeInterval
     let line: Int
     private var requests: [Request] = []
     private var currentRequest: Request? { return requests.last }
 
-    public init(test: KituraTest, router: ServerDelegate, sslOption: SSLOption, timeout: TimeInterval, line: Int) {
+    public init(test: KituraTest, router: ServerDelegate, sslOption: SSLOption, socketTypeOption: SocketTypeOption, timeout: TimeInterval, line: Int) {
         self.test = test
         self.router = router
         self.sslOption = sslOption
+        self.socketTypeOption = socketTypeOption
         self.timeout = timeout
         self.line = line
     }
@@ -324,6 +326,6 @@ class ServerTestBuilder: RequestTestBuilder, AssertionTestBuilder {
                 }
             }
         }
-        test.performServerTest(router, sslOption: sslOption, timeout: timeout, line: line, asyncTasks: tasks)
+        test.performServerTest(router, sslOption: sslOption, socketTypeOption: socketTypeOption, timeout: timeout, line: line, asyncTasks: tasks)
     }
 }

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -58,7 +58,7 @@ class TestRequests: KituraTest {
             next()
         }
 
-        performServerTest(router) { expectation in
+        performServerTest(router, socketTypeOption: .inet) { expectation in
             self.performRequest("get", path: "/zxcv/ploni", callback: { response in
                 XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
                 expectation.fulfill()

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -23,12 +23,16 @@ import KituraNet
 class TestServer: KituraTest {
 
     static var allTests: [(String, (TestServer) -> () throws -> Void)] {
-        return [
+        var listOfTests: [(String, (TestServer) -> () throws -> Void)] = [
             ("testServerStartStop", testServerStartStop),
             ("testServerRun", testServerRun),
             ("testServerFail", testServerFail),
             ("testServerRestart", testServerRestart)
         ]
+        #if !SKIP_UNIX_SOCKETS
+            listOfTests.append(("testUnixSocketServerRestart", testUnixSocketServerRestart))
+        #endif
+        return listOfTests
     }
 
     var httpPort = 8080
@@ -199,6 +203,7 @@ class TestServer: KituraTest {
     }
 
     func testUnixSocketServerRestart() {
+#if !SKIP_UNIX_SOCKETS
         let path = "/testSocketServerRestart"
         let body = "Server is running."
 
@@ -252,6 +257,7 @@ class TestServer: KituraTest {
         }
 
         XCTAssertEqual(Kitura.httpServersAndUnixSocketPaths.count, 0, "Kitura.httpServersAndUnixSocketPaths.count is \(Kitura.httpServersAndUnixSocketPaths.count), should be 0")
+#endif
     }
 
     private func testResponse(port: Int? = nil, socketPath: String? = nil, method: String = "get", path: String, expectedBody: String?, expectedStatus: HTTPStatusCode? = HTTPStatusCode.OK) {

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -198,9 +198,65 @@ class TestServer: KituraTest {
         XCTAssertEqual(Kitura.httpServersAndPorts.count, 0, "Kitura.httpServersAndPorts.count is \(Kitura.httpServersAndPorts.count), should be 0")
     }
 
-    private func testResponse(port: Int, method: String = "get", path: String, expectedBody: String?, expectedStatus: HTTPStatusCode? = HTTPStatusCode.OK) {
+    func testUnixSocketServerRestart() {
+        let path = "/testSocketServerRestart"
+        let body = "Server is running."
 
-        performRequest(method, path: path, port: port, useSSL: true, callback: { response in
+        // Create a temporary socket path for this server
+        let socketPath = uniqueTemporaryFilePath()
+        defer {
+            removeTemporaryFilePath(socketPath)
+        }
+
+        let router = Router()
+        router.get(path) { _, response, next in
+            response.send(body)
+            next()
+        }
+
+        let server = Kitura.addHTTPServer(onUnixDomainSocket: socketPath, with: router)
+        server.sslConfig = KituraTest.sslConfig.config
+
+        let stopped = DispatchSemaphore(value: 0)
+        let started = DispatchSemaphore(value: 0)
+        server.stopped {
+            stopped.signal()
+        }
+        server.started {
+            started.signal()
+        }
+
+        Kitura.start()
+        if started.wait(timeout: DispatchTime.now() + DispatchTimeInterval.seconds(5)) != DispatchTimeoutResult.success {
+            return XCTFail("Server failed to start")
+        }
+        XCTAssertEqual(server.unixDomainSocketPath, socketPath, "Server listening on wrong path")
+        testResponse(socketPath: socketPath, path: path, expectedBody: body)
+        Kitura.stop(unregister: false)
+        if stopped.wait(timeout: DispatchTime.now() + DispatchTimeInterval.seconds(5)) != DispatchTimeoutResult.success {
+            return XCTFail("Server failed to stop")
+        }
+
+        XCTAssertEqual(Kitura.httpServersAndUnixSocketPaths.count, 1, "Kitura.httpServersAndUnixSocketPaths.count is \(Kitura.httpServersAndUnixSocketPaths.count), should be 1")
+        testResponse(socketPath: socketPath, path: path, expectedBody: nil, expectedStatus: nil)
+
+        Kitura.start()
+        if started.wait(timeout: DispatchTime.now() + DispatchTimeInterval.seconds(5)) != DispatchTimeoutResult.success {
+            return XCTFail("Server failed to start")
+        }
+        XCTAssertEqual(server.unixDomainSocketPath, socketPath, "Server listening on wrong path")
+        testResponse(socketPath: socketPath, path: path, expectedBody: body)
+        Kitura.stop() // default for unregister is true
+        if stopped.wait(timeout: DispatchTime.now() + DispatchTimeInterval.seconds(5)) != DispatchTimeoutResult.success {
+            return XCTFail("Server failed to stop")
+        }
+
+        XCTAssertEqual(Kitura.httpServersAndUnixSocketPaths.count, 0, "Kitura.httpServersAndUnixSocketPaths.count is \(Kitura.httpServersAndUnixSocketPaths.count), should be 0")
+    }
+
+    private func testResponse(port: Int? = nil, socketPath: String? = nil, method: String = "get", path: String, expectedBody: String?, expectedStatus: HTTPStatusCode? = HTTPStatusCode.OK) {
+
+        performRequest(method, path: path, port: port, socketPath: socketPath, useSSL: true, useUnixSocket: (socketPath != nil), callback: { response in
             let status = response?.statusCode
             XCTAssertEqual(status, expectedStatus, "status was \(String(describing: status)), expected \(String(describing: expectedStatus))")
             do {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Depends on https://github.com/IBM-Swift/Kitura-NIO/pull/187 / https://github.com/IBM-Swift/Kitura-net/pull/296

Adds the ability to listen on a Unix domain socket, rather than an INET (TCP) port.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests added.  Updated KituraTest to run existing tests over Unix domain sockets.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
