### PR TITLE
A convenience API to create and add cookies.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,3 +11,4 @@ disabled_rules:
   - function_body_length
   - large_tuple
   - identifier_name
+  - type_name

--- a/Sources/Kitura/AdditionalCookieAttribute.swift
+++ b/Sources/Kitura/AdditionalCookieAttribute.swift
@@ -7,8 +7,6 @@ public struct AdditionalCookieAttribute {
         case comment(String?)
         // A URL that can be presented to the user as a link for further information about this cookie.
         case commentURL(String?)
-        // Custom cookie attributes
-        case custom(String, String)
         // A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session
         case discard(String)
         // The list of ports for the cookie,  an array of NSNumber objects containing integers.
@@ -41,13 +39,6 @@ public struct AdditionalCookieAttribute {
     /// A URL that can be presented to the user as a link for further information about this cookie.
     public static func commentURL(_ value: String?) -> AdditionalCookieAttribute {
         return AdditionalCookieAttribute(_CookieAttribute.commentURL(value))
-    }
-
-    /// Custom cookie attributes
-    ///
-    ///Note: Custom cookie attributes are not honoured by Foundation yet.
-    public static func custom(_ key: String, _ value: String) -> AdditionalCookieAttribute {
-        return AdditionalCookieAttribute(_CookieAttribute.custom(key, value))
     }
 
     /// A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session.

--- a/Sources/Kitura/OptionalCookieAttribute.swift
+++ b/Sources/Kitura/OptionalCookieAttribute.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Describes an optional attribute of a cookie.
-public struct OptionalCookieAttribute {
+public struct AdditionalCookieAttribute {
     internal enum _CookieAttribute {
         // A comment for the cookie.
         case comment(String?)
@@ -34,54 +34,54 @@ public struct OptionalCookieAttribute {
     }
 
     /// A comment for the cookie.
-    public static func comment(_ value: String?) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.comment(value))
+    public static func comment(_ value: String?) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.comment(value))
     }
 
     /// A URL that can be presented to the user as a link for further information about this cookie.
-    public static func commentURL(_ value: String?) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.commentURL(value))
+    public static func commentURL(_ value: String?) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.commentURL(value))
     }
 
     /// Custom cookie attributes
     ///
     ///Note: Custom cookie attributes are not honoured by Foundation yet.
-    public static func custom(_ key: String, _ value: String) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.custom(key, value))
+    public static func custom(_ key: String, _ value: String) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.custom(key, value))
     }
 
     /// A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session.
-    public static func discard(_ value: String) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.discard(value))
+    public static func discard(_ value: String) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.discard(value))
     }
 
     /// The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
-    public static func expires(_ value: Date?) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.expires(value))
+    public static func expires(_ value: Date?) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.expires(value))
     }
 
     /// A boolean value that indicates whether this cookie should only be sent over secure channels.
-    public static func isSecure(_ value: Bool) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.isSecure(value))
+    public static func isSecure(_ value: Bool) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.isSecure(value))
     }
 
     /// A value stating how long in seconds the cookie should be kept, at most.
-    public static func maximumAge(_ value: String) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.maximumAge(value))
+    public static func maximumAge(_ value: String) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.maximumAge(value))
     }
 
     /// The URL that set this cookie.
-    public static func originURL(_ value: URL?) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.originURL(value))
+    public static func originURL(_ value: URL?) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.originURL(value))
     }
 
     /// The list of ports for the cookie,  an array of NSNumber objects containing integers.
-    public static func portList(_ value: [NSNumber]?) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.portList(value))
+    public static func portList(_ value: [NSNumber]?) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.portList(value))
     }
 
     /// The version of the cookie. Must be either 0 or 1. The default is 0.
-    public static func version(_ value: Int) -> OptionalCookieAttribute {
-        return OptionalCookieAttribute(_CookieAttribute.version(value))
+    public static func version(_ value: Int) -> AdditionalCookieAttribute {
+        return AdditionalCookieAttribute(_CookieAttribute.version(value))
     }
 }

