### PR TITLE
Enable all tests on Linux

### DIFF
--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -42,8 +42,17 @@ enum SocketTypeOption {
     case unix
 }
 
-class KituraTest: XCTestCase {
+// Kitura test suites should conform to this so that TestLinuxSafeguard can
+// access the `allTests` array generically
+protocol KituraTestSuite {
+    static var allTests: [(String, (Self) -> () throws -> Void)] { get }
+    #if os(macOS)
+    // Expose defaultTestSuite from XCTestSuite
+    static var defaultTestSuite: XCTestSuite { get }
+    #endif
+}
 
+class KituraTest: XCTestCase {
     // A singleton Kitura server listening on HTTP on an INET socket
     static private(set) var httpInetServer: HTTPServer?
     // A singleton Kitura server listening on HTTPS on an INET socket

--- a/Tests/KituraTests/MiscellaneousTests.swift
+++ b/Tests/KituraTests/MiscellaneousTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Kitura
 @testable import KituraNet
 
-class MiscellaneousTests: KituraTest {
+final class MiscellaneousTests: KituraTest, KituraTestSuite {    
 
     static var allTests: [(String, (MiscellaneousTests) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestBridgingHTTPStatusCode.swift
+++ b/Tests/KituraTests/TestBridgingHTTPStatusCode.swift
@@ -30,7 +30,7 @@ import Darwin
 // to HTTPStatusCode builds and runs without error. Other existing tests
 // that import KituraNet should be sufficient to show that the typealias does not
 // interfere in that case.
-class TestBridgingHTTPStatusCode: KituraTest {
+final class TestBridgingHTTPStatusCode: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestBridgingHTTPStatusCode) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestBridgingRequestError.swift
+++ b/Tests/KituraTests/TestBridgingRequestError.swift
@@ -30,7 +30,7 @@ import Darwin
 // run without error in the absence of this import. Other existing tests that
 // import KituraContracts should be sufficient to show that the typealias does not
 // interfere in that case.
-class TestBridgingRequestError: KituraTest {
+final class TestBridgingRequestError: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestBridgingRequestError) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -20,7 +20,7 @@ import KituraContracts
 
 @testable import Kitura
 
-class TestCodableRouter: KituraTest {
+final class TestCodableRouter: KituraTest, KituraTestSuite {
     static var allTests: [(String, (TestCodableRouter) -> () throws -> Void)] {
         return [
             ("testBasicPost", testBasicPost),

--- a/Tests/KituraTests/TestContentType.swift
+++ b/Tests/KituraTests/TestContentType.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import Kitura
 
-class TestContentType: KituraTest {
+final class TestContentType: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestContentType) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -31,7 +31,7 @@ let cookieHost = "localhost"
 
 let responseBodySeparator = "RESPONSE-BODY-SEPARATOR"
 
-class TestCookies: KituraTest {
+final class TestCookies: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestCookies) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestCustomCoders.swift
+++ b/Tests/KituraTests/TestCustomCoders.swift
@@ -20,7 +20,7 @@ import KituraContracts
 
 @testable import Kitura
 
-class TestCustomCoders: KituraTest {
+final class TestCustomCoders: KituraTest, KituraTestSuite {
     static var allTests: [(String, (TestCustomCoders) -> () throws -> Void)] {
         return [
             ("testCustomCoder", testCustomCoder),

--- a/Tests/KituraTests/TestDecodingErrorExtension.swift
+++ b/Tests/KituraTests/TestDecodingErrorExtension.swift
@@ -16,7 +16,7 @@
 
 import XCTest
 
-class TestDecodingErrorExtension: XCTestCase {
+final class TestDecodingErrorExtension: XCTestCase, KituraTestSuite {
     
     static var allTests: [(String, (TestDecodingErrorExtension) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestErrors.swift
+++ b/Tests/KituraTests/TestErrors.swift
@@ -27,7 +27,7 @@ import XCTest
     import Darwin
 #endif
 
-class TestErrors: KituraTest {
+final class TestErrors: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestErrors) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestLinuxSafeguard.swift
+++ b/Tests/KituraTests/TestLinuxSafeguard.swift
@@ -14,92 +14,44 @@
  * limitations under the License.
  **/
 
-// Test disabled on Swift 4 for now due to
+// Test requires Swift 4.1 or higher due to
 // https://bugs.swift.org/browse/SR-5684
-// We will need to renable this once the bug is addressed in Swift
-// TODO: Enable this test case (see above)
-#if os(OSX) && !swift(>=4.0)
+#if os(OSX) && swift(>=4.1)
     import XCTest
 
     class TestLinuxSafeguard: XCTestCase {
+
+        func verifyCount<T: KituraTestSuite>(_ testSuite: T.Type) {
+            let linuxCount = T.allTests.count
+            let darwinCount = Int(T.defaultTestSuite.testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from \(T.self).allTests")
+        }
+
         func testVerifyLinuxTestCount() {
-            var linuxCount: Int
-            var darwinCount: Int
-
-            // MiscellaneousTests
-            linuxCount = MiscellaneousTests.allTests.count
-            darwinCount = Int(MiscellaneousTests.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from MiscellaneousTests.allTests")
-
-            // TestContentType
-            linuxCount = TestContentType.allTests.count
-            darwinCount = Int(TestContentType.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestContentType.allTests")
-
-            // TestCookies
-            linuxCount = TestCookies.allTests.count
-            darwinCount = Int(TestCookies.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestCookies.allTests")
-
-            // TestDecodeErrorExtensions
-            linuxCount = TestDecodingErrorExtension.allTests.count
-            darwinCount = Int(TestDecodingErrorExtension.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestDecodingErrorExtension.allTests")
-
-            // TestErrors
-            linuxCount = TestErrors.allTests.count
-            darwinCount = Int(TestErrors.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestErrors.allTests")
-
-            // TestMultiplicity
-            linuxCount = TestMultiplicity.allTests.count
-            darwinCount = Int(TestMultiplicity.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestMultiplicity.allTests")
-
-            // TestRequests
-            linuxCount = TestRequests.allTests.count
-            darwinCount = Int(TestRequests.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestRequests.allTests")
-
-            // TestResponse
-            linuxCount = TestResponse.allTests.count
-            darwinCount = Int(TestResponse.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestResponse.allTests")
-
-            // TestRouteRegex
-            linuxCount = TestRouteRegex.allTests.count
-            darwinCount = Int(TestRouteRegex.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestRouteRegex.allTests")
-
-            // TestRouterHTTPVerbsGenerated
-            linuxCount = TestRouterHTTPVerbsGenerated.allTests.count
-            darwinCount = Int(TestRouterHTTPVerbsGenerated.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestRouterHTTPVerbsGenerated.allTests")
-
-            // TestServer
-            linuxCount = TestServer.allTests.count
-            darwinCount = Int(TestServer.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestServer.allTests")
-
-            // TestStaticFileServer
-            linuxCount = TestStaticFileServer.allTests.count
-            darwinCount = Int(TestStaticFileServer.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestStaticFileServer.allTests")
-
-            // TestRangeHeader
-            linuxCount = TestRangeHeaderParser.allTests.count
-            darwinCount = Int(TestRangeHeaderParser.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestRangeHeaderParser.allTests")
-
-            // TestSubrouter
-            linuxCount = TestSubrouter.allTests.count
-            darwinCount = Int(TestSubrouter.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestSubrouter.allTests")
-
-            // TestTemplateEngine
-            linuxCount = TestTemplateEngine.allTests.count
-            darwinCount = Int(TestTemplateEngine.defaultTestSuite.testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from TestTemplateEngine.allTests")
+            verifyCount(MiscellaneousTests.self)
+            verifyCount(TestBridgingHTTPStatusCode.self)
+            verifyCount(TestBridgingRequestError.self)
+            verifyCount(TestCodableRouter.self)
+            verifyCount(TestContentType.self)
+            verifyCount(TestCookies.self)
+            verifyCount(TestCustomCoders.self)
+            verifyCount(TestDecodingErrorExtension.self)
+            verifyCount(TestErrors.self)
+            verifyCount(TestMediaType.self)
+            verifyCount(TestMultiplicity.self)
+            verifyCount(TestRangeHeaderDataExtensions.self)
+            verifyCount(TestRangeHeaderParser.self)
+            verifyCount(TestRequests.self)
+            verifyCount(TestResponse.self)
+            verifyCount(TestRouteRegex.self)
+            verifyCount(TestRouterHTTPVerbsGenerated.self)
+            verifyCount(TestServer.self)
+            verifyCount(TestStack.self)
+            verifyCount(TestStaticFileServer.self)
+            verifyCount(TestSubrouter.self)
+            verifyCount(TestSwaggerGeneration.self)
+            verifyCount(TestTemplateEngine.self)
+            verifyCount(TestTypeSafeMiddleware.self)
         }
     }
   #endif

--- a/Tests/KituraTests/TestMediaType.swift
+++ b/Tests/KituraTests/TestMediaType.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Kitura
 @testable import KituraNet
 
-class TestMediaType: KituraTest {
+final class TestMediaType: KituraTest, KituraTestSuite {
     
     static var allTests: [(String, (TestMediaType) -> () throws -> Void)] {
         return [
@@ -28,11 +28,13 @@ class TestMediaType: KituraTest {
             ("testAllTextSlashMediaTypeBuilder", testAllTextSlashMediaTypeBuilder),
             ("testHTMLMediaTypeBuilder", testPartsHTMLMediaTypeBuilder),
             ("testMediaCaseInsensitive", testMediaCaseInsensitive),
+            ("testIncorrectTopLevelType", testIncorrectTopLevelType),
             ("testPartsAllTextMediaTypeBuilder", testPartsAllTextMediaTypeBuilder),
             ("testPartsHTMLMediaTypeBuilder", testPartsHTMLMediaTypeBuilder),
             ("testPartsMediaCaseInsensitive", testPartsMediaCaseInsensitive),
             ("testValidMediaType", testValidMediaType),
             ("testInvalidMediaType", testInvalidMediaType),
+            ("testEmptyMediaType", testEmptyMediaType),
         ]
     }
     

--- a/Tests/KituraTests/TestMultiplicity.swift
+++ b/Tests/KituraTests/TestMultiplicity.swift
@@ -19,7 +19,7 @@ import XCTest
 @testable import Kitura
 @testable import KituraNet
 
-class TestMultiplicity: KituraTest {
+final class TestMultiplicity: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestMultiplicity) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestRangeHeader.swift
+++ b/Tests/KituraTests/TestRangeHeader.swift
@@ -18,7 +18,7 @@ import XCTest
 
 @testable import Kitura
 
-class TestRangeHeaderParser: XCTestCase {
+final class TestRangeHeaderParser: XCTestCase, KituraTestSuite {
 
     static var allTests: [(String, (TestRangeHeaderParser) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestRangeHeaderDataExtensions.swift
+++ b/Tests/KituraTests/TestRangeHeaderDataExtensions.swift
@@ -19,7 +19,15 @@ import XCTest
 
 @testable import Kitura
 
-class TestRangeHeaderDataExtensions: XCTestCase {
+final class TestRangeHeaderDataExtensions: XCTestCase, KituraTestSuite {
+
+    static var allTests: [(String, (TestRangeHeaderDataExtensions) -> () throws -> Void)] {
+        return [
+            ("testPartialDataReadWithErrorFileNotFound", testPartialDataReadWithErrorFileNotFound),
+            ("testPartialDataRead", testPartialDataRead),
+            ("testPartialDataReadEntireFile", testPartialDataReadEntireFile),
+        ]
+    }
 
     var fileUrl: URL!
 

--- a/Tests/KituraTests/TestRequests.swift
+++ b/Tests/KituraTests/TestRequests.swift
@@ -21,7 +21,7 @@ import KituraContracts
 @testable import Kitura
 @testable import KituraNet
 
-class TestRequests: KituraTest {
+final class TestRequests: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestRequests) -> () throws -> Void)] {
         return [
@@ -30,6 +30,8 @@ class TestRequests: KituraTest {
                    ("testCustomMiddlewareURLParameter", testCustomMiddlewareURLParameter),
                    ("testCustomMiddlewareURLParameterWithQueryParam", testCustomMiddlewareURLParameterWithQueryParam),
                    ("testParameters", testParameters),
+                   ("testOneParameterMultipleHandlers", testOneParameterMultipleHandlers),
+                   ("testMultipleParametersMultipleHandlers", testMultipleParametersMultipleHandlers),
                    ("testParameterExit", testParameterExit)
         ]
     }

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -26,7 +26,7 @@ import Glibc
 import Darwin
 #endif
 
-class TestResponse: KituraTest {
+final class TestResponse: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestResponse) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestRouteRegex.swift
+++ b/Tests/KituraTests/TestRouteRegex.swift
@@ -48,7 +48,7 @@ fileprivate let subrouter = { () -> Router in
     return subrouter
 }()
 
-class TestRouteRegex: KituraTest {
+final class TestRouteRegex: KituraTest, KituraTestSuite {
     static var allTests: [(String, (TestRouteRegex) -> () throws -> Void)] {
         return [
             ("testBuildRegexFromPattern", testBuildRegexFromPattern),

--- a/Tests/KituraTests/TestRouterHTTPVerbs_generated.swift
+++ b/Tests/KituraTests/TestRouterHTTPVerbs_generated.swift
@@ -26,7 +26,7 @@ import Glibc
 import Darwin
 #endif
 
-class TestRouterHTTPVerbsGenerated: KituraTest {
+final class TestRouterHTTPVerbsGenerated: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestRouterHTTPVerbsGenerated) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -20,7 +20,7 @@ import Dispatch
 import KituraNet
 @testable import Kitura
 
-class TestServer: KituraTest {
+final class TestServer: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestServer) -> () throws -> Void)] {
         var listOfTests: [(String, (TestServer) -> () throws -> Void)] = [

--- a/Tests/KituraTests/TestStack.swift
+++ b/Tests/KituraTests/TestStack.swift
@@ -18,7 +18,7 @@ import XCTest
 
 @testable import Kitura
 
-class TestStack: XCTestCase {
+final class TestStack: XCTestCase, KituraTestSuite {
 
     static var allTests: [(String, (TestStack) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -26,7 +26,7 @@ import Glibc
 import Darwin
 #endif
 
-class TestStaticFileServer: KituraTest {
+final class TestStaticFileServer: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestStaticFileServer) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestSubrouter.swift
+++ b/Tests/KituraTests/TestSubrouter.swift
@@ -27,7 +27,7 @@ import Foundation
     import Darwin
 #endif
 
-class TestSubrouter: KituraTest {
+final class TestSubrouter: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestSubrouter) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestSwaggerGeneration.swift
+++ b/Tests/KituraTests/TestSwaggerGeneration.swift
@@ -161,7 +161,7 @@ func getEmbeddedInCollectionType(id: Int, completion: (EmbeddedInCollection?, Re
     completion(nil, nil)
 }
 
-class TestSwaggerGeneration: KituraTest {
+final class TestSwaggerGeneration: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestSwaggerGeneration) -> () throws -> Void)] {
         return [

--- a/Tests/KituraTests/TestTemplateEngine.swift
+++ b/Tests/KituraTests/TestTemplateEngine.swift
@@ -28,7 +28,7 @@ import Glibc
 import Darwin
 #endif
 
-class TestTemplateEngine: KituraTest {
+final class TestTemplateEngine: KituraTest, KituraTestSuite {
 
     static var allTests: [(String, (TestTemplateEngine) -> () throws -> Void)] {
         return [
@@ -45,7 +45,19 @@ class TestTemplateEngine: KituraTest {
              testRenderWithExtensionAndWithoutDefaultTemplateEngineAfterSettingViewsPath),
             ("testAddWithFileExtensions", testAddWithFileExtensions),
             ("testAddWithFileExtensionsWithoutTheDefaultOne",
-             testAddWithFileExtensionsWithoutTheDefaultOne)
+             testAddWithFileExtensionsWithoutTheDefaultOne),
+            ("testEmptyTemplateNameCodable", testEmptyTemplateNameCodable),
+            ("testMissingExtensionCodable", testMissingExtensionCodable),
+            ("testNoDefaultEngineCodable", testNoDefaultEngineCodable),
+            ("testCodableRender", testCodableRender),
+            ("testCodableRenderWithServer", testCodableRenderWithServer),
+            ("testCodableRenderWithOptionsWithServer", testCodableRenderWithOptionsWithServer),
+            ("testCodableRenderWithServerAndSubRouter", testCodableRenderWithServerAndSubRouter),
+            ("testCodableRenderWithExtensionAndWithoutDefaultTemplateEngine", testCodableRenderWithExtensionAndWithoutDefaultTemplateEngine),
+            ("testCodableRenderWithExtensionAndWithoutDefaultTemplateEngineAfterSettingViewsPath", testCodableRenderWithExtensionAndWithoutDefaultTemplateEngineAfterSettingViewsPath),
+            ("testCodableAddWithFileExtensions", testCodableAddWithFileExtensions),
+            ("testCodableAddWithFileExtensionsWithoutTheDefaultOne", testCodableAddWithFileExtensionsWithoutTheDefaultOne),
+            ("testCodableRenderWithTuple", testCodableRenderWithTuple),
         ]
     }
     

--- a/Tests/KituraTests/TestTypeSafeMiddleware.swift
+++ b/Tests/KituraTests/TestTypeSafeMiddleware.swift
@@ -20,7 +20,7 @@ import KituraContracts
 
 @testable import Kitura
 
-class TestTypeSafeMiddleware: KituraTest {
+final class TestTypeSafeMiddleware: KituraTest, KituraTestSuite {
     static var allTests: [(String, (TestTypeSafeMiddleware) -> () throws -> Void)] {
         return [
             ("testSingleMiddlewareGetSingleton", testSingleMiddlewareGetSingleton),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Many of Kitura's tests are missing from the `allTests` definition in their respective test classes, and so do not get picked up by XCTest on Linux.

There is actually a test designed to catch this: TestLinuxSafeguard is a macOS-only test that verifies that the count of tests returned by `XCTestCase.defaultTestSuite` is equal to the number declared in `allTests` (doesn't check the names of the tests, but good enough).

Unfortunately there are two problems with that test:  it doesn't automatically pick up new test classes - so must itself be updated manually when new sets of tests are added - and it was disabled back when Swift 4 had an issue.

This PR re-enables the safeguard test, guarded to run on Swift 4.1 or higher, and changes the way the test is written to remove a lot of code duplication (which will make it much easier to add more test classes the future).  It also adds all the missing test classes and tests so that they are run on Linux.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While testing another issue, I noticed a significant discrepancy between the number of tests running on Linux (212) vs Mac (249): https://travis-ci.org/IBM-Swift/Kitura/builds/514592479

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
