### PR TITLE
Add option to only listen on one address

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,9 +22,9 @@ import Foundation
 var kituraNetPackage: Package.Dependency
 
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.0.0")
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.1.0")
 } else {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0")
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0")
 }
 
 let package = Package(

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0")

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0")

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -28,7 +28,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.2.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -226,12 +226,12 @@ public class Kitura {
         serverLock.lock()
         var numberOfFailures = 0
         for (server, port, address) in httpServersAndPorts {
-            Log.verbose("Starting an HTTP Server on port \(port) with address \(String(describing: address))...")
+            Log.verbose("Starting an HTTP Server on \(address ?? "*"):\(port)...")
             do {
                 try server.listen(on: port, address: address)
             } catch {
                 numberOfFailures += 1
-                Log.error("Error listening on port \(port): \(error). Use server.failed(callback:) to handle")
+                Log.error("Error listening on \(address ?? "*"):\(port): \(error). Use server.failed(callback:) to handle")
             }
         }
         for (server, path) in httpServersAndUnixSocketPaths {
@@ -243,12 +243,12 @@ public class Kitura {
             }
         }
         for (server, port, address) in fastCGIServersAndPorts {
-            Log.verbose("Starting a FastCGI Server on port \(port)...")
+            Log.verbose("Starting a FastCGI Server on \(address ?? "*"):\(port)...")
             do {
                 try server.listen(on: port, address: address)
             } catch {
                 numberOfFailures += 1
-                Log.error("Error listening on port \(port): \(error). Use server.failed(callback:) to handle")
+                Log.error("Error listening on \(address ?? "*"):\(port): \(error). Use server.failed(callback:) to handle")
             }
         }
         serverLock.unlock()
@@ -272,7 +272,7 @@ public class Kitura {
     public class func stop(unregister: Bool = true) {
         serverLock.lock()
         for (server, port, address) in httpServersAndPorts {
-            Log.verbose("Stopping HTTP Server on port \(port) with address \(String(describing: address))...")
+            Log.verbose("Stopping HTTP Server on \(address ?? "*"):\(port)...")
             server.stop()
         }
 
@@ -282,7 +282,7 @@ public class Kitura {
         }
 
         for (server, port, address) in fastCGIServersAndPorts {
-            Log.verbose("Stopping FastCGI Server on port \(port) with address \(String(describing: address))...")
+            Log.verbose("Stopping FastCGI Server on \(address ?? "*"):\(port)...")
             server.stop()
         }
 

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -59,17 +59,17 @@ public class Kitura {
     /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
     ///```
     /// - Parameter onPort: The port to listen on.
-    /// - Parameter with: The `ServerDelegate` to use.
-    /// - Parameter address: The address to listen on, for example "localhost". The default is nil, which listens on
+    /// - Parameter onAddress: The address to listen on, for example "localhost". The default is nil, which listens on
     ///             all addresses.
+    /// - Parameter with: The `ServerDelegate` to use.
     /// - Parameter withSSL: The `sslConfig` to use.
     /// - Parameter keepAlive: The maximum number of additional requests to permit per Keep-Alive connection. Defaults to `.unlimited`. If set to `.disabled`, Keep-Alive will not be permitted.
     /// - Parameter allowPortReuse: Determines whether the listener port may be shared with other Kitura instances (`SO_REUSEPORT`). Defaults to `false`. If the specified port is already in use by another listener that has not allowed sharing, the server will fail to start.
     /// - Returns: The created `HTTPServer`.
     @discardableResult
     public class func addHTTPServer(onPort port: Int,
+                                    onAddress address: String? = nil,
                                     with delegate: ServerDelegate,
-                                    address: String? = nil,
                                     withSSL sslConfig: SSLConfig?=nil,
                                     keepAlive keepAliveState: KeepAliveState = .unlimited,
                                     allowPortReuse: Bool = false) -> HTTPServer {
@@ -132,15 +132,15 @@ public class Kitura {
     /// Kitura.addFastCGIServer(onPort: 8080, with: router)
     ///```
     /// - Parameter onPort: The port to listen on.
-    /// - Parameter with: The `ServerDelegate` to use.
-    /// - Parameter address: The address to listen on, for example "localhost". The default is nil, which listens on
+    /// - Parameter onAddress: The address to listen on, for example "localhost". The default is nil, which listens on
     ///             all addresses.
+    /// - Parameter with: The `ServerDelegate` to use.
     /// - Parameter allowPortReuse: Determines whether the listener port may be shared with other Kitura instances (`SO_REUSEPORT`). Defaults to `false`. If the specified port is already in use by another listener that has not allowed sharing, the server will fail to start.
     /// - Returns: The created `FastCGIServer`.
     @discardableResult
     public class func addFastCGIServer(onPort port: Int,
+                                       onAddress address: String? = nil,
                                        with delegate: ServerDelegate,
-                                       address: String? = nil,
                                        allowPortReuse: Bool = false) -> FastCGIServer {
         let server = FastCGI.createServer()
         server.delegate = delegate

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -34,7 +34,7 @@ import Dispatch
      response.send("Hello world")
      next()
  }
- Kitura.addHTTPServer(onPort: 8080, with: router)
+ Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
  Kitura.run()
  ```
  */
@@ -42,7 +42,7 @@ public class Kitura {
 
     // Socket types that we currently support
     private enum ListenerType {
-        case inet(Int)
+        case inet(Int, String?) // port, address
         case unix(String)
     }
 
@@ -56,10 +56,12 @@ public class Kitura {
     ///### Usage Example: ###
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router)
+    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
     ///```
     /// - Parameter onPort: The port to listen on.
     /// - Parameter with: The `ServerDelegate` to use.
+    /// - Parameter address: The address to listen on, for example "localhost". The default is nil, which listens on
+    ///             all addresses.
     /// - Parameter withSSL: The `sslConfig` to use.
     /// - Parameter keepAlive: The maximum number of additional requests to permit per Keep-Alive connection. Defaults to `.unlimited`. If set to `.disabled`, Keep-Alive will not be permitted.
     /// - Parameter allowPortReuse: Determines whether the listener port may be shared with other Kitura instances (`SO_REUSEPORT`). Defaults to `false`. If the specified port is already in use by another listener that has not allowed sharing, the server will fail to start.
@@ -67,10 +69,12 @@ public class Kitura {
     @discardableResult
     public class func addHTTPServer(onPort port: Int,
                                     with delegate: ServerDelegate,
+                                    address: String? = nil,
                                     withSSL sslConfig: SSLConfig?=nil,
                                     keepAlive keepAliveState: KeepAliveState = .unlimited,
                                     allowPortReuse: Bool = false) -> HTTPServer {
-        return Kitura._addHTTPServer(on: .inet(port), with: delegate, withSSL: sslConfig, keepAlive: keepAliveState, allowPortReuse: allowPortReuse)
+        return Kitura._addHTTPServer(on: .inet(port, address), with: delegate, withSSL: sslConfig,
+                                     keepAlive: keepAliveState, allowPortReuse: allowPortReuse)
     }
 
     /// Add an HTTPServer on a Unix domain socket path with a delegate.
@@ -108,8 +112,8 @@ public class Kitura {
         server.allowPortReuse = allowPortReuse
         serverLock.lock()
         switch listenType {
-        case .inet(let port):
-            httpServersAndPorts.append((server: server, port: port))
+        case .inet(let port, let address):
+            httpServersAndPorts.append((server: server, port: port, address: address))
         case .unix(let socketPath):
             httpServersAndUnixSocketPaths.append((server: server, socketPath: socketPath))
         }
@@ -129,17 +133,20 @@ public class Kitura {
     ///```
     /// - Parameter onPort: The port to listen on.
     /// - Parameter with: The `ServerDelegate` to use.
+    /// - Parameter address: The address to listen on, for example "localhost". The default is nil, which listens on
+    ///             all addresses.
     /// - Parameter allowPortReuse: Determines whether the listener port may be shared with other Kitura instances (`SO_REUSEPORT`). Defaults to `false`. If the specified port is already in use by another listener that has not allowed sharing, the server will fail to start.
     /// - Returns: The created `FastCGIServer`.
     @discardableResult
     public class func addFastCGIServer(onPort port: Int,
                                        with delegate: ServerDelegate,
+                                       address: String? = nil,
                                        allowPortReuse: Bool = false) -> FastCGIServer {
         let server = FastCGI.createServer()
         server.delegate = delegate
         server.allowPortReuse = allowPortReuse
         serverLock.lock()
-        fastCGIServersAndPorts.append((server: server, port: port))
+        fastCGIServersAndPorts.append((server: server, port: port, address: address))
         serverLock.unlock()
         return server
     }
@@ -153,7 +160,7 @@ public class Kitura {
     /// Make all registered servers start listening on their port.
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router)
+    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
     /// Kitura.run()
     ///```
     /// Make all registered servers start listening on their port and exit if any fail to start.
@@ -183,7 +190,7 @@ public class Kitura {
     /// Make all registered servers start listening on their port.
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router)
+    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
     /// Kitura.start()
     ///```
     public class func start() {
@@ -212,16 +219,16 @@ public class Kitura {
     /// Make all registered servers start listening on their port.
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router)
+    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
     /// Kitura.startWithStatus() // Returns the number of failed server starts.
     ///```
     public class func startWithStatus() -> Int {
         serverLock.lock()
         var numberOfFailures = 0
-        for (server, port) in httpServersAndPorts {
-            Log.verbose("Starting an HTTP Server on port \(port)...")
+        for (server, port, address) in httpServersAndPorts {
+            Log.verbose("Starting an HTTP Server on port \(port) with address \(String(describing: address))...")
             do {
-                try server.listen(on: port)
+                try server.listen(on: port, address: address)
             } catch {
                 numberOfFailures += 1
                 Log.error("Error listening on port \(port): \(error). Use server.failed(callback:) to handle")
@@ -235,10 +242,10 @@ public class Kitura {
                 Log.error("Error listening on path \(path): \(error). Use server.failed(callback:) to handle")
             }
         }
-        for (server, port) in fastCGIServersAndPorts {
+        for (server, port, address) in fastCGIServersAndPorts {
             Log.verbose("Starting a FastCGI Server on port \(port)...")
             do {
-                try server.listen(on: port)
+                try server.listen(on: port, address: address)
             } catch {
                 numberOfFailures += 1
                 Log.error("Error listening on port \(port): \(error). Use server.failed(callback:) to handle")
@@ -256,7 +263,7 @@ public class Kitura {
     /// Make all registered servers stop listening on their port.
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router)
+    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
     /// Kitura.start()
     /// Kitura.stop()
     ///```
@@ -264,8 +271,8 @@ public class Kitura {
     /// - Parameter unregister: If servers should be unregistered after they are stopped (default true).
     public class func stop(unregister: Bool = true) {
         serverLock.lock()
-        for (server, port) in httpServersAndPorts {
-            Log.verbose("Stopping HTTP Server on port \(port)...")
+        for (server, port, address) in httpServersAndPorts {
+            Log.verbose("Stopping HTTP Server on port \(port) with address \(String(describing: address))...")
             server.stop()
         }
 
@@ -274,8 +281,8 @@ public class Kitura {
             server.stop()
         }
 
-        for (server, port) in fastCGIServersAndPorts {
-            Log.verbose("Stopping FastCGI Server on port \(port)...")
+        for (server, port, address) in fastCGIServersAndPorts {
+            Log.verbose("Stopping FastCGI Server on port \(port) with address \(String(describing: address))...")
             server.stop()
         }
 
@@ -289,7 +296,7 @@ public class Kitura {
 
     typealias Port = Int
     internal static let serverLock = NSLock()
-    internal private(set) static var httpServersAndPorts = [(server: HTTPServer, port: Port)]()
+    internal private(set) static var httpServersAndPorts = [(server: HTTPServer, port: Port, address: String?)]()
     internal private(set) static var httpServersAndUnixSocketPaths = [(server: HTTPServer, socketPath: String)]()
-    internal private(set) static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port)]()
+    internal private(set) static var fastCGIServersAndPorts = [(server: FastCGIServer, port: Port, address: String?)]()
 }

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -34,7 +34,7 @@ import Dispatch
      response.send("Hello world")
      next()
  }
- Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
+ Kitura.addHTTPServer(onPort: 8080, onAddress: "localhost", with: router)
  Kitura.run()
  ```
  */
@@ -56,7 +56,7 @@ public class Kitura {
     ///### Usage Example: ###
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
+    /// Kitura.addHTTPServer(onPort: 8080, onAddress: "localhost", with: router)
     ///```
     /// - Parameter onPort: The port to listen on.
     /// - Parameter onAddress: The address to listen on, for example "localhost". The default is nil, which listens on
@@ -129,7 +129,7 @@ public class Kitura {
     ///### Usage Example: ###
     ///```swift
     /// let router = Router()
-    /// Kitura.addFastCGIServer(onPort: 8080, with: router)
+    /// Kitura.addFastCGIServer(onPort: 8080, onAddress: "localhost", with: router)
     ///```
     /// - Parameter onPort: The port to listen on.
     /// - Parameter onAddress: The address to listen on, for example "localhost". The default is nil, which listens on
@@ -160,7 +160,7 @@ public class Kitura {
     /// Make all registered servers start listening on their port.
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
+    /// Kitura.addHTTPServer(onPort: 8080, onAddress: "localhost", with: router)
     /// Kitura.run()
     ///```
     /// Make all registered servers start listening on their port and exit if any fail to start.
@@ -190,7 +190,7 @@ public class Kitura {
     /// Make all registered servers start listening on their port.
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
+    /// Kitura.addHTTPServer(onPort: 8080, onAddress: "localhost", with: router)
     /// Kitura.start()
     ///```
     public class func start() {
@@ -219,7 +219,7 @@ public class Kitura {
     /// Make all registered servers start listening on their port.
     ///```swift
     /// let router = Router()
-    /// Kitura.addHTTPServer(onPort: 8080, with: router, address: "localhost")
+    /// Kitura.addHTTPServer(onPort: 8080, onAddress: "localhost", with: router)
     /// Kitura.startWithStatus() // Returns the number of failed server starts.
     ///```
     public class func startWithStatus() -> Int {

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -194,7 +194,7 @@ class KituraTest: XCTestCase {
         }
 
         do {
-            try server.listen(on: 0)
+            try server.listen(on: 0, address: "localhost")
 
             if useSSL {
                 KituraTest.httpsInetServer = server

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -47,9 +47,9 @@ final class TestServer: KituraTest, KituraTestSuite {
 
     private func setupServerAndExpectations(expectStart: Bool, expectStop: Bool, expectFail: Bool, httpPort: Int?=nil, fastCgiPort: Int?=nil) {
         let router = Router()
-        let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? 0, with: router, address: "localhost")
-        let fastCgiServer = useNIO ? FastCGIServer() : Kitura.addFastCGIServer(onPort: fastCgiPort ?? 0, with: router,
-                                                                               address: "localhost")
+        let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? 0, onAddress: "localhost", with: router)
+        let fastCgiServer = useNIO ? FastCGIServer() : Kitura.addFastCGIServer(onPort: fastCgiPort ?? 0,
+                                                                               onAddress: "localhost", with: router)
 
         if expectStart {
             let httpStarted = expectation(description: "HTTPServer started()")

--- a/Tests/KituraTests/TestServer.swift
+++ b/Tests/KituraTests/TestServer.swift
@@ -47,8 +47,9 @@ final class TestServer: KituraTest, KituraTestSuite {
 
     private func setupServerAndExpectations(expectStart: Bool, expectStop: Bool, expectFail: Bool, httpPort: Int?=nil, fastCgiPort: Int?=nil) {
         let router = Router()
-        let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? 0, with: router)
-        let fastCgiServer = useNIO ? FastCGIServer() : Kitura.addFastCGIServer(onPort: fastCgiPort ?? 0, with: router)
+        let httpServer = Kitura.addHTTPServer(onPort: httpPort ?? 0, with: router, address: "localhost")
+        let fastCgiServer = useNIO ? FastCGIServer() : Kitura.addFastCGIServer(onPort: fastCgiPort ?? 0, with: router,
+                                                                               address: "localhost")
 
         if expectStart {
             let httpStarted = expectation(description: "HTTPServer started()")


### PR DESCRIPTION
This fixes https://github.com/IBM-Swift/Kitura/issues/1450.

## Description
Add address parameter to `Kitura.addHTTPServer()` and `Kitura.addFastCGIServer()` which are passed to Kitura-Net and Kitura-NIO for `Server.listen()`.

Feedback is very welcome, especially if I accidentally missed some of your coding convention. I would pay special attention to the parameter order that I used for the methods.

## Motivation and Context
This is necessary to fix https://github.com/IBM-Swift/Kitura/issues/1450.

## How Has This Been Tested?
Manual testing by myself. I also modified the test harness to use the new code path.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
