### PR TITLE
Remove BluePic from Kitura landing page

### DIFF
--- a/Sources/Kitura/resources/index.html
+++ b/Sources/Kitura/resources/index.html
@@ -35,9 +35,9 @@
           <p>Build an iOS game powered by CoreML and Watson Visual Recognition.</p>
           <img class="github-image" src="/@@Kitura-router@@/github-icon.png" alt="Dark GitHub logo">
         </a>
-        <a href="https://github.com/IBM/BluePic" target="_blank" class="project-card">
-          <h3>BluePic</h3>
-            <p>Take a look at our photo-sharing app which uses Kitura with IBM Cloud.</p>
+        <a href="https://developer.ibm.com/patterns/design-a-step-tracking-app-with-kitura-and-kubernetes/" target="_blank" class="project-card">
+          <h3>Step Tracker iOS app</h3>
+            <p>Design a step-tracking app with Kitura and Kubernetes.</p>
           <img class="github-image" src="/@@Kitura-router@@/github-icon.png" alt="Dark GitHub logo">
         </a>
       </section>


### PR DESCRIPTION
## Description
Removes BluePic link (which is no longer being maintained) from the Kitura landing page.

## Motivation and Context
Fixes: #1470

## How Has This Been Tested?
Run landing page within a local app as shown here ->
<img width="1286" alt="Screenshot 2019-07-04 at 13 28 27" src="https://user-images.githubusercontent.com/20067264/60666727-a2af7400-9e5f-11e9-83bc-a9819085d904.png">