--- a/Sources/Kitura/OptionalCookieAttribute.swift
+++ b/Sources/Kitura/OptionalCookieAttribute.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Describes an optional attribute of a cookie.
+public struct OptionalCookieAttribute {
+    internal enum _CookieAttribute {
+        // A comment for the cookie.
+        case comment(String?)
+        // A URL that can be presented to the user as a link for further information about this cookie.
+        case commentURL(String?)
+        // Custom cookie attributes
+        case custom(String, String)
+        // A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session
+        case discard(String)
+        // The list of ports for the cookie,  an array of NSNumber objects containing integers.
+        case expires(Date?)
+        //  A boolean value that indicates whether this cookie should only be sent over secure channels.
+        case isSecure(Bool)
+        // A value stating how long in seconds the cookie should be kept, at most.
+        case maximumAge(String)
+        // The URL that set this cookie.
+        case originURL(URL?)
+        // The version of the cookie. Must be either 0 or 1. The default is 0.
+        case portList([NSNumber]?)
+        // The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
+        case version(Int)
+    }
+
+    // The internal case represented by this instance of CookieAttribute.
+    internal let _value: _CookieAttribute
+
+    // Called by public API to create an internal representation.
+    private init(_ value: _CookieAttribute) {
+        self._value = value
+    }
+
+    /// A comment for the cookie.
+    public static func comment(_ value: String?) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.comment(value))
+    }
+
+    /// A URL that can be presented to the user as a link for further information about this cookie.
+    public static func commentURL(_ value: String?) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.commentURL(value))
+    }
+
+    /// Custom cookie attributes
+    ///
+    ///Note: Custom cookie attributes are not honoured by Foundation yet.
+    public static func custom(_ key: String, _ value: String) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.custom(key, value))
+    }
+
+    /// A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session.
+    public static func discard(_ value: String) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.discard(value))
+    }
+
+    /// The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
+    public static func expires(_ value: Date?) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.expires(value))
+    }
+
+    /// A boolean value that indicates whether this cookie should only be sent over secure channels.
+    public static func isSecure(_ value: Bool) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.isSecure(value))
+    }
+
+    /// A value stating how long in seconds the cookie should be kept, at most.
+    public static func maximumAge(_ value: String) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.maximumAge(value))
+    }
+
+    /// The URL that set this cookie.
+    public static func originURL(_ value: URL?) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.originURL(value))
+    }
+
+    /// The list of ports for the cookie,  an array of NSNumber objects containing integers.
+    public static func portList(_ value: [NSNumber]?) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.portList(value))
+    }
+
+    /// The version of the cookie. Must be either 0 or 1. The default is 0.
+    public static func version(_ value: Int) -> OptionalCookieAttribute {
+        return OptionalCookieAttribute(_CookieAttribute.version(value))
+    }
+}

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -266,7 +266,7 @@ public class RouterResponse {
                 cookieProperties[HTTPCookiePropertyKey.discard] = discard
 
             case .isSecure(let secure):
-                cookieProperties[HTTPCookiePropertyKey.secure] = secure
+                cookieProperties[HTTPCookiePropertyKey.secure] = secure ? "YES" : "NO"
 
             case .comment(let comment):
                 if let comment = comment {

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -178,42 +178,54 @@ public class RouterResponse {
             }
         }
     }
