### PR TITLE
tests: Remove workaround for SR-11012

### DIFF
--- a/Tests/KituraTests/TestCodableRouter.swift
+++ b/Tests/KituraTests/TestCodableRouter.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2017
+ * Copyright IBM Corporation 2017-2019
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import KituraContracts
 final class TestCodableRouter: KituraTest, KituraTestSuite {
     static var allTests: [(String, (TestCodableRouter) -> () throws -> Void)] {
         return [
-            ("testBasicPost", testBasicPost),  // Slow compile on 5.1
+            ("testBasicPost", testBasicPost),
             ("testBasicPostIdentifier", testBasicPostIdentifier),
             ("testBasicGetSingleton", testBasicGetSingleton),
             ("testBasicGetArray", testBasicGetArray),
@@ -33,7 +33,7 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
             ("testBasicDeleteSingle", testBasicDeleteSingle),
             ("testBasicPut", testBasicPut),
             ("testBasicPatch", testBasicPatch),
-            ("testErrorOverridesBody", testErrorOverridesBody),  // Slow compile on 5.1
+            ("testErrorOverridesBody", testErrorOverridesBody),
             ("testCodableRoutesWithBodyParsingFail", testCodableRoutesWithBodyParsingFail),
             ("testCodableGetSingleQueryParameters", testCodableGetSingleQueryParameters),
             ("testCodableGetArrayQueryParameters", testCodableGetArrayQueryParameters),
@@ -141,7 +141,6 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     }
 
     func testBasicPost() {
-        #if !swift(>=5.1)
         router.post("/users") { (user: User, respondWith: (User?, RequestError?) -> Void) in
             print("POST on /users for user \(user)")
             respondWith(user, nil)
@@ -194,9 +193,6 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
             .hasData()
 
             .run()
-        #else
-        print("Test temporarily disabled for 5.1: see SR-11012")
-        #endif
     }
 
     func testBasicPostIdentifier() {
@@ -596,7 +592,6 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
     }
 
     func testErrorOverridesBody() {
-        #if !swift(>=5.1)
         let status = Status("This should not be sent")
         router.get("/status") { (id: Int, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, .conflict) }
         router.post("/status") { (status: Status, respondWith: (Status?, RequestError?) -> Void) in respondWith(status, .conflict) }
@@ -648,9 +643,6 @@ final class TestCodableRouter: KituraTest, KituraTestSuite {
             .hasData(conflict)
 
             .run()
-        #else
-        print("Test temporarily disabled for 5.1: see SR-11012")
-        #endif
     }
 
     // Test that we get an internalServerError when using BodyParser with a Codable route


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the workaround (disabling two tests) with Swift 5.1 due to slow compilation (https://bugs.swift.org/browse/SR-11012), which was causing our Travis to time out.  This issue is now resolved in the latest snapshots (tested with 5.1 2019-09-16-a).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Restores test coverage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
