### PR TITLE
Add a StaticFileServer option to fallback to the index page

### DIFF
--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -41,6 +41,8 @@ extension StaticFileServer {
         /// Whether accepts range requests or not
         let acceptRanges: Bool
 
+        /// A default index to be served if the requested path is not found.
+        /// This is intended to be used by single page applications.
         let defaultIndex: String?
 
         init(servingFilesPath: String, options: StaticFileServer.Options,
@@ -108,6 +110,11 @@ extension StaticFileServer {
                 return
             }
 
+            // We haven't been able to find the requested path. For single page applications,
+            // a default fallback index may be configured. Before we serve the default index
+            // we make sure that this is a not a direct file request. The best check we could
+            // run for that is if the requested file contains a '.'. This is inspired by:
+            // https://github.com/bripkens/connect-history-api-fallback
             let isDirectFileAccess = filePath.split(separator: "/").last?.contains(".") ?? false
             if isDirectFileAccess == false, let defaultIndex = self.defaultIndex {
                 serveDefaultIndex(defaultIndex: defaultIndex, response: response)

--- a/Sources/Kitura/staticFileServer/FileServer.swift
+++ b/Sources/Kitura/staticFileServer/FileServer.swift
@@ -41,7 +41,7 @@ extension StaticFileServer {
         /// Whether accepts range requests or not
         let acceptRanges: Bool
 
-        let fallbackToDefaultIndex: Bool
+        let defaultIndex: String?
 
         init(servingFilesPath: String, options: StaticFileServer.Options,
              responseHeadersSetter: ResponseHeadersSetter?) {
@@ -51,7 +51,7 @@ extension StaticFileServer {
             self.acceptRanges = options.acceptRanges
             self.servingFilesPath = servingFilesPath
             self.responseHeadersSetter = responseHeadersSetter
-            self.fallbackToDefaultIndex = options.fallbackToDefaultIndex
+            self.defaultIndex = options.defaultIndex
         }
 
         func getFilePath(from request: RouterRequest) -> String? {
@@ -108,14 +108,15 @@ extension StaticFileServer {
                 return
             }
 
-            if fallbackToDefaultIndex {
-                serveDefaultIndex(response: response)
+            let isDirectFileAccess = filePath.split(separator: "/").last?.contains(".") ?? false
+            if isDirectFileAccess == false, let defaultIndex = self.defaultIndex {
+                serveDefaultIndex(defaultIndex: defaultIndex, response: response)
             }
         }
 
-        private func serveDefaultIndex(response: RouterResponse) {
+        fileprivate func serveDefaultIndex(defaultIndex: String, response: RouterResponse) {
             do {
-                try response.send(fileName: servingFilesPath + "/index.html")
+                try response.send(fileName: servingFilesPath + defaultIndex)
             } catch {
                  response.error = Error.failedToRedirectRequest(path: servingFilesPath + "/", chainedError: error)
             }

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -65,6 +65,7 @@ open class StaticFileServer: RouterMiddleware {
         let serveIndexForDirectory: Bool
         let cacheOptions: CacheOptions
         let acceptRanges: Bool
+        let fallbackToDefaultIndex: Bool
 
         /// Initialize an Options instance.
         ///
@@ -78,12 +79,14 @@ open class StaticFileServer: RouterMiddleware {
         /// "/" when the requested path is a directory.
         /// - Parameter cacheOptions: cache options for StaticFileServer.
         public init(possibleExtensions: [String] = [], serveIndexForDirectory: Bool = true,
-             redirect: Bool = true, cacheOptions: CacheOptions = CacheOptions(), acceptRanges: Bool = true) {
+             redirect: Bool = true, cacheOptions: CacheOptions = CacheOptions(), acceptRanges: Bool = true,
+             fallbackToDefaultIndex: Bool = false) {
             self.possibleExtensions = possibleExtensions
             self.serveIndexForDirectory = serveIndexForDirectory
             self.redirect = redirect
             self.cacheOptions = cacheOptions
             self.acceptRanges = acceptRanges
+            self.fallbackToDefaultIndex = fallbackToDefaultIndex
         }
     }
 

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -80,9 +80,9 @@ open class StaticFileServer: RouterMiddleware {
         /// - Parameter cacheOptions: cache options for StaticFileServer.
         /// - Parameter defaultIndex: A default index, like "/index.html", to be served if the
         /// requested path is not found. This is intended to be used by single page applications
-        /// that wish to fallback to a default index when a requested path is not found.
-        /// It will be assumed that the default index is reachable from the root directory
-        /// configured with the StaticFileServer. Here's a usage example:
+        /// that wish to fallback to a default index when a requested path is not found, and where
+        /// that path is not a file request. It will be assumed that the default index is reachable
+        /// from the root directory configured with the StaticFileServer. Here's a usage example:
         /// ```swift
         /// let router = Router()
         /// router.all("/", middleware: StaticFileServer(defaultIndex: "/index.html"))

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -65,7 +65,7 @@ open class StaticFileServer: RouterMiddleware {
         let serveIndexForDirectory: Bool
         let cacheOptions: CacheOptions
         let acceptRanges: Bool
-        let fallbackToDefaultIndex: Bool
+        let defaultIndex: String?
 
         /// Initialize an Options instance.
         ///
@@ -78,18 +78,24 @@ open class StaticFileServer: RouterMiddleware {
         /// - Parameter redirect: an indication whether to redirect to trailing
         /// "/" when the requested path is a directory.
         /// - Parameter cacheOptions: cache options for StaticFileServer.
-        /// - Parameter fallbackToDefaultIndex: an indication to serve the "index.html"
-        /// if a requested path is not found. This is intended to be used by single page
-        /// applications.
+        /// - Parameter defaultIndex: A default index, like "/index.html", to be served if the
+        /// requested path is not found. This is intended to be used by single page applications
+        /// that wish to fallback to a default index when a requested path is not found.
+        /// It will be assumed that the default index is reachable from the root directory
+        /// configured with the StaticFileServer. Here's a usage example:
+        /// ```swift
+        /// let router = Router()
+        /// router.all("/", middleware: StaticFileServer(defaultIndex: "/index.html"))
+        /// ```
         public init(possibleExtensions: [String] = [], serveIndexForDirectory: Bool = true,
              redirect: Bool = true, cacheOptions: CacheOptions = CacheOptions(), acceptRanges: Bool = true,
-             fallbackToDefaultIndex: Bool = false) {
+             defaultIndex: String? = nil) {
             self.possibleExtensions = possibleExtensions
             self.serveIndexForDirectory = serveIndexForDirectory
             self.redirect = redirect
             self.cacheOptions = cacheOptions
             self.acceptRanges = acceptRanges
-            self.fallbackToDefaultIndex = fallbackToDefaultIndex
+            self.defaultIndex = defaultIndex
         }
     }
 

--- a/Sources/Kitura/staticFileServer/StaticFileServer.swift
+++ b/Sources/Kitura/staticFileServer/StaticFileServer.swift
@@ -78,6 +78,9 @@ open class StaticFileServer: RouterMiddleware {
         /// - Parameter redirect: an indication whether to redirect to trailing
         /// "/" when the requested path is a directory.
         /// - Parameter cacheOptions: cache options for StaticFileServer.
+        /// - Parameter fallbackToDefaultIndex: an indication to serve the "index.html"
+        /// if a requested path is not found. This is intended to be used by single page
+        /// applications.
         public init(possibleExtensions: [String] = [], serveIndexForDirectory: Bool = true,
              redirect: Bool = true, cacheOptions: CacheOptions = CacheOptions(), acceptRanges: Bool = true,
              fallbackToDefaultIndex: Bool = false) {

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -63,6 +63,7 @@ final class TestStaticFileServer: KituraTest, KituraTestSuite {
             ("testStaticFileServerRedirectPreservingQueryParams", testStaticFileServerRedirectPreservingQueryParams),
             ("testFallbackToDefaultIndex", testFallbackToDefaultIndex),
             ("testFallbackToDefaultIndexFailsIfOptionNotSet", testFallbackToDefaultIndexFailsIfOptionNotSet),
+            ("testFallbackToDefaultIndexWithSubrouter", testFallbackToDefaultIndexWithSubrouter),
         ]
     }
 


### PR DESCRIPTION
Add a StaticFileServer option to fallback to the index page

## Description
This commit adds a new option to the `StaticFileServer.Options` class to enable
fallback to the index.html. This is intended to be used only by single page
applications. Just before the static file server returns a 404, we check if
this option is configured and serve the default index page if it is. The webapp
takes care of the rendering.

## Motivation and Context
Single page applications use only one index file that is accessible by web
browsers, which is usually the index.html, which also serves as a landing page.
All the other pages are accessible only from the landing page. If the users
bypasses the index page to directly visit an inner page, or if they try to
refresh an inner page, the static file server returns a 404  error. Some SPAs
might wish to have a fallback feature where the static file server
serves the index.html in the event of such user activity.

This is in response to #1329 

## How Has This Been Tested?
This has been tested with a user's single-page application.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.


## Caveat
In a single page application, when we decide to serve the index page when anything other than the landing page is requested for, we fall into a tricky situation when it comes to responding to invalid paths. For example, `/help/contact` may be a valid path but `/help/contact/dfdfdf` may be in invalid path. With the fallback option in place, it is difficult to differentiate between a valid non-landing page path and an invalid page. There are two different approaches followed by some popular single-page apps:
 - Default to index: example: `mail.google.com` accepts any invalid path like `https://mail.google.com/mail/#inbox/dsdsd/dsds` and falls back to `https://mail.google.com/mail/#inbox`, returning HTTP status code 200.
 -  Return 404: example: `twitter.com` returns 404 for invalid paths.

With the current implementation, we'd always return status code 200. The javascript running in the browser can detect an invalid path and still show a message indicating 404.