-
+    
+    /// An enum to describe the attributes  (name, value, domain, path etc) of a cookie.
     public enum CookieAttribute {
-        //The cookie’s name.
+        /// The cookie’s name.
         case name(String)
 
-        //The cookie‘s string value.
+        /// The cookie‘s value.
         case value(String)
 
-        //The domain of the cookie.
+        /// The domain of the cookie.
         case domain(String)
 
-        //The cookie’s path.
+        /// The cookie’s path.
         case path(String)
 
+        /// The list of ports for the cookie,  an array of NSNumber objects containing integers.
         case portList([NSNumber]?)
 
-        //The cookie’s expiration date.
+        /// The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
         case expires(Date?)
 
+        /// A  value stating how long in seconds the cookie should be kept, at most.
         case maximumAge(String)
 
+        /// The URL that set this cookie.
         case originURL(URL?)
 
+        /// The version of the cookie. Must be either 0 or 1. The default is 0.
         case version(Int)
 
+        /// A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session.
         case discard(String)
 
-        //A Boolean value that indicates whether this cookie should only be sent over secure channels.
+        /// A  boolean value that indicates whether this cookie should only be sent over secure channels.
         case isSecure(Bool)
 
+        /// A comment for the cookie.
         case comment(String?)
 
+        /// A URL that can be presented to the user as a link for further information about this cookie.
         case commentURL(String?)
     }
 
-    // creation of HTTP cookie
+    /// Add a cookie to the response.
+    ///
+    /// This function attempts to create an `HTTPCookie`  from a given `CookieAttribute`  array and, if successful , adds the HTTPCookie to the `cookies` dictionary.
+    /// - Parameter with: An  array of  `CookieAttribute`s
+    /// - Returns: Returns the added `HTTPCookie` or `nil` in the case of  an `HTTPCookie` creation failure. Here success or failure is governed by the Foundation's HTTPCookie specifiacation: https://developer.apple.com/documentation/foundation/httpcookie
     @discardableResult
     public func addCookie(with attributes: [CookieAttribute]) -> HTTPCookie? {
         var cookieProperties = [HTTPCookiePropertyKey: Any]()

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -768,7 +768,7 @@ public typealias WrittenDataFilter = (Data) -> Data
 
 /// Describes an optional attribute of a cookie.
 public struct CookieAttribute {
-    internal enum _CookieAttribute {
+    internal enum OptionalCookieAttribute {
         // A comment for the cookie.
         case comment(String?)
         // A URL that can be presented to the user as a link for further information about this cookie.
@@ -792,62 +792,62 @@ public struct CookieAttribute {
     }
 
     // The internal case represented by this instance of CookieAttribute.
-    internal let _value: _CookieAttribute
+    internal let _value: OptionalCookieAttribute
 
     // Called by public API to create an internal representation.
-    private init(_ value: _CookieAttribute) {
+    private init(_ value: OptionalCookieAttribute) {
         self._value = value
     }
 
     /// A comment for the cookie.
     public static func comment(_ value: String?) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.comment(value))
+        return CookieAttribute(OptionalCookieAttribute.comment(value))
     }
 
     /// A URL that can be presented to the user as a link for further information about this cookie.
     public static func commentURL(_ value: String?) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.commentURL(value))
+        return CookieAttribute(OptionalCookieAttribute.commentURL(value))
     }
 
     /// Custom cookie attributes
     ///
     ///Note: Custom cookie attributes are not honoured by Foundation yet.
     public static func custom(_ key: String, _ value: String) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.custom(key, value))
+        return CookieAttribute(OptionalCookieAttribute.custom(key, value))
     }
 
     /// A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session.
     public static func discard(_ value: String) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.discard(value))
+        return CookieAttribute(OptionalCookieAttribute.discard(value))
     }
 
     /// The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
     public static func expires(_ value: Date?) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.expires(value))
+        return CookieAttribute(OptionalCookieAttribute.expires(value))
     }
 
     /// A boolean value that indicates whether this cookie should only be sent over secure channels.
     public static func isSecure(_ value: Bool) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.isSecure(value))
+        return CookieAttribute(OptionalCookieAttribute.isSecure(value))
     }
 
     /// A value stating how long in seconds the cookie should be kept, at most.
     public static func maximumAge(_ value: String) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.maximumAge(value))
+        return CookieAttribute(OptionalCookieAttribute.maximumAge(value))
     }
 
     /// The URL that set this cookie.
     public static func originURL(_ value: URL?) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.originURL(value))
