### PR TITLE
Update various package, resource and copyright notices

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,9 +13,9 @@ We love contributions to the Kitura project and request you follow the guideline
 
 ## Getting Started
 
-Please follow the [Kitura coding standards](https://github.com/IBM-Swift/Kitura/blob/master/Documentation/CodeConventions.md); this keeps the source code tidy and allows [Swift Lint](https://github.com/realm/SwiftLint) to work with the project.
+Please follow the [Kitura coding standards](https://github.com/Kitura/Kitura/blob/master/Documentation/CodeConventions.md); this keeps the source code tidy and allows [Swift Lint](https://github.com/realm/SwiftLint) to work with the project.
 
-**First time contributing?** We have created the label ["good first issue"](https://github.com/IBM-Swift/Kitura/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to help new members of the community get involved with Kitura quickly and effectively. These issues include documentation changes, test cases, minor bug fixes, logging, renaming and refactoring.
+**First time contributing?** We have created the label ["good first issue"](https://github.com/Kitura/Kitura/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to help new members of the community get involved with Kitura quickly and effectively. These issues include documentation changes, test cases, minor bug fixes, logging, renaming and refactoring.
 
 To get started, you will need to open a Terminal and:
 
@@ -24,7 +24,7 @@ To get started, you will need to open a Terminal and:
    `$ git clone https://github.com/YOUR_GITHUB_ID/Kitura`
 
 
-2. Make changes to code, usually by tackling an issue. A list of issues can be found [here](https://github.com/IBM-Swift/Kitura/issues). If you are new to Swift or software development, look for issues labelled ["good first issue"](https://github.com/IBM-Swift/Kitura/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+2. Make changes to code, usually by tackling an issue. A list of issues can be found [here](https://github.com/Kitura/Kitura/issues). If you are new to Swift or software development, look for issues labelled ["good first issue"](https://github.com/Kitura/Kitura/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
    If there aren't any tagged issues, post in [Slack](http://swift-at-ibm-slack.mybluemix.net/) and the team would be happy to help you get started.
 
@@ -59,7 +59,7 @@ When opening a PR, please:
 
 1. Create minimal differences and do not reformat the code. If you feel the codes structure needs changing, open a separate PR.
 2. Check for unnecessary white space using `git diff --check` before you commit your code.
-3. Ensure you follow the coding standards for the Kitura project, [linked here](https://github.com/IBM-Swift/Kitura/blob/master/Documentation/CodeConventions.md).
+3. Ensure you follow the coding standards for the Kitura project, [linked here](https://github.com/Kitura/Kitura/blob/master/Documentation/CodeConventions.md).
 
 ## Coding Style
 

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,6 +1,6 @@
 module: Kitura
-author: IBM
-github_url: https://github.com/IBM-Swift/Kitura/
+author: IBM and the Kitura project authors
+github_url: https://github.com/Kitura/Kitura/
 
 theme: fullwidth
 clean: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ matrix:
       env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT SWIFT_TEST_ARGS="--parallel"
 
 before_install:
-  - git clone https://github.com/IBM-Swift/Package-Builder.git
+  - git clone https://github.com/Kitura/Package-Builder.git
 
 script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/Configuration/RouterHTTPVerbs.txt
+++ b/Configuration/RouterHTTPVerbs.txt
@@ -1,5 +1,5 @@
 #/**
-#* Copyright IBM Corporation 2016
+#* Copyright IBM Corporation and the Kitura project authors 2016-2020
 #*
 #* Licensed under the Apache License, Version 2.0 (the "License");
 #* you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## Summary
 
-Kitura is a web framework and web server that is created for web services written in Swift. For more information, visit [www.kitura.io](http://www.kitura.io).
+Kitura is a web framework and web server that is created for web services written in Swift. For more information, visit [www.kitura.dev](http://www.kitura.dev).
 
 ## Table of Contents
 * [Summary](#summary)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-<a href="http://kitura.io/">
-<img src="https://raw.githubusercontent.com/IBM-Swift/Kitura/master/Documentation/KituraLogo-wide.png" height="100" alt="Kitura">
+<a href="http://kitura.dev/">
+<img src="https://raw.githubusercontent.com/Kitura/Kitura/master/Documentation/KituraLogo-wide.png" height="100" alt="Kitura">
 </a>
 <p align="center"><strong>A Swift Web Framework and HTTP Server</strong></p>
 </p>
@@ -9,14 +9,14 @@
 <a href="https://www.kitura.io/packages.html#all">
 <img src="https://img.shields.io/badge/docs-kitura.io-1FBCE4.svg" alt="Docs">
 </a>
-<a href="https://travis-ci.org/IBM-Swift/Kitura">
-<img src="https://travis-ci.org/IBM-Swift/Kitura.svg?branch=master" alt="Build Status - Master">
+<a href="https://travis-ci.org/Kitura/Kitura">
+<img src="https://travis-ci.org/Kitura/Kitura.svg?branch=master" alt="Build Status - Master">
 </a>
 <img src="https://img.shields.io/badge/os-macOS-green.svg?style=flat" alt="macOS">
 <img src="https://img.shields.io/badge/os-linux-green.svg?style=flat" alt="Linux">
 <img src="https://img.shields.io/badge/license-Apache2-blue.svg?style=flat" alt="Apache 2">
-<a href="https://codecov.io/gh/IBM-Swift/Kitura">
-<img src="https://codecov.io/gh/IBM-Swift/Kitura/branch/master/graph/badge.svg" alt="codecov">
+<a href="https://codecov.io/gh/Kitura/Kitura">
+<img src="https://codecov.io/gh/Kitura/Kitura/branch/master/graph/badge.svg" alt="codecov">
 </a>
 <a href="https://codebeat.co/projects/github-com-ibm-swift-kitura">
 <img src="https://codebeat.co/badges/d2d1cb10-e587-44b7-b63a-0a76ffb7bd96" alt="codebeat badge">
@@ -44,7 +44,7 @@ Kitura is a web framework and web server that is created for web services writte
 - Codable routing
 - URL parameters
 - Static file serving
-- [FastCGI support](https://github.com/IBM-Swift/Kitura/blob/master/Documentation/FastCGI.md)
+- [FastCGI support](https://github.com/Kitura/Kitura/blob/master/Documentation/FastCGI.md)
 - SSL/TLS support
 - Pluggable middleware
 
@@ -58,13 +58,13 @@ All improvements to Kitura are very welcome! Here's how to get started with deve
 
 1. Clone this repository.
 
-  `$ git clone https://github.com/IBM-Swift/Kitura`
+  `$ git clone https://github.com/Kitura/Kitura`
 
 2. Build and run tests.
 
   `$ swift test`
 
-You can find more info on contributing to Kitura in our [contributing guidelines](https://github.com/IBM-Swift/Kitura/blob/master/.github/CONTRIBUTING.md).
+You can find more info on contributing to Kitura in our [contributing guidelines](https://github.com/Kitura/Kitura/blob/master/.github/CONTRIBUTING.md).
 
 ## Community
 

--- a/Scripts/generate_router_verb_tests.sh
+++ b/Scripts/generate_router_verb_tests.sh
@@ -1,5 +1,5 @@
 #/**
-#* Copyright IBM Corporation 2016
+#* Copyright IBM Corporation and the Kitura project authors 2016-2020
 #*
 #* Licensed under the Apache License, Version 2.0 (the "License");
 #* you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ echo "--- Generating ${OUTPUT_FILE}"
 
 cat <<'EOF' > ${OUTPUT_FILE}
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Scripts/generate_router_verbs.sh
+++ b/Scripts/generate_router_verbs.sh
@@ -1,5 +1,5 @@
 #/**
-#* Copyright IBM Corporation 2016
+#* Copyright IBM Corporation and the Kitura project authors 2016-2020
 #*
 #* Licensed under the Apache License, Version 2.0 (the "License");
 #* you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ echo "--- Generating ${OUTPUT_FILE}"
 
 cat <<'EOF' > ${OUTPUT_FILE}
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation and the Kitura project authors 2016-2020
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vagrantfile
+++ b/vagrantfile
@@ -8,7 +8,7 @@ SWIFT_DIRECTORY = 'swift-3.1-RELEASE-ubuntu14.04'.freeze
 SWIFT_FILE = "#{SWIFT_DIRECTORY}.tar.gz".freeze
 SWIFT_HOME = "/home/vagrant/#{SWIFT_DIRECTORY}".freeze
 
-KITURA_URL = 'https://github.com/IBM-Swift/Kitura.git'.freeze
+KITURA_URL = 'https://github.com/Kitura/Kitura.git'.freeze
 KITURA_BRANCH = 'master'.freeze
 
 Vagrant.configure(2) do |config|


### PR DESCRIPTION
This PR updates many of the packages, resources and copyright notices to point to the new Kitura community project. This is NOT a comprehensive update, as nearly all the html files deep within the folder structures of the repo still point to either `kitura.io` or the packages in the IBM-Swift project. Updating the broken links in all these html files is beyond the scope of this PR.