### PR TITLE
fix: Correctly register Codable routes with trailing `:id`

### DIFF
--- a/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
+++ b/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift
@@ -277,7 +277,7 @@ extension Router {
             return
         }
         registerGetRoute(route: route, id: Id.self, outputType: O.self)
-        get(join(path: route, with: ":id")) { request, response, next in
+        get(appendId(path: route)) { request, response, next in
             Log.verbose("Received GET (singular with identifier and middleware) type-safe request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
@@ -318,7 +318,7 @@ extension Router {
             return
         }
         registerGetRoute(route: route, id: Id.self, outputType: O.self)
-        get(join(path: route, with: ":id")) { request, response, next in
+        get(appendId(path: route)) { request, response, next in
             Log.verbose("Received GET (singular with identifier and middleware) type-safe request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
@@ -359,7 +359,7 @@ extension Router {
             return
         }
         registerGetRoute(route: route, id: Id.self, outputType: O.self)
-        get(join(path: route, with: ":id")) { request, response, next in
+        get(appendId(path: route)) { request, response, next in
             Log.verbose("Received GET (singular with identifier and middleware) type-safe request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
@@ -1069,7 +1069,7 @@ extension Router {
             return
         }
         registerDeleteRoute(route: route, id: Id.self)
-        delete(join(path: route, with: ":id")) { request, response, next in
+        delete(appendId(path: route)) { request, response, next in
             Log.verbose("Received DELETE (singular with middleware) type-safe request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
@@ -1108,7 +1108,7 @@ extension Router {
             return
         }
         registerDeleteRoute(route: route, id: Id.self)
-        delete(join(path: route, with: ":id")) { request, response, next in
+        delete(appendId(path: route)) { request, response, next in
             Log.verbose("Received DELETE (singular with middleware) type-safe request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
@@ -1147,7 +1147,7 @@ extension Router {
             return
         }
         registerDeleteRoute(route: route, id: Id.self)
-        delete(join(path: route, with: ":id")) { request, response, next in
+        delete(appendId(path: route)) { request, response, next in
             Log.verbose("Received DELETE (singular with middleware) type-safe request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
@@ -1738,7 +1738,7 @@ extension Router {
             return
         }
         registerPutRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        put(join(path: route, with: ":id")) { request, response, next in
+        put(appendId(path: route)) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
@@ -1779,7 +1779,7 @@ extension Router {
             return
         }
         registerPutRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        put(join(path: route, with: ":id")) { request, response, next in
+        put(appendId(path: route)) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
@@ -1820,7 +1820,7 @@ extension Router {
             return
         }
         registerPutRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        put(join(path: route, with: ":id")) { request, response, next in
+        put(appendId(path: route)) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {
@@ -1872,7 +1872,7 @@ extension Router {
             return
         }
         registerPatchRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        patch(join(path: route, with: ":id")) { request, response, next in
+        patch(appendId(path: route)) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             self.handleMiddleware(T.self, request: request, response: response) { typeSafeMiddleware in
                 guard let typeSafeMiddleware = typeSafeMiddleware else {
@@ -1919,7 +1919,7 @@ extension Router {
             return
         }
         registerPatchRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        patch(join(path: route, with: ":id")) { request, response, next in
+        patch(appendId(path: route)) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             self.handleMiddleware(T1.self, T2.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2 else {
@@ -1965,7 +1965,7 @@ extension Router {
             return
         }
         registerPatchRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        patch(join(path: route, with: ":id")) { request, response, next in
+        patch(appendId(path: route)) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             self.handleMiddleware(T1.self, T2.self, T3.self, request: request, response: response) { typeSafeMiddleware1, typeSafeMiddleware2, typeSafeMiddleware3 in
                 guard let typeSafeMiddleware1 = typeSafeMiddleware1, let typeSafeMiddleware2 = typeSafeMiddleware2, let typeSafeMiddleware3 = typeSafeMiddleware3 else {

--- a/Sources/Kitura/CodableRouter.swift
+++ b/Sources/Kitura/CodableRouter.swift
@@ -387,7 +387,7 @@ extension Router {
             return
         }
         registerPutRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        put(join(path: route, with: ":id")) { request, response, next in
+        put(appendId(path: route)) { request, response, next in
             Log.verbose("Received PUT type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
                   let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
@@ -405,7 +405,7 @@ extension Router {
             return
         }
         registerPatchRoute(route: route, id: Id.self, inputType: I.self, outputType: O.self)
-        patch(join(path: route, with: ":id")) { request, response, next in
+        patch(appendId(path: route)) { request, response, next in
             Log.verbose("Received PATCH type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response),
                   let codableInput = CodableHelpers.readCodableOrSetResponseStatus(I.self, from: request, response: response)
@@ -536,7 +536,7 @@ extension Router {
             return
         }
         registerGetRoute(route: route, id: Id.self, outputType: O.self)
-        get(join(path: route, with: ":id")) { request, response, next in
+        get(appendId(path: route)) { request, response, next in
             Log.verbose("Received GET (singular with identifier) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
                 next()
@@ -564,7 +564,7 @@ extension Router {
             return
         }
         registerDeleteRoute(route: route, id: Id.self)
-        delete(join(path: route, with: ":id")) { request, response, next in
+        delete(appendId(path: route)) { request, response, next in
             Log.verbose("Received DELETE (singular) type-safe request")
             guard let identifier = CodableHelpers.parseIdOrSetResponseStatus(Id.self, from: request, response: response) else {
                 next()
@@ -641,7 +641,18 @@ extension Router {
         }
     }
 
-    internal func join(path base: String, with component: String) -> String {
+    /// Append the `:id` parameter to a path that does not already contain a parameter.
+    /// If the path already contains a parameter, it will be returned unmodified.
+    internal func appendId(path base: String) -> String {
+        let identifierSupplied = base.contains(":")
+        guard !identifierSupplied else {
+            return base
+        }
+        return joinPath(base, with: ":id")
+    }
+
+    /// Join two path components together such that they are separated by a single `/`.
+    private func joinPath(_ base: String, with component: String) -> String {
         let strippedBase = base.hasSuffix("/") ? String(base.dropLast()) : base
         let strippedComponent = component.hasPrefix("/") ? String(component.dropFirst()) : component
         return "\(strippedBase)/\(strippedComponent)"

--- a/Tests/KituraTests/TestCodablePathParams.swift
+++ b/Tests/KituraTests/TestCodablePathParams.swift
@@ -1,0 +1,198 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+import Foundation
+import KituraContracts
+
+@testable import Kitura
+
+final class TestCodablePathParams: KituraTest, KituraTestSuite {
+    static var allTests: [(String, (TestCodablePathParams) -> () throws -> Void)] {
+        return [
+            ("testJoinPath", testJoinPath),
+            ("testRouteWithTrailingSlash", testRouteWithTrailingSlash),
+            ("testInvalidRouteParameters", testInvalidRouteParameters),
+            ("testInvalidIdentifierSupplied", testInvalidIdentifierSupplied),
+            ("testIdentifierNotExpected", testIdentifierNotExpected),
+            ("testPartialIdentifierSupplied", testPartialIdentifierSupplied),
+            ("testIdentifierNotSupplied", testIdentifierNotSupplied),
+            ("testGetIdentifierNotSupplied", testGetIdentifierNotSupplied),
+            ("testGetIdentifierSupplied", testGetIdentifierSupplied),
+        ]
+    }
+
+    // Need to initialise to avoid compiler error
+    var router = Router()
+
+    // Reset for each test
+    override func setUp() {
+        super.setUp()           // Initialize logging
+        router = Router()
+    }
+
+    struct Fruit: Codable, Equatable {
+        let name: String
+        let id: Int
+
+        static func == (lhs: Fruit, rhs: Fruit) -> Bool {
+            return lhs.name == rhs.name && lhs.id == rhs.id
+        }
+    }
+
+    func testJoinPath() {
+        let router = Router()
+        // Implicit append of :id
+        XCTAssertEqual(router.appendId(path: "a"), "a/:id")
+        XCTAssertEqual(router.appendId(path: "a/"), "a/:id")
+        // User already specified :id
+        XCTAssertEqual(router.appendId(path: "a/:id"), "a/:id")
+        // User specified a different identifier name (not supported)
+        XCTAssertEqual(router.appendId(path: "a/:foo"), "a/:foo")
+    }
+
+    // Test adding a trailing slash to your route when it has an implicit id parameter
+    func testRouteWithTrailingSlash() {
+        router.get("/fruit/") { (id: Int, respondWith: (Fruit?, RequestError?) -> Void) in
+            respondWith(Fruit(name: "apple", id: id), nil)
+        }
+        router.put("/fruit/") { (id: Int, fruit: Fruit, respondWith: (Fruit?, RequestError?) -> Void) in
+            respondWith(Fruit(name: fruit.name, id: id), nil)
+        }
+        router.patch("/fruit/") { (id: Int, fruit: Fruit, respondWith: (Fruit?, RequestError?) -> Void) in
+            respondWith(Fruit(name: fruit.name, id: id), nil)
+        }
+        router.delete("/fruit/") { (id: Int, respondWith: (RequestError?) -> Void) in
+            XCTAssertEqual(id, 1)
+            respondWith(nil)
+        }
+        let apple = Fruit(name: "apple", id: 1)
+        let banana = Fruit(name: "banana", id: 2)
+
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/fruit/1").hasStatus(.OK).hasContentType(withPrefix: "application/json").hasData(apple)
+            .request("put", path: "/fruit/2", data: banana).hasStatus(.OK).hasContentType(withPrefix: "application/json").hasData(banana)
+            .request("patch", path: "/fruit/2", data: banana).hasStatus(.OK).hasContentType(withPrefix: "application/json").hasData(banana)
+            .request("delete", path: "/fruit/1").hasStatus(.noContent).hasNoData()
+            .run()
+    }
+
+    func testInvalidRouteParameters() {
+        //Add this erroneous route which should not be hit by the test, should log an error but we can't test the log so we check for a 404 not found.
+        let result = Fruit(name: "banana", id: 1)
+        router.get("/status/:notId") { (id: Int, respondWith: (Fruit?, RequestError?) -> Void) in
+            XCTFail("GET on /status/:notId that should not happen")
+            respondWith(result, nil)
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/status/1")
+            .hasStatus(.notFound)
+            .hasData()
+            .run()
+    }
+
+    func testInvalidIdentifierSupplied() {
+        //Add this erroneous route with invalid identifier, should log an error but we can't test the log so we check for a 404 not found.
+        router.delete("/status/:myid") { (id: Int, respondWith: (RequestError?) -> Void) in
+            XCTFail("DELETE on /status/:myid that should not happen")
+            respondWith(.badRequest)
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("delete", path: "/status/1")
+            .hasStatus(.notFound)
+            .hasData()
+            .run()
+    }
+
+    func testIdentifierNotExpected() {
+        //Add this erroneous route which should not be hit by the test, should log an error but we can't test the log so we check for a 404 not found.
+        router.delete("/users/:id") { (respondWith: (RequestError?) -> Void) in
+            print("DELETE on /users")
+            respondWith(.badRequest)
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("delete", path: "/users/1")
+            .hasStatus(.notFound)
+            .hasData()
+            .run()
+    }
+
+    func testPartialIdentifierSupplied() {
+        //Add this route with partial identifier. should log an error but we can't test the log so we check for a 404 not found.
+        router.delete("/status/:") { (id: Int, respondWith: (RequestError?) -> Void) in
+            XCTFail("DELETE on /status/: that should not happen")
+            respondWith(.badRequest)
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("delete", path: "/status/1")
+            .hasStatus(.notFound)
+            .hasData()
+            .run()
+    }
+
+    func testIdentifierNotSupplied() {
+        router.delete("/status/") { (id: Int, respondWith: (RequestError?) -> Void) in
+            print("DELETE on /status")
+            respondWith(nil)
+        }
+
+        buildServerTest(router, timeout: 30)
+            .request("delete", path: "/status/1")
+            .hasStatus(.noContent)
+            .hasNoData()
+            .run()
+    }
+
+    // A trailing :id parameter is allowed, but if not supplied will be added
+    // implicitly (with a warning to signal to the user that this has occurred).
+    func testGetIdentifierNotSupplied() {
+        router.get("/banana") { (id: Int, respondWith: (Fruit?, RequestError?) -> Void) in
+            print("GET on /banana")
+            respondWith(Fruit(name: "banana", id: id), nil)
+        }
+
+        let banana = Fruit(name: "banana", id: 10)
+
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/banana/10")
+            .hasStatus(.OK)
+            .hasData(banana)
+            .run()
+    }
+
+    // Test added to address fix for https://github.com/IBM-Swift/Kitura/issues/1473
+    // A trailing :id parameter is allowed, and replaces the :id parameter that
+    // would otherwise be added implicitly.
+    func testGetIdentifierSupplied() {
+        router.get("/banana/:id") { (id: Int, respondWith: (Fruit?, RequestError?) -> Void) in
+            print("GET on /banana/:id")
+            respondWith(Fruit(name: "banana", id: id), nil)
+        }
+
+        let banana = Fruit(name: "banana", id: 20)
+
+        buildServerTest(router, timeout: 30)
+            .request("get", path: "/banana/20")
+            .hasStatus(.OK)
+            .hasData(banana)
+            .run()
+    }
+
+}

--- a/Tests/KituraTests/TestLinuxSafeguard.swift
+++ b/Tests/KituraTests/TestLinuxSafeguard.swift
@@ -31,6 +31,7 @@
             verifyCount(MiscellaneousTests.self)
             verifyCount(TestBridgingHTTPStatusCode.self)
             verifyCount(TestBridgingRequestError.self)
+            verifyCount(TestCodablePathParams.self)
             verifyCount(TestCodableRouter.self)
             verifyCount(TestContentType.self)
             verifyCount(TestCookies.self)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -65,5 +65,6 @@ XCTMain([
     testCase(TestSwaggerGeneration.allTests.shuffled()),
     testCase(TestMediaType.allTests.shuffled()),
     testCase(TestCustomCoders.allTests.shuffled()),
+    testCase(TestCodablePathParams.allTests.shuffled()),
 //    testCase(TestCRUDTypeRouter.allTests.shuffled()),
     ].shuffled())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://github.com/IBM-Swift/Kitura/pull/1310 added a warning if a user registers a Codable route that accepts an `Identifier` but does not explicitly declare the trailing `:id` path parameter.

Unfortunately, the implementation there was flawed, and although supplying a trailing path parameter silences the warning, the route had a duplicate `:id` parameter appended, such that:
- `/codable` was registered (with a warning) as `/codable/:id`
- `/codable/:id` was (erroneously) registered as `/codable/:id/:id`

This PR resolves this so that `/codable/:id` is correctly registered.  It also adds tests that were missed from the previous PR, and fixes an existing (misleading) test that asserted that registering an explicit `:id` should fail (the test continued to pass, but only as a side-effect of this bug).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1473.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests have been added to cover the incorrect cases, and refactored into a separate test class.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