+        return CookieAttribute(OptionalCookieAttribute.originURL(value))
     }
 
     /// The list of ports for the cookie,  an array of NSNumber objects containing integers.
     public static func portList(_ value: [NSNumber]?) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.portList(value))
+        return CookieAttribute(OptionalCookieAttribute.portList(value))
     }
 
     /// The version of the cookie. Must be either 0 or 1. The default is 0.
     public static func version(_ value: Int) -> CookieAttribute {
-        return CookieAttribute(_CookieAttribute.version(value))
+        return CookieAttribute(OptionalCookieAttribute.version(value))
     }
 }

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -178,7 +178,8 @@ public class RouterResponse {
             }
         }
     }
-    
+
+    /// Describes an optional attribute of a cookie.
     public struct CookieAttribute {
         internal enum _CookieAttribute {
             case portList([NSNumber]?)
@@ -195,6 +196,7 @@ public class RouterResponse {
         // The internal case represented by this instance of CookieAttribute.
         internal let _value: _CookieAttribute
         // Called by public API to create an internal representation.
+
         private init(_ value: _CookieAttribute) {
             self._value = value
         }
@@ -258,9 +260,7 @@ public class RouterResponse {
     /// - Parameter value: The cookie‘s value.
     /// - Parameter domain: The domain of the cookie.
     /// - Parameter path: The cookie’s path.
-    /// - Parameter otherAttributes: An array of optional `CookieAttribute`s other
-    /// than name, value, domain,path,these values are ignored
-    /// if they are given in otherAttributes array.
+    /// - Parameter otherAttributes: An array of  any other optional cookie attributes
     public func addCookie(name: String, value: String, domain: String, path: String, otherAttributes: [CookieAttribute] = []) {
         var cookieProperties = [HTTPCookiePropertyKey: Any]()
         cookieProperties[HTTPCookiePropertyKey.name] = name

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -179,8 +179,6 @@ public class RouterResponse {
         }
     }
 
-
-
     /// Add a cookie to the response.
     ///
     /// This function creates an `HTTPCookie`  from the provided attributes and adds it to the `cookies` dictionary.
@@ -189,7 +187,7 @@ public class RouterResponse {
     /// - Parameter domain: The domain of the cookie.
     /// - Parameter path: The cookie’s path.
     /// - Parameter otherAttributes: An array of  any other optional cookie attributes
-    public func addCookie(name: String, value: String, domain: String, path: String, otherAttributes: [CookieAttribute]? = nil ) {
+    public func addCookie(name: String, value: String, domain: String, path: String, otherAttributes: [OptionalCookieAttribute]? = nil ) {
         var cookieProperties = [HTTPCookiePropertyKey: Any]()
         cookieProperties[HTTPCookiePropertyKey.name] = name
         cookieProperties[HTTPCookiePropertyKey.value] = value
@@ -765,89 +763,3 @@ public typealias LifecycleHandler = () -> Void
 
 /// Type alias for written data filter, i.e. pre-write lifecycle handler.
 public typealias WrittenDataFilter = (Data) -> Data
-
-/// Describes an optional attribute of a cookie.
-public struct CookieAttribute {
-    internal enum OptionalCookieAttribute {
-        // A comment for the cookie.
-        case comment(String?)
-        // A URL that can be presented to the user as a link for further information about this cookie.
-        case commentURL(String?)
-        // Custom cookie attributes
-        case custom(String, String)
-        // A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session
-        case discard(String)
-        // The list of ports for the cookie,  an array of NSNumber objects containing integers.
-        case expires(Date?)
-        //  A boolean value that indicates whether this cookie should only be sent over secure channels.
-        case isSecure(Bool)
-        // A value stating how long in seconds the cookie should be kept, at most.
-        case maximumAge(String)
-        // The URL that set this cookie.
-        case originURL(URL?)
-        // The version of the cookie. Must be either 0 or 1. The default is 0.
-        case portList([NSNumber]?)
-        // The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
-        case version(Int)
-    }
-
-    // The internal case represented by this instance of CookieAttribute.
-    internal let _value: OptionalCookieAttribute
-
-    // Called by public API to create an internal representation.
-    private init(_ value: OptionalCookieAttribute) {
-        self._value = value
-    }
-
-    /// A comment for the cookie.
-    public static func comment(_ value: String?) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.comment(value))
-    }
-
-    /// A URL that can be presented to the user as a link for further information about this cookie.
-    public static func commentURL(_ value: String?) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.commentURL(value))
-    }
-
-    /// Custom cookie attributes
-    ///
-    ///Note: Custom cookie attributes are not honoured by Foundation yet.
-    public static func custom(_ key: String, _ value: String) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.custom(key, value))
-    }
-
-    /// A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session.
-    public static func discard(_ value: String) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.discard(value))
-    }
-
-    /// The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
-    public static func expires(_ value: Date?) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.expires(value))
-    }
-
-    /// A boolean value that indicates whether this cookie should only be sent over secure channels.
-    public static func isSecure(_ value: Bool) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.isSecure(value))
-    }
-
-    /// A value stating how long in seconds the cookie should be kept, at most.
-    public static func maximumAge(_ value: String) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.maximumAge(value))
-    }
-
-    /// The URL that set this cookie.
-    public static func originURL(_ value: URL?) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.originURL(value))
-    }
-
-    /// The list of ports for the cookie,  an array of NSNumber objects containing integers.
-    public static func portList(_ value: [NSNumber]?) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.portList(value))
-    }
-
-    /// The version of the cookie. Must be either 0 or 1. The default is 0.
-    public static func version(_ value: Int) -> CookieAttribute {
-        return CookieAttribute(OptionalCookieAttribute.version(value))
-    }
-}

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -179,6 +179,99 @@ public class RouterResponse {
         }
     }
 
