### PR TITLE
ci: Enable xcode11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,11 +72,10 @@ matrix:
       osx_image: xcode10.2
       sudo: required
       env: KITURA_NIO=1 SWIFT_TEST_ARGS="--parallel"
-# Awaiting xcode11 image from Travis
-#    - os: osx
-#      osx_image: xcode10.2
-#      sudo: required
-#      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
+    - os: osx
+      osx_image: xcode11
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git


### PR DESCRIPTION
Travis recently published an `xcode11` macOS image.  This enables the macOS 5.1 CI testing.