### PR TITLE
Require TypeDecoder 1.3 on Swift 4.0 and 4.1

### DIFF
--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
-        .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.1.0")
+        .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0")
     ],
     targets: [
         .target(

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.1.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
-        .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.1.0")
+        .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Currently our `Package@swift-4.2.swift` specifies TypeDecoder 1.3.  This is so that the Swagger generator can take advantage of `ValidSingleCodingValueProvider` if it is used.

For consistency, we should make the same version required when building on Swift 4.0 and 4.1.