+    public enum CookieAttribute {
+        //The cookie’s name.
+        case name(String)
+
+        //The cookie‘s string value.
+        case value(String)
+
+        //The domain of the cookie.
+        case domain(String)
+
+        //The cookie’s path.
+        case path(String)
+
+        //The cookie’s port list.
+        case portList([NSNumber]?)
+
+        //The cookie’s expiration date.
+        case expiresDate(Date?)
+
+        //The cookie’s version.
+        case version(Int)
+
+        //A Boolean value that indicates whether the cookie should only be sent to HTTP servers.
+        case isHTTPOnly(Bool)
+
+        //A Boolean value that indicates whether this cookie should only be sent over secure channels.
+        case isSecure(Bool)
+
+        //The cookie’s comment string.You can present this string to the user, explaining the contents and purpose of the cookie.
+        case comment(String?)
+
+        //The cookie’s comment URL. this Link to the information explaining the contents and purpose of the cookie
+        case commentURL(String?)
+    }
+
+    // creation of HTTP cookie
+    @discardableResult
+    public func addCookie(with attributes: [CookieAttribute]) -> HTTPCookie? {
+        var cookieProperties = [HTTPCookiePropertyKey: Any]()
+        for attribute in attributes {
+            switch attribute {
+            case .name(let cookieName):
+                cookieProperties[HTTPCookiePropertyKey.name] = cookieName
+
+            case .value(let cookieValue):
+                cookieProperties[HTTPCookiePropertyKey.value] = cookieValue
+
+            case .domain(let domainName):
+                cookieProperties[HTTPCookiePropertyKey.domain] = domainName
+
+            case .path(let pathName):
+                cookieProperties[HTTPCookiePropertyKey.path] = pathName
+
+            case .portList(let ports):
+                if let ports = ports {
+                    cookieProperties[HTTPCookiePropertyKey.port] = ports
+                }
+
+            case .expiresDate(let expiresDate):
+                if let expiresDate = expiresDate {
+                    cookieProperties[HTTPCookiePropertyKey.expires] = expiresDate
+                }
+
+            case .version(let cookieVersion):
+                cookieProperties[HTTPCookiePropertyKey.version] = cookieVersion
+
+            case .isHTTPOnly(let httpOnly):
+                cookieProperties[HTTPCookiePropertyKey.discard] = httpOnly
+
+            case .isSecure(let secure):
+                cookieProperties[HTTPCookiePropertyKey.secure] = secure
+
+            case .comment(let comment):
+                if let comment = comment {
+                    cookieProperties[HTTPCookiePropertyKey.comment] = comment
+                }
+
+            case .commentURL(let commentURL):
+                if let commentURL = commentURL {
+                    cookieProperties[HTTPCookiePropertyKey.commentURL] = commentURL
+                }
+            }
+        }
+
+        guard let cookie = HTTPCookie(properties: cookieProperties) else {
+            Log.warning("RouterResponse.addCookie() failed to create a cookie due to invalid cookie attributes.")
+            return nil
+        }
+        cookies[cookie.name] = cookie
+        return cookie
+    }
+
+
     // MARK: End
     
     /// End the response.

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -179,51 +179,76 @@ public class RouterResponse {
         }
     }
     
