### PR TITLE
Swift 5.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0.1 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
     - os: osx
       osx_image: xcode9.2
       sudo: required
@@ -72,10 +72,11 @@ matrix:
       osx_image: xcode10.2
       sudo: required
       env: KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel"
-    - os: osx
-      osx_image: xcode10.2
-      sudo: required
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
+# Awaiting xcode11 image from Travis
+#    - os: osx
+#      osx_image: xcode10.2
+#      sudo: required
+#      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
       osx_image: xcode10.2
       sudo: required
       env: KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel"
-# Awaiting xcode11 image from Travis
+# Awaiting xcode11 image from Travis.
 #    - os: osx
 #      osx_image: xcode10.2
 #      sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
       osx_image: xcode10.2
       sudo: required
       env: KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel"
-# Awaiting xcode11 image from Travis.
+# Awaiting xcode11 image from Travis
 #    - os: osx
 #      osx_image: xcode10.2
 #      sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
+      env: DOCKER_IMAGE=swift:5.0.1 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
     - os: osx
       osx_image: xcode9.2
       sudo: required
@@ -79,7 +79,7 @@ matrix:
 #      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
 
 before_install:
-  - git clone https://github.com/IBM-Swift/Package-Builder.git
+  - git clone https://github.com/IBM-Swift/Package-Builder.git -b avoidSwiftOnMountedVolume
 
 script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
 #      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
 
 before_install:
-  - git clone https://github.com/IBM-Swift/Package-Builder.git -b libseccomp
+  - git clone https://github.com/IBM-Swift/Package-Builder.git
 
 script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
 #      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
 
 before_install:
-  - git clone https://github.com/IBM-Swift/Package-Builder.git -b avoidSwiftOnMountedVolume
+  - git clone https://github.com/IBM-Swift/Package-Builder.git -b libseccomp
 
 script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/Sources/Kitura/RouterRequest.swift
+++ b/Sources/Kitura/RouterRequest.swift
@@ -19,6 +19,11 @@ import KituraNet
 import Socket
 import LoggerAPI
 import KituraContracts
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
 
 // MARK: RouterRequest
 

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -19,7 +19,11 @@ import KituraTemplateEngine
 import LoggerAPI
 import Foundation
 import KituraContracts
-
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
 
 // MARK: RouterResponse
 

