### PR TITLE
Add POST codable route support without input object.

### DIFF
--- a/Sources/Kitura/SwaggerGenerator.swift
+++ b/Sources/Kitura/SwaggerGenerator.swift
@@ -1408,6 +1408,17 @@ extension Router {
         registerDelete(route: route, id: Id.self, responseTypes: responseTypes)
     }
 
+    /// Register POST route.
+    ///
+    /// - Parameter route: The route to register.
+    /// - Parameter outputType: The output object type.
+    public func registerPostRoute<O: Codable>(route: String, outputType: O.Type) {
+        var responseTypes = [SwaggerResponseType]()
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, tuple: false, type: O.self, statusCode: .created))
+        responseTypes.append(SwaggerResponseType(optional: true, array: false, tuple: false, type: nil, statusCode: .internalServerError))
+        registerRoute(route: route, method: "post", outputType: O.self, responseTypes: responseTypes)
+    }
+
     /// Register POST route that is handled by a CodableIdentifierClosure.
     ///
     /// - Parameter route: The route to register.


### PR DESCRIPTION
Add a new codable route for POST with no object as input.

## Description
This allows to create a resource without arguments, like this:
```
router.post("/resource") { (respondWith: (Resource?, RequestError?) -> Void) in
  respondWith(resource, nil)
}
```

## Motivation and Context
It is not possible to use the POST verb without argument, making it weird to create a new resource from an endpoint that has no dependencies.

## How Has This Been Tested?
External testing done. I'm unsure about where to add the test if needed.

## Checklist:
- [X] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