-    /// An enum to describe the attributes  (name, value, domain, path etc) of a cookie.
-    public enum CookieAttribute {
-        /// The cookie’s name.
-        case name(String)
-
-        /// The cookie‘s value.
-        case value(String)
-
-        /// The domain of the cookie.
-        case domain(String)
-
-        /// The cookie’s path.
-        case path(String)
-
+    public struct CookieAttribute {
+        internal enum _CookieAttribute {
+            case portList([NSNumber]?)
+            case expires(Date?)
+            case maximumAge(String)
+            case originURL(URL?)
+            case version(Int)
+            case discard(String)
+            case isSecure(Bool)
+            case comment(String?)
+            case commentURL(String?)
+            case custom(String,String)
+        }
+        // The internal case represented by this instance of CookieAttribute.
+        internal let _value: _CookieAttribute
+        // Called by public API to create an internal representation.
+        private init(_ value: _CookieAttribute) {
+            self._value = value
+        }
         /// The list of ports for the cookie,  an array of NSNumber objects containing integers.
-        case portList([NSNumber]?)
+        public static func portList(_ value: [NSNumber]?) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.portList(value))
+        }
 
         /// The cookie’s expiration date. The expiration date is the date when the cookie should be deleted.
-        case expires(Date?)
+        public static func expires(_ value: Date?) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.expires(value))
+        }
 
-        /// A  value stating how long in seconds the cookie should be kept, at most.
-        case maximumAge(String)
+        /// A value stating how long in seconds the cookie should be kept, at most.
+        public static func maximumAge(_ value: String) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.maximumAge(value))
+        }
 
         /// The URL that set this cookie.
-        case originURL(URL?)
+        public static func originURL(_ value: URL?) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.originURL(value))
+        }
 
         /// The version of the cookie. Must be either 0 or 1. The default is 0.
-        case version(Int)
+        public static func version(_ value: Int) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.version(value))
+        }
 
         /// A String value representing a boolean (TRUE/FALSE), stating whether the cookie should be discarded at the end of the session.
-        case discard(String)
+        public static func discard(_ value: String) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.discard(value))
+        }
 
         /// A  boolean value that indicates whether this cookie should only be sent over secure channels.
-        case isSecure(Bool)
+        public static func isSecure(_ value: Bool) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.isSecure(value))
+        }
 
         /// A comment for the cookie.
-        case comment(String?)
+        public static func comment(_ value: String?) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.comment(value))
+        }
 
         /// A URL that can be presented to the user as a link for further information about this cookie.
-        case commentURL(String?)
+        public static func commentURL(_ value: String?) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.commentURL(value))
+        }
 
         /// Custom cookie attributes
         ///
         ///Note: Custom cookie attributes are not honoured by Foundation yet.