--- a/Sources/Kitura/staticFileServer/RangeHeader.swift
+++ b/Sources/Kitura/staticFileServer/RangeHeader.swift
@@ -77,7 +77,7 @@ extension RangeHeader {
         // parse all ranges
         var ranges: [Range<UInt64>] = []
         rangeStrings.forEach { rangeString in
-            var range = rangeString.components(separatedBy: "-")
+            let range = rangeString.components(separatedBy: "-")
             guard range.count > 1 else {
                 // one range is malformed
                 return

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -202,7 +202,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
 
             .run()
         #else
-        print("Test temporarily disabled for 5.1: see SR-xxxxx")
+        print("Test temporarily disabled for 5.1: see SR-11012")
         #endif
     }
 
@@ -680,7 +680,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
 
             .run()
         #else
-        print("Test temporarily disabled for 5.1: see SR-xxxxx")
+        print("Test temporarily disabled for 5.1: see SR-11012")
         #endif
     }
 

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -148,7 +148,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     }
 
     func testBasicPost() {
-        #if swift(<5.1)
+        #if !swift(>=5.1)
         router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
             print("POST on /users for user \(user)")
             respondWith(user, nil)
@@ -627,7 +627,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     }
 
     func testErrorOverridesBody() {
-        #if swift(<5.1)
+        #if !swift(>=5.1)
         let status = Status("This should not be sent")
         router.get("/status") { (id: Int, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, .conflict) }
         router.post("/status") { (status: Status, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, .conflict) }

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -23,7 +23,7 @@ import KituraContracts
 final class TestCodableRouter: KituraTest, KituraTestSuite {
     static var allTests: [(String, (TestCodableRouter) -> () throws -> Void)] {
         return [
-            ("testBasicPost", testBasicPost),
+            ("testBasicPost", testBasicPost),  // Slow compile on 5.1
             ("testBasicPostIdentifier", testBasicPostIdentifier),
             ("testBasicGetSingleton", testBasicGetSingleton),
             ("testBasicGetArray", testBasicGetArray),
@@ -35,7 +35,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
             ("testBasicPatch", testBasicPatch),
             ("testJoinPath", testJoinPath),
             ("testRouteWithTrailingSlash", testRouteWithTrailingSlash),
-            ("testErrorOverridesBody", testErrorOverridesBody),
+            ("testErrorOverridesBody", testErrorOverridesBody),  // Slow compile on 5.1
             ("testRouteParameters", testRouteParameters),
             ("testCodableRoutesWithBodyParsingFail", testCodableRoutesWithBodyParsingFail),
             ("testCodableGetSingleQueryParameters", testCodableGetSingleQueryParameters),
@@ -148,6 +148,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     }
 
     func testBasicPost() {
+        #if swift(<5.1)
         router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
             print("POST on /users for user \(user)")
             respondWith(user, nil)
@@ -198,10 +199,11 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
             .request("post", path: "/urlencoded", urlEncodedString: "invalidEncoding")
             .hasStatus(.unprocessableEntity)
             .hasData()
-            
-
 
             .run()
+        #else
+        print("Test temporarily disabled for 5.1: see SR-xxxxx")
+        #endif
     }
 
     func testBasicPostIdentifier() {
@@ -625,6 +627,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     }
 
     func testErrorOverridesBody() {
+        #if swift(<5.1)
         let status = Status("This should not be sent")
         router.get("/status") { (id: Int, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, .conflict) }
         router.post("/status") { (status: Status, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, .conflict) }
@@ -676,6 +679,9 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
             .hasData(conflict)
 
             .run()
+        #else
+        print("Test temporarily disabled for 5.1: see SR-xxxxx")
+        #endif
     }
 
     func testRouteParameters() {
@@ -950,4 +956,5 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
             .hasNoData()
             .run()
     }
+
 }

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -172,7 +172,7 @@ final class TestCookies: KituraTest, KituraTestSuite {
                         properties[HTTPCookiePropertyKey.value] =  cookieValue
 
                         for  part in parts[1..<parts.count] {
-                            var pieces = part.components(separatedBy: "=")
+                            let pieces = part.components(separatedBy: "=")
                             let piece = pieces[0].lowercased()
                             switch piece {
                             case "secure", "httponly":

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -16,6 +16,11 @@
 
 import XCTest
 import Foundation
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
 
 @testable import Kitura
 @testable import KituraNet

--- a/Tests/KituraTests/TestStaticFileServer.swift
+++ b/Tests/KituraTests/TestStaticFileServer.swift
@@ -174,10 +174,9 @@ final class TestStaticFileServer: KituraTest, KituraTestSuite {
         // the original repository directory is 3 path components up
         let currentFilePath = #file
 
-        var pathComponents = currentFilePath.split(separator: "/").map(String.init)
+        let pathComponents = currentFilePath.split(separator: "/").map(String.init)
 
         // We need to check whether we have an edited Kitura package, this will be seen from a path containing Packages and Kitura at the relevant indexes
-        let numberOfComponents = pathComponents.count
         let expectedKituraIndex = pathComponents.count - 4
         let expectedPackagesIndex = pathComponents.count - 5
         if pathComponents[expectedKituraIndex] == "Kitura"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolve compilation errors and warnings relating to changes in the Swift 5.1 release:
- `import FoundationNetworking` on Linux to access `HTTPCookie` and similar types, due to [changes to Foundation structure](https://forums.swift.org/t/foundationnetworking/24769)
- fix compilation warnings relating to `var`s that were never mutated
- Temporarily disables two of the TestCodableRouter tests that have extremely long compile times with Swift 5.1 on Linux (reported under: https://bugs.swift.org/browse/SR-11012)

Depends on https://github.com/IBM-Swift/Package-Builder/pull/169 to deploy workaround for running 5.1 snapshot in Docker on Travis.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
