### PR TITLE
feat: Ability to limit request size and connection count

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ import Foundation
 var kituraNetPackage: Package.Dependency
 
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.1.0")
+    kituraNetPackage = .package(url: "https://github.com/RudraniW/Kitura-NIO.git", .branch("limitRequestSize"))
 } else {
     kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit"))
 }

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ import Foundation
 var kituraNetPackage: Package.Dependency
 
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    kituraNetPackage = .package(url: "https://github.com/RudraniW/Kitura-NIO.git", .branch("limitRequestSize"))
+    kituraNetPackage = .package(url: "https://github.com/RudraniW/Kitura-NIO.git", .branch("requestSize"))
 } else {
     kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit"))
 }

--- a/Package.swift
+++ b/Package.swift
@@ -22,9 +22,9 @@ import Foundation
 var kituraNetPackage: Package.Dependency
 
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    kituraNetPackage = .package(url: "https://github.com/RudraniW/Kitura-NIO.git", .branch("requestSize"))
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.3.0")
 } else {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit"))
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.4.0")
 }
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ var kituraNetPackage: Package.Dependency
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
     kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-NIO.git", from: "2.1.0")
 } else {
-    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0")
+    kituraNetPackage = .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit"))
 }
 
 let package = Package(

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit")),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.4.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit")),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit")),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.4.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit")),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit")),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.4.0"),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-log.git", Version("0.0.0") ..< Version("2.0.0")),
-        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", from: "2.3.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-net.git", .branch("requestLimit")),
         .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.0.0"),
         .package(url: "https://github.com/IBM-Swift/TypeDecoder.git", from: "1.3.0"),

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -316,7 +316,7 @@ public class Kitura {
 
  ServerOptions allows customization of default connection policies, including:
 
- - `requestSizeLimit`: Defines the maximum size of an incoming request, in bytes. If requests are received that are larger than this limit, they will be rejected and the connection will be closed. A value of `nil` means no limit.
+ - `requestSizeLimit`: Defines the maximum size of an incoming request body, in bytes. If requests are received that are larger than this limit, they will be rejected and the connection will be closed. A value of `nil` means no limit.
  - `connectionLimit`: Defines the maximum number of concurrent connections that a server should accept. Clients attempting to connect when this limit has been reached will be rejected. A value of `nil` means no limit.
 
  The server can optionally respond to the client with a message in either of these cases. This message can be customized by defining `requestSizeResponseGenerator` and `connectionResponseGenerator`.

--- a/Sources/Kitura/Kitura.swift
+++ b/Sources/Kitura/Kitura.swift
@@ -73,9 +73,10 @@ public class Kitura {
                                     with delegate: ServerDelegate,
                                     withSSL sslConfig: SSLConfig?=nil,
                                     keepAlive keepAliveState: KeepAliveState = .unlimited,
-                                    allowPortReuse: Bool = false) -> HTTPServer {
+                                    allowPortReuse: Bool = false,
+                                    options: ServerOptions? = nil) -> HTTPServer {
         return Kitura._addHTTPServer(on: .inet(port, address), with: delegate, withSSL: sslConfig,
-                                     keepAlive: keepAliveState, allowPortReuse: allowPortReuse)
+                                     keepAlive: keepAliveState, allowPortReuse: allowPortReuse, options: options)
     }
 
     /// Add an HTTPServer on a Unix domain socket path with a delegate.