-        case custom(String,String)
+        public static func custom(_ key: String, _ value: String) -> CookieAttribute {
+            return CookieAttribute(_CookieAttribute.custom(key, value))
+        }
     }
 
     /// Add a cookie to the response.
@@ -244,10 +269,7 @@ public class RouterResponse {
         cookieProperties[HTTPCookiePropertyKey.path] = path
 
         for attribute in otherAttributes {
-            switch attribute {
-            case .name, .value, .domain, .path:
-                Log.info("The \(attribute) value if supplied through otherAtrributes array is ignored.")
-                continue
+            switch attribute._value {
             case .portList(let ports):
                 if let ports = ports {
                     cookieProperties[HTTPCookiePropertyKey.port] = ports

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -192,25 +192,24 @@ public class RouterResponse {
         //The cookie’s path.
         case path(String)
 
-        //The cookie’s port list.
         case portList([NSNumber]?)
 
         //The cookie’s expiration date.
-        case expiresDate(Date?)
+        case expires(Date?)
 
-        //The cookie’s version.
+        case maximumAge(String)
+
+        case originURL(URL?)
+
         case version(Int)
 
-        //A Boolean value that indicates whether the cookie should only be sent to HTTP servers.
-        case isHTTPOnly(Bool)
+        case discard(String)
 
         //A Boolean value that indicates whether this cookie should only be sent over secure channels.
         case isSecure(Bool)
 
-        //The cookie’s comment string.You can present this string to the user, explaining the contents and purpose of the cookie.
         case comment(String?)
 
-        //The cookie’s comment URL. this Link to the information explaining the contents and purpose of the cookie
         case commentURL(String?)
     }
 
@@ -237,16 +236,22 @@ public class RouterResponse {
                     cookieProperties[HTTPCookiePropertyKey.port] = ports
                 }
 
-            case .expiresDate(let expiresDate):
+            case .expires(let expiresDate):
                 if let expiresDate = expiresDate {
                     cookieProperties[HTTPCookiePropertyKey.expires] = expiresDate
                 }
 
+            case .maximumAge(let maxAge):
+                cookieProperties[HTTPCookiePropertyKey.maximumAge] = maxAge
+
+            case .originURL(let originURL):
+                cookieProperties[HTTPCookiePropertyKey.originURL] = originURL
+
             case .version(let cookieVersion):
                 cookieProperties[HTTPCookiePropertyKey.version] = cookieVersion
 
-            case .isHTTPOnly(let httpOnly):
-                cookieProperties[HTTPCookiePropertyKey.discard] = httpOnly
+            case .discard(let discard):
+                cookieProperties[HTTPCookiePropertyKey.discard] = discard
 
             case .isSecure(let secure):
                 cookieProperties[HTTPCookiePropertyKey.secure] = secure

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -187,7 +187,7 @@ public class RouterResponse {
     /// - Parameter domain: The domain of the cookie.
     /// - Parameter path: The cookie’s path.
     /// - Parameter otherAttributes: An array of  any other optional cookie attributes
-    public func addCookie(name: String, value: String, domain: String, path: String, otherAttributes: [OptionalCookieAttribute]? = nil ) {
+    public func addCookie(name: String, value: String, domain: String, path: String, otherAttributes: [AdditionalCookieAttribute]? = nil ) {
         var cookieProperties = [HTTPCookiePropertyKey: Any]()
         cookieProperties[HTTPCookiePropertyKey.name] = name
         cookieProperties[HTTPCookiePropertyKey.value] = value

--- a/Sources/Kitura/RouterResponse.swift
+++ b/Sources/Kitura/RouterResponse.swift
@@ -230,10 +230,6 @@ public class RouterResponse {
                     if let commentURL = commentURL {
                         cookieProperties[HTTPCookiePropertyKey.commentURL] = commentURL
                     }
-
-                case.custom(let key, let value):
-                    let customKey = HTTPCookiePropertyKey(rawValue: key)
-                    cookieProperties[customKey] = value
                 }
             }
             if let cookie = HTTPCookie(properties: cookieProperties) {

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -179,17 +179,8 @@ final class TestCookies: KituraTest, KituraTestSuite {
                 }
                 expectation.fulfill()
             })
-        }, { expectation in
-            self.performRequest("get", path: "/4/sendcookie", callback: { response in
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK,
-                               "/4/sendcookie route did not match single path request")
-                let (cookie, _) = self.cookieFrom(response:
-                    response, named: cookie4Name as String)
-                XCTAssertNil(cookie)
-                expectation.fulfill()
-            })
         }
-        )}
+    )}
     func cookieFrom(response: ClientResponse?, named: String) -> (HTTPCookie?, String?) {
         guard let response = response else {
             return (nil, nil)
@@ -329,26 +320,10 @@ final class TestCookies: KituraTest, KituraTestSuite {
 
         router.get("/3/sendcookie") {request, response, next in
             response.status(HTTPStatusCode.OK)
-            response.addCookie(with: [
-                .name(cookie4Name),
-                .value(cookie4Value),
-                .domain(cookieHost),
-                .path("/"),
-                .isSecure(true),
-                .expires(Date.distantFuture)
-               ])
-
+            response.addCookie(name: cookie4Name, value: cookie4Value, domain: cookieHost, path: "/", otherAttributes: [.isSecure(true)])
             next()
         }
-        router.get("/4/sendcookie") {request, response, next in
-            response.status(HTTPStatusCode.OK)
-            response.addCookie(with: [
-                .domain(cookieHost),
-                .path("/")
-                ])
 
-            next()
-        }
         return router
     }
 }

--- a/Tests/KituraTests/TestCookies.swift
+++ b/Tests/KituraTests/TestCookies.swift
@@ -154,7 +154,7 @@ final class TestCookies: KituraTest, KituraTestSuite {
             self.performRequest("get", path: "/3/sendcookie", callback: { response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK,
                     "/3/sendcookie route did not match single path request")
-                let (cookie, cookieExpire) = self.cookieFrom(response:
+                let (cookie, _) = self.cookieFrom(response:
                     response, named: cookie4Name as String)
                 XCTAssertNotNil(cookie, "Cookie \(cookie4Name) wasn't found in the response.")
                 if let cookie = cookie {
@@ -168,7 +168,7 @@ final class TestCookies: KituraTest, KituraTestSuite {
             self.performRequest("get", path: "/3/sendcookie", callback: { response in
                 XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK,
                                "/3/sendcookie route did not match single path request")
-                let (cookie, cookieExpire) = self.cookieFrom(response:
+                let (cookie, _) = self.cookieFrom(response:
                     response, named: cookie4Name as String)
                 XCTAssertNotNil(cookie, "Cookie \(cookie4Name) wasn't found in the response.")
                 if let cookie = cookie {


### PR DESCRIPTION
A convenience API to create and add cookies.

## Description
The new public enum `CookieAttribute` is created with cases that represent the attributes of a cookie. The `addCookie` function takes an array of  type `CookieAttribute` and returns either an HTTPCookie object or nil, depending on whether foundation HTTPCookie initializer passes or fails. Each attribute in the array is added into the dictionary `cookieProperties` with appropriate keys. The attributes having nil values are not added. This `cookieProperties` dictionary is then passed to the HTTPCookie initializer. If this initializer returns a new  HTTPcookie object, with the given properties, the HTTPCookie object is added to the `cookies` dictionary which contains set of cookies to return with the response. If the initializer fails then a warning is logged. Resolves #1456

## Motivation and Context
Currently, the user has to write a lot of boilerplate code for cookie creation. This pull request tries to cookie creation and its addition to the response easier for the user.

## Checklist:
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
