### PR TITLE
add ios availability

### DIFF
--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -899,7 +899,7 @@ struct SwaggerDocument: Encodable {
         let nl = pretty ? "\n" : ""
 
         let encoder = JSONEncoder()
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.13, iOS 11.0, *) {
             encoder.outputFormatting = .sortedKeys
         } else {
             // Fallback on earlier versions
@@ -938,7 +938,7 @@ struct SwaggerDocument: Encodable {
             contentStr.append("\(sp)\"type\": \"\(modelRef.type)\",\(nl)")
             if modelRef.required.count > 0 {
                 let encoder = JSONEncoder()
-                if #available(OSX 10.13, *) {
+                if #available(OSX 10.13, iOS 11.0, *) {
                     encoder.outputFormatting = .sortedKeys
                 } else {
                     // Fallback on earlier versions
@@ -1027,7 +1027,7 @@ struct SwaggerDocument: Encodable {
     ///
     func serializeAPIToJSON() throws -> String? {
         let encoder = JSONEncoder()
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.13, iOS 11.0, *) {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         } else {
             // Fallback on earlier versions


### PR DESCRIPTION
add ios availability in SwaggerGenerator

## Description
#available(OSX 10.13, *) -> #available(OSX 10.13, iOS 11.0, *)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'll try to compile latest version of Kitura for iOS, but it were compilation errors.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/IBM-Swift/Kitura/issues/1422
## How Has This Been Tested?
<!--- Please describein detail how you tested your changes. -->
nothing :)
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.