@@ -97,8 +98,10 @@ public class Kitura {
     public class func addHTTPServer(onUnixDomainSocket socketPath: String,
                                     with delegate: ServerDelegate,
                                     withSSL sslConfig: SSLConfig?=nil,
-                                    keepAlive keepAliveState: KeepAliveState = .unlimited) -> HTTPServer {
-        return Kitura._addHTTPServer(on: .unix(socketPath), with: delegate, withSSL: sslConfig, keepAlive: keepAliveState)
+                                    keepAlive keepAliveState: KeepAliveState = .unlimited,
+                                    options: ServerOptions? = nil) -> HTTPServer {
+
+        return Kitura._addHTTPServer(on: .unix(socketPath), with: delegate, withSSL: sslConfig, keepAlive: keepAliveState, options: options)
     }
 
     private class func _addHTTPServer(on listenType: ListenerType,
@@ -106,7 +109,7 @@ public class Kitura {
                                     withSSL sslConfig: SSLConfig?=nil,
                                     keepAlive keepAliveState: KeepAliveState = .unlimited,
                                     allowPortReuse: Bool = false,
-                                    options: ServerOptions? = nil) -> HTTPServer {
+                                    options: ServerOptions?) -> HTTPServer {
         let server = HTTP.createServer()
         server.delegate = delegate
         server.sslConfig = sslConfig?.config

--- a/Tests/KituraTests/KituraTest.swift
+++ b/Tests/KituraTests/KituraTest.swift
@@ -62,6 +62,9 @@ class KituraTest: XCTestCase {
     // A singleton Kitura server listening on HTTPS on a Unix socket
     static private(set) var httpsUnixServer: HTTPServer?
 
+    // Options for servers for the current KituraTest subclass
+    static var options: ServerOptions?
+
     // The port of the server returned by startServer().
     private(set) var port = -1
     // Whether the server used by doPerformServerTest should use SSL.
@@ -192,6 +195,9 @@ class KituraTest: XCTestCase {
         if useSSL {
             server.sslConfig = KituraTest.sslConfig.config
         }
+        if let options = KituraTest.options {
+            server.options = options
+        }
 
         do {
             try server.listen(on: 0, address: "localhost")
@@ -235,7 +241,9 @@ class KituraTest: XCTestCase {
         if useSSL {
             server.sslConfig = KituraTest.sslConfig.config
         }
-
+        if let options = KituraTest.options {
+            server.options = options
+        }
         // Create a temporary path for Unix domain socket
         let socketPath = uniqueTemporaryFilePath()
         self.socketFilePath = socketPath

--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -663,7 +663,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     }
 
     func testCodableGetSingleQueryParameters() {
-        let date: Date = Coder().dateFormatter.date(from: Coder().dateFormatter.string(from: Date()))!
+        let date: Date = Coder.defaultDateFormatter.date(from: Coder.defaultDateFormatter.string(from: Date()))!
 
         let expectedQuery = MyQuery(intField: 23, optionalIntField: 282, stringField: "a string", intArray: [1, 2, 3], dateField: date, optionalDateField: date, nested: Nested(nestedIntField: 333, nestedStringField: "nested string"))
 
@@ -715,7 +715,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     func testCodableGetArrayQueryParameters() {
         /// Currently the milliseconds are cut off by our date formatter
         /// This synchronizes it for testing with the codable route
-        let date: Date = Coder().dateFormatter.date(from: Coder().dateFormatter.string(from: Date()))!
+        let date: Date = Coder.defaultDateFormatter.date(from: Coder.defaultDateFormatter.string(from: Date()))!
 
         let expectedQuery = MyQuery(intField: 23, optionalIntField: 282, stringField: "a string", intArray: [1, 2, 3], dateField: date, optionalDateField: date, nested: Nested(nestedIntField: 333, nestedStringField: "nested string"))
 
@@ -767,7 +767,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     func testCodableDeleteQueryParameters() {
         /// Currently the milliseconds are cut off by our date formatter
         /// This synchronizes it for testing with the codable route
-        let date: Date = Coder().dateFormatter.date(from: Coder().dateFormatter.string(from: Date()))!
+        let date: Date = Coder.defaultDateFormatter.date(from: Coder.defaultDateFormatter.string(from: Date()))!
 
         let expectedQuery = MyQuery(intField: 23, optionalIntField: 282, stringField: "a string", intArray: [1, 2, 3], dateField: date, optionalDateField: date, nested: Nested(nestedIntField: 333, nestedStringField: "nested string"))
 

--- a/Tests/KituraTests/TestLinuxSafeguard.swift
+++ b/Tests/KituraTests/TestLinuxSafeguard.swift
@@ -47,6 +47,7 @@
             verifyCount(TestRouteRegex.self)
             verifyCount(TestRouterHTTPVerbsGenerated.self)
             verifyCount(TestServer.self)
+            verifyCount(TestServerOptions.self)
             verifyCount(TestStack.self)
             verifyCount(TestStaticFileServer.self)
             verifyCount(TestSubrouter.self)

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -86,6 +86,12 @@ final class TestResponse: KituraTest, KituraTestSuite {
 
     let router = TestResponse.setupRouter()
 
+    override func setUp() {
+        super.setUp()
+        // Increase request size limit to allow testLargePost() to succeed
+        KituraTest.options = ServerOptions(requestSizeLimit: 2000000)
+    }
+
     func testSimpleResponse() {
     	performServerTest(router) { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in

--- a/Tests/KituraTests/TestResponse.swift
+++ b/Tests/KituraTests/TestResponse.swift
@@ -86,12 +86,6 @@ final class TestResponse: KituraTest, KituraTestSuite {
 
     let router = TestResponse.setupRouter()
 
-    override func setUp() {
-        super.setUp()
-        // Increase request size limit to allow testLargePost() to succeed
-        KituraTest.options = ServerOptions(requestSizeLimit: 2000000)
-    }
-
     func testSimpleResponse() {
     	performServerTest(router) { expectation in
             self.performRequest("get", path:"/qwer", callback: {response in
@@ -167,7 +161,7 @@ final class TestResponse: KituraTest, KituraTestSuite {
     }
 
     func testLargePost() {
-        performServerTest(router, timeout: 30) { expectation in
+        performServerTest(router, options: ServerOptions(requestSizeLimit: 2000000), timeout: 30) { expectation in
             let count = 1024 * 1024
             let postData = Data(repeating: UInt8.max, count: count)
 

--- a/Tests/KituraTests/TestServerOptions.swift
+++ b/Tests/KituraTests/TestServerOptions.swift
@@ -37,14 +37,8 @@ final class TestServerOptions: KituraTest, KituraTestSuite {
 
     let router = TestServerOptions.setupRouter()
 
-    override func setUp() {
-        super.setUp()
-        // Impose limit on request size. Must allow for headers and payload
-        KituraTest.options = ServerOptions(requestSizeLimit: 200, connectionLimit: 1)
-    }
-
     func testSmallPostSucceeds() {
-        performServerTest(router, timeout: 30) { expectation in
+        performServerTest(router, options: ServerOptions(requestSizeLimit: 200), timeout: 30) { expectation in
             // Data that (together with headers) is within request limit
             let count = 10
             let postData = Data(repeating: UInt8.max, count: count)
@@ -60,7 +54,7 @@ final class TestServerOptions: KituraTest, KituraTestSuite {
     }
 
     func testLargePostFails() {
-        performServerTest(router, timeout: 30) { expectation in
+        performServerTest(router, options: ServerOptions(requestSizeLimit: 200), timeout: 30) { expectation in
             // Data that exceeds the request size limit
             let count = 10000
             let postData = Data(repeating: UInt8.max, count: count)

--- a/Tests/KituraTests/TestServerOptions.swift
+++ b/Tests/KituraTests/TestServerOptions.swift
@@ -1,0 +1,92 @@
+/**
+ * Copyright IBM Corporation 2016
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import Foundation
+
+@testable import Kitura
+@testable import KituraNet
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+final class TestServerOptions: KituraTest, KituraTestSuite {
+
+    static var allTests: [(String, (TestServerOptions) -> () throws -> Void)] {
+        return [
+            ("testSmallPostSucceeds", testSmallPostSucceeds),
+            ("testLargePostFails", testLargePostFails),
+        ]
+    }
+
+    let router = TestServerOptions.setupRouter()
+
+    override func setUp() {
+        super.setUp()
+        // Impose limit on request size. Must allow for headers and payload
+        KituraTest.options = ServerOptions(requestSizeLimit: 200, connectionLimit: 1)
+    }
+
+    func testSmallPostSucceeds() {
+        performServerTest(router, timeout: 30) { expectation in
+            // Data that (together with headers) is within request limit
+            let count = 10
+            let postData = Data(repeating: UInt8.max, count: count)
+
+            self.performRequest("post", path: "/smallPost", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
+                expectation.fulfill()
+            }, requestModifier: { request in
+                request.write(from: postData)
+            })
+        }
+    }
+
+    func testLargePostFails() {
+        performServerTest(router, timeout: 30) { expectation in
+            // Data that exceeds the request size limit
+            let count = 10000
+            let postData = Data(repeating: UInt8.max, count: count)
+
+            self.performRequest("post", path: "/largePostFail", callback: { response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.requestTooLong, "HTTP Status code was \(String(describing: response?.statusCode))")
+                expectation.fulfill()
+            }, requestModifier: { request in
+                request.write(from: postData)
+            })
+        }
+    }
+
+    static func setupRouter() -> Router {
+        let router = Router()
+
+        router.post("/smallPost") { request, response, _ in
+            try response.status(.OK).end()
+        }
+
+        router.post("/largePostFail") { request, response, _ in
+            XCTFail("Large post request succeeded, should have been rejected")
+        }
+
+        return router
+    }
+
+}

--- a/Tests/KituraTests/TestServerOptions.swift
+++ b/Tests/KituraTests/TestServerOptions.swift
@@ -42,8 +42,8 @@ final class TestServerOptions: KituraTest, KituraTestSuite {
 
     // Tests that a request whose total size is smaller than the configured limit is successful.
     func testSmallPostSucceeds() {
-        performServerTest(router, options: ServerOptions(requestSizeLimit: 200), timeout: 30) { expectation in
-            // Data that (together with headers) is within request limit
+        performServerTest(router, options: ServerOptions(requestSizeLimit: 10), timeout: 30) { expectation in
+            // Data that is within request limit
             let count = 10
             let postData = Data(repeating: UInt8.max, count: count)
 
@@ -60,9 +60,9 @@ final class TestServerOptions: KituraTest, KituraTestSuite {
     // Tests that a POST request containing body data that exceeds the configured limit is
     // correctly rejected with `.requestTooLong`.
     func testLargePostExceedsLimit() {
-        performServerTest(router, options: ServerOptions(requestSizeLimit: 200), timeout: 30) { expectation in
+        performServerTest(router, options: ServerOptions(requestSizeLimit: 10), timeout: 30) { expectation in
             // Data that exceeds the request size limit
-            let count = 10000
+            let count = 20
             let postData = Data(repeating: UInt8.max, count: count)
 
             self.performRequest("post", path: "/largePostFail", callback: { response in
@@ -170,7 +170,7 @@ final class TestServerOptions: KituraTest, KituraTestSuite {
 
         router.post("/largePostFail") { request, response, _ in
             XCTFail("Large post request succeeded, should have been rejected")
-            try response.status(.internalServerError).end()
+            try response.status(.OK).end()
         }
 
         router.get("/answerSlowly") { request, response, _ in

--- a/Tests/KituraTests/TestServerOptions.swift
+++ b/Tests/KituraTests/TestServerOptions.swift
@@ -120,8 +120,13 @@ final class TestServerOptions: KituraTest, KituraTestSuite {
             let tooLongString = String(data: headerData, encoding: .utf8)!
 
             self.performRequest("post", path: "/smallPost", callback: { response in
-                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
-                XCTAssertEqual(response?.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(String(describing: response?.statusCode))")
+                if let response = response {
+                    XCTAssertEqual(response.statusCode, HTTPStatusCode.badRequest, "HTTP Status code was \(response.statusCode)")
+                } else {
+                    // Valid outcome of connection rejection: server closes connection before
+                    // client has completed sending headers: curl reports send failure. We cannot
+                    // test this explicitly as ClientRequest does not return the underlying error.
+                }
                 expectation.fulfill()
             }, requestModifier: { request in
                 request.headers["Much-Too-Long"] = tooLongString

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -66,5 +66,6 @@ XCTMain([
     testCase(TestMediaType.allTests.shuffled()),
     testCase(TestCustomCoders.allTests.shuffled()),
     testCase(TestCodablePathParams.allTests.shuffled()),
+    testCase(TestServerOptions.allTests.shuffled()),
 //    testCase(TestCRUDTypeRouter.allTests.shuffled()),
     ].shuffled())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR allows a `requestSizeLimit` (maximum bytes for the request body) and `connectionLimit` (on total number of concurrent connections) to be configured when registering a server.

Example usage from Kitura is as follows:
```swift
let options = ServerOptions(requestSizeLimit: 100, connectionLimit: 3)
Kitura.addHTTPServer(onPort: port, with: router, options: options)
```

If you do not specify either of the parameters, or do not specify a `ServerOptions` at all, then default values are used.  The defaults are defined as constants `ServerOptions.defaultRequestSizeLimit` and `ServerOptions.defaultConnectionLimit`.
- These have been given conservative defaults of 100mb and 10,000 connections, so as to not break existing deployments.

If a client sends a request that exceeds the limit, then they are immediately sent an `HTTP/1.1 413 Request Entity Too Large` and the connection is closed.
If a client attempts to connect, but we are already at the connection limit, they are immediately sent an `HTTP/1.1 503 Service Unavailable` and the connection is closed.

These responses can be further customized by supplying `requestSizeResponseGenerator` and `connectionResponseGenerator` closures, which are passed an `Int` (the limit that was exceeded) and a `String` (the hostname and port of the socket), and return an `HTTPStatusCode` and a `String` that is a plaintext message to be returned to the client.  The default responses are again defined as constants `defaultRequestSizeResponseGenerator` and `defaultConnectionResponseGenerator`.

This does not provide a means to set a limit on the request _headers_ (more specifically, all data up to the point where the HTTP parser determines that headers are complete).  Both the HTTPParser in Kitura-net and Swift-NIO set a limit of 80kb on the size of the headers, and it seems unlikely in practice that this would need to be modified.

Some issues I'm aware of:
- There are already parameters `keepAlive` and `allowPortReuse` on `Kitura.addHTTPServer` which could be rolled into this new options struct.

Depends on https://github.com/IBM-Swift/Kitura-net/pull/307 and https://github.com/IBM-Swift/Kitura-NIO/pull/221

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1384 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests have been added for:
- a POST request that is (exactly) within the limit is successful,
- an oversized POST request is rejected,
- a request with oversized headers is rejected,
- connections above the configured limit are rejected,
- custom responses for oversized requests and excess connections.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
