### PR TITLE
Add the NIO switch to the 4.x.x Package.swift files

### DIFF
--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -19,6 +19,14 @@
 import PackageDescription
 import Foundation
 
+var kituraNetPackage: Package.Dependency
+
+if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
+} else {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0")
+}
+
 let package = Package(
     name: "Kitura",
     products: [
@@ -28,7 +36,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
+        kituraNetPackage,
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0")

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -19,6 +19,14 @@
 import PackageDescription
 import Foundation
 
+var kituraNetPackage: Package.Dependency
+
+if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
+} else {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0")
+}
+
 let package = Package(
     name: "Kitura",
     products: [
@@ -28,7 +36,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
+        kituraNetPackage,
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0")

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -19,6 +19,14 @@
 import PackageDescription
 import Foundation
 
+var kituraNetPackage: Package.Dependency
+
+if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "1.0.0")
+} else {
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0")
+}
+
 let package = Package(
     name: "Kitura",
     products: [
@@ -28,7 +36,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
+        kituraNetPackage,
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),


### PR DESCRIPTION
The Kitura-NIO switch needs to be supported on 4.x.x versions of the manifest file.

## Description
PR https://github.com/IBM-Swift/Kitura/pull/1436 removed support for KITURA_NIO. I think this was based on the decision that we'd be supporting Kitura-NIO only with Swift 5 (and SwiftNIO 2). However, we now have a `kitura-nio-1.0` branch on `Kitura-NIO` and we run Kitura tests in the CI for this. This needs Kitura-NIO support for Kitura with swift 4.x.